### PR TITLE
Add 3D arch tilt/balance indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -2297,7 +2297,7 @@ ON</button>
       <button class="lobby-back" id="btn-back-role-join">&larr; Back</button>
     </div>
 
-    <p class="lobby-credits">Users First Games <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span class="lobby-version" id="lobby-version">v.cacab29 | 03-01-2026 23:07</span></p>
+    <p class="lobby-credits">Users First Games <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span class="lobby-version" id="lobby-version">v.7cadfc7 | 03-03-2026 00:40</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
 </div>

--- a/js/arch-indicator.js
+++ b/js/arch-indicator.js
@@ -1,0 +1,371 @@
+// ============================================================
+// ARCH INDICATOR — polished radial gauge with band arch + tapered needles
+// ============================================================
+
+import * as THREE from 'three';
+import { BALANCE_DEFAULTS } from './config.js';
+
+const ARCH_RADIUS = 3.0;
+const ARCH_BAND_WIDTH = 0.35;       // width of the gauge band
+const ARCH_INNER = ARCH_RADIUS - ARCH_BAND_WIDTH / 2;
+const ARCH_OUTER = ARCH_RADIUS + ARCH_BAND_WIDTH / 2;
+const ARCH_EDGE_RADIUS = 0.025;     // thin edge tubes
+const ARCH_BASE_Y = 0.3;
+const ARCH_SEGMENTS = 48;
+
+const NEEDLE_LENGTH = ARCH_RADIUS * 0.92;
+const NEEDLE_BASE_WIDTH = 0.10;     // wider at pivot
+const NEEDLE_TIP_WIDTH = 0.025;     // tapered tip
+
+// Derive sweep from sensitivity (degrees → radians)
+const LEAN_SCALE = BALANCE_DEFAULTS.sensitivity * Math.PI / 180;
+const ARCH_MARGIN = 0.08;           // small pad beyond max needle travel
+// Arch spans from (90° - sweep - margin) to (90° + sweep + margin)
+const ARCH_START = Math.PI / 2 - LEAN_SCALE - ARCH_MARGIN;
+const ARCH_END   = Math.PI / 2 + LEAN_SCALE + ARCH_MARGIN;
+const ARCH_SPAN  = ARCH_END - ARCH_START;
+
+export class ArchIndicator {
+  constructor(scene) {
+    this.scene = scene;
+    this.group = new THREE.Group();
+    this.group.visible = false;
+    this.scene.add(this.group);
+
+    this._archParts = [];   // all arch meshes for disposal
+    this._playerNeedle = null;
+    this._partnerNeedle = null;
+    this._visible = false;
+    this._mode = 'solo';
+
+    this._buildArch();
+  }
+
+  // ----------------------------------------------------------
+  // Arch — two edge tubes + translucent band fill between them
+  // ----------------------------------------------------------
+
+  _buildArch() {
+    // Shared edge material — subtle, sits in background
+    const edgeMat = new THREE.MeshBasicMaterial({
+      color: 0x333333,
+      opacity: 0.35,
+      transparent: true,
+      depthWrite: false
+    });
+
+    // Inner edge tube
+    const innerPts = this._arcPoints(ARCH_INNER);
+    const innerCurve = new THREE.CatmullRomCurve3(innerPts);
+    const innerGeom = new THREE.TubeGeometry(innerCurve, ARCH_SEGMENTS, ARCH_EDGE_RADIUS, 6, false);
+    const innerMesh = new THREE.Mesh(innerGeom, edgeMat);
+    this.group.add(innerMesh);
+    this._archParts.push(innerMesh);
+
+    // Outer edge tube
+    const outerPts = this._arcPoints(ARCH_OUTER);
+    const outerCurve = new THREE.CatmullRomCurve3(outerPts);
+    const outerGeom = new THREE.TubeGeometry(outerCurve, ARCH_SEGMENTS, ARCH_EDGE_RADIUS, 6, false);
+    const outerMesh = new THREE.Mesh(outerGeom, edgeMat.clone());
+    this.group.add(outerMesh);
+    this._archParts.push(outerMesh);
+
+    // Translucent band fill between inner and outer arcs
+    const bandGeom = this._buildBandGeometry();
+    const bandMat = new THREE.MeshBasicMaterial({
+      color: 0x222222,
+      opacity: 0.10,
+      transparent: true,
+      depthWrite: false,
+      side: THREE.DoubleSide
+    });
+    const bandMesh = new THREE.Mesh(bandGeom, bandMat);
+    this.group.add(bandMesh);
+    this._archParts.push(bandMesh);
+
+    // Tick marks at center (12 o'clock) and quarter positions
+    this._addTickMarks(edgeMat);
+  }
+
+  _arcPoints(radius) {
+    const pts = [];
+    for (let i = 0; i <= ARCH_SEGMENTS; i++) {
+      const angle = ARCH_START + ARCH_SPAN * (i / ARCH_SEGMENTS);
+      pts.push(new THREE.Vector3(
+        Math.cos(angle) * radius,
+        ARCH_BASE_Y + Math.sin(angle) * radius,
+        0
+      ));
+    }
+    return pts;
+  }
+
+  _buildBandGeometry() {
+    // Triangle strip between inner and outer arcs
+    const positions = [];
+    const indices = [];
+    for (let i = 0; i <= ARCH_SEGMENTS; i++) {
+      const angle = ARCH_START + ARCH_SPAN * (i / ARCH_SEGMENTS);
+      const cosA = Math.cos(angle);
+      const sinA = Math.sin(angle);
+      // Inner vertex
+      positions.push(cosA * ARCH_INNER, ARCH_BASE_Y + sinA * ARCH_INNER, 0);
+      // Outer vertex
+      positions.push(cosA * ARCH_OUTER, ARCH_BASE_Y + sinA * ARCH_OUTER, 0);
+      if (i < ARCH_SEGMENTS) {
+        const base = i * 2;
+        indices.push(base, base + 1, base + 2);
+        indices.push(base + 1, base + 3, base + 2);
+      }
+    }
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geom.setIndex(indices);
+    geom.computeVertexNormals();
+    return geom;
+  }
+
+  _addTickMarks(edgeMat) {
+    // Tick marks: center, ±25%, ±50%, ±75%, ±100% of max lean
+    const tickOffsets = [0, 0.25, -0.25, 0.5, -0.5, 0.75, -0.75, 1.0, -1.0];
+    const tickLengths = [0.20, 0.08, 0.08, 0.10, 0.10, 0.08, 0.08, 0.14, 0.14];
+    const tickAngles = tickOffsets.map(f => Math.PI / 2 + f * LEAN_SCALE);
+
+    for (let t = 0; t < tickAngles.length; t++) {
+      const angle = tickAngles[t];
+      const len = tickLengths[t];
+      const cosA = Math.cos(angle);
+      const sinA = Math.sin(angle);
+
+      const midR = ARCH_RADIUS;
+      const cx = cosA * midR;
+      const cy = ARCH_BASE_Y + sinA * midR;
+
+      const geom = new THREE.BoxGeometry(0.02, len, 0.02);
+      // Rotate tick to be radial (perpendicular to arc)
+      const tickMesh = new THREE.Mesh(geom, edgeMat.clone());
+      tickMesh.position.set(cx, cy, 0);
+      tickMesh.rotation.z = angle - Math.PI / 2; // align radially
+      this.group.add(tickMesh);
+      this._archParts.push(tickMesh);
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Tapered radial needle — wide at pivot, narrow at tip
+  // ----------------------------------------------------------
+
+  _buildNeedle(color, opacity, labelText, labelY) {
+    const needleGroup = new THREE.Group();
+
+    // Tapered needle using CylinderGeometry (radiusTop, radiusBottom, height)
+    // Bottom = pivot (wider), Top = tip (narrow)
+    const geom = new THREE.CylinderGeometry(
+      NEEDLE_TIP_WIDTH / 2,   // top radius (tip)
+      NEEDLE_BASE_WIDTH / 2,  // bottom radius (pivot)
+      NEEDLE_LENGTH,
+      6                        // radial segments
+    );
+    // Shift geometry up so bottom is at origin (pivot point)
+    geom.translate(0, NEEDLE_LENGTH / 2, 0);
+
+    const mat = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(color),
+      opacity: opacity,
+      transparent: true,
+      depthWrite: false
+    });
+    const needleMesh = new THREE.Mesh(geom, mat);
+    needleGroup.add(needleMesh);
+
+    // Small pivot hub circle at the base
+    const hubGeom = new THREE.SphereGeometry(0.08, 8, 8);
+    const hubMat = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(color),
+      opacity: Math.min(opacity + 0.1, 1.0),
+      transparent: true,
+      depthWrite: false
+    });
+    const hubMesh = new THREE.Mesh(hubGeom, hubMat);
+    needleGroup.add(hubMesh);
+
+    // Label sprite — matches needle opacity
+    const label = this._buildLabel(labelText, color, opacity);
+    label.position.set(0, labelY, 0);
+    needleGroup.add(label);
+
+    // Pivot at arch center
+    needleGroup.position.set(0, ARCH_BASE_Y, 0);
+
+    return needleGroup;
+  }
+
+  // ----------------------------------------------------------
+  // Text label — canvas-texture sprite
+  // ----------------------------------------------------------
+
+  _buildLabel(text, color, opacity = 1.0) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 256;
+    canvas.height = 64;
+    const ctx = canvas.getContext('2d');
+
+    ctx.font = 'bold 36px Arial';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    // Black stroke outline for readability
+    ctx.strokeStyle = '#000000';
+    ctx.lineWidth = 5;
+    ctx.strokeText(text, 128, 32);
+
+    // Fill with player color
+    ctx.fillStyle = color;
+    ctx.fillText(text, 128, 32);
+
+    const tex = new THREE.CanvasTexture(canvas);
+    const mat = new THREE.SpriteMaterial({
+      map: tex,
+      opacity: opacity,
+      transparent: true,
+      depthWrite: false
+    });
+    const sprite = new THREE.Sprite(mat);
+    sprite.scale.set(2.0, 0.5, 1);
+    return sprite;
+  }
+
+  // ----------------------------------------------------------
+  // Setup — called at countdown start
+  // ----------------------------------------------------------
+
+  setup(mode, playerColor, partnerColor) {
+    this._clearNeedles();
+    this._mode = mode;
+
+    const isMultiplayer = (mode === 'captain' || mode === 'stoker');
+    const playerRole = mode === 'captain' ? 'YOU CAPTAIN' : mode === 'stoker' ? 'YOU STOKER' : 'YOU';
+    const partnerRole = mode === 'captain' ? 'STOKER' : 'CAPTAIN';
+
+    // Player needle — label on inner (bottom) edge of arch
+    this._playerNeedle = this._buildNeedle(playerColor, 0.75, playerRole, ARCH_INNER - 0.35);
+    this.group.add(this._playerNeedle);
+
+    // Partner needle — label on outer (top) edge of arch
+    if (isMultiplayer) {
+      this._partnerNeedle = this._buildNeedle(partnerColor, 0.6, partnerRole, ARCH_OUTER + 0.35);
+      this.group.add(this._partnerNeedle);
+    }
+
+    this.group.visible = true;
+    this._visible = true;
+  }
+
+  // ----------------------------------------------------------
+  // Per-frame update
+  // ----------------------------------------------------------
+
+  update(bike, playerLean, partnerLean) {
+    if (!this._visible) return;
+
+    // Position at bike location
+    this.group.position.copy(bike.position);
+
+    // Orient with yaw + pitch only (NO lean — arch stays upright)
+    const qYaw = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0), bike.heading
+    );
+    const qPitch = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(1, 0, 0), bike._smoothPitch
+    );
+    const q = new THREE.Quaternion();
+    q.multiplyQuaternions(qYaw, qPitch);
+    this.group.quaternion.copy(q);
+
+    // Rotate player needle — 0 = straight up, lean left tilts needle left
+    if (this._playerNeedle) {
+      this._playerNeedle.rotation.z = (playerLean || 0) * LEAN_SCALE;
+    }
+
+    // Rotate partner needle
+    if (this._partnerNeedle) {
+      this._partnerNeedle.rotation.z = (partnerLean || 0) * LEAN_SCALE;
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Update partner color (when profile received)
+  // ----------------------------------------------------------
+
+  updatePartnerColor(color) {
+    if (!this._partnerNeedle) return;
+
+    // Update needle mesh material (child 0)
+    const needleMesh = this._partnerNeedle.children[0];
+    if (needleMesh && needleMesh.material) needleMesh.material.color.set(color);
+
+    // Update hub mesh material (child 1)
+    const hubMesh = this._partnerNeedle.children[1];
+    if (hubMesh && hubMesh.material) hubMesh.material.color.set(color);
+
+    // Rebuild label sprite with new color (child 2)
+    const oldLabel = this._partnerNeedle.children[2];
+    if (oldLabel) {
+      this._partnerNeedle.remove(oldLabel);
+      this._disposeSprite(oldLabel);
+    }
+    const partnerRole = this._mode === 'captain' ? 'STOKER' : 'CAPTAIN';
+    const partnerOpacity = needleMesh ? needleMesh.material.opacity : 0.2;
+    const newLabel = this._buildLabel(partnerRole, color, partnerOpacity);
+    newLabel.position.set(0, ARCH_OUTER + 0.35, 0);
+    this._partnerNeedle.add(newLabel);
+  }
+
+  // ----------------------------------------------------------
+  // Hide / Destroy
+  // ----------------------------------------------------------
+
+  hide() {
+    this.group.visible = false;
+    this._visible = false;
+    this._clearNeedles();
+  }
+
+  _clearNeedles() {
+    if (this._playerNeedle) {
+      this._disposeGroup(this._playerNeedle);
+      this.group.remove(this._playerNeedle);
+      this._playerNeedle = null;
+    }
+    if (this._partnerNeedle) {
+      this._disposeGroup(this._partnerNeedle);
+      this.group.remove(this._partnerNeedle);
+      this._partnerNeedle = null;
+    }
+  }
+
+  _disposeGroup(grp) {
+    grp.children.forEach(c => {
+      if (c.geometry) c.geometry.dispose();
+      if (c.material) {
+        if (c.material.map) c.material.map.dispose();
+        c.material.dispose();
+      }
+    });
+  }
+
+  _disposeSprite(sprite) {
+    if (sprite.material.map) sprite.material.map.dispose();
+    if (sprite.material) sprite.material.dispose();
+  }
+
+  destroy() {
+    this.hide();
+    for (const part of this._archParts) {
+      if (part.geometry) part.geometry.dispose();
+      if (part.material) part.material.dispose();
+    }
+    this._archParts.length = 0;
+    this.scene.remove(this.group);
+  }
+}

--- a/js/game.js
+++ b/js/game.js
@@ -22,6 +22,7 @@ import { HUD } from './hud.js';
 import { GrassParticles } from './grass-particles.js';
 import { Lobby } from './lobby.js';
 import { GameRecorder } from './game-recorder.js';
+import { ArchIndicator } from './arch-indicator.js';
 
 class Game {
   constructor() {
@@ -53,6 +54,8 @@ class Game {
     this.chaseCamera = new ChaseCamera(this.camera);
     this.hud = new HUD(this.input);
     this.grassParticles = new GrassParticles(this.scene);
+    this.archIndicator = new ArchIndicator(this.scene);
+    this._partnerBikeColor = null;
     this.recorder = new GameRecorder(this.renderer.domElement, this.input);
 
     // Mode
@@ -90,6 +93,14 @@ class Game {
     this._dpadPrevLeft = false;
     this._dpadPrevRight = false;
     this._gpPrevY = false;
+    this._gpPrevA = false;
+
+    // Tap center of screen to recalibrate tilt (mobile)
+    this.renderer.domElement.addEventListener('touchstart', (e) => {
+      if (this.state !== 'playing') return;
+      if (!this.input.motionEnabled && !this.input.gyroConnected) return;
+      this._recalibrateTilt();
+    });
 
     // Victory overlay input cooldown
     this._overlayCooldownUntil = 0;
@@ -410,6 +421,11 @@ class Game {
       }
       // Capture partner server ID for score attribution
       if (profile.serverId) this._partnerServerId = profile.serverId;
+      // Partner bike color for arch indicator
+      if (profile.bikeColor) {
+        this._partnerBikeColor = profile.bikeColor;
+        this.archIndicator.updatePartnerColor(profile.bikeColor);
+      }
     };
 
     // Pre-acquire local media stream so calls connect instantly on both sides.
@@ -547,6 +563,13 @@ class Game {
     this.hud.updateTimer(initialBudget, initialBudget);
     this.hud.showCollectibles(level);
     this.world.setRaceMarkers(level, this.camera);
+
+    // Setup arch tilt indicator (only for motion/gyro input)
+    if (this.input.motionEnabled || this.input.gyroConnected) {
+      const playerColor = this._getFrameColor(this.lobby.selectedPreset);
+      const partnerColor = this._partnerBikeColor || '#888888';
+      this.archIndicator.setup(this.mode, playerColor, partnerColor);
+    }
 
     // Show contribution bar in multiplayer
     if (this.mode !== 'solo') {
@@ -960,6 +983,28 @@ class Game {
     this._sendProfile();
   }
 
+  _recalibrateTilt() {
+    if (this.input.motionEnabled) {
+      this.input.motionOffset = this.input.rawGamma;
+      this.input.motionLean = 0;
+    }
+    if (this.input.gyroConnected) {
+      this.input.calibrateGyro();
+    }
+    // Flash the calibrate overlay briefly
+    const flash = document.getElementById('calibrate-flash');
+    if (flash) {
+      flash.style.display = 'block';
+      setTimeout(() => { flash.style.display = 'none'; }, 800);
+    }
+  }
+
+  _getFrameColor(presetData) {
+    if (!presetData) return '#888888';
+    const entry = presetData['Cylinder006_cycle_0'];
+    return entry?.color || '#888888';
+  }
+
   _sendProfile() {
     if (!this.net || !this.net.connected) return;
     const profile = { achievements: this.achievements.getEarned() };
@@ -971,6 +1016,7 @@ class Game {
         if (user.serverId) profile.serverId = user.serverId;
       }
     }
+    profile.bikeColor = this._getFrameColor(this.lobby.selectedPreset);
     this.net.sendProfile(profile);
   }
 
@@ -1324,6 +1370,9 @@ class Game {
     const partnerTitle = document.querySelector('#partner-gauge .gauge-title');
     if (partnerTitle) partnerTitle.textContent = 'PARTNER';
 
+    this.archIndicator.hide();
+    this._partnerBikeColor = null;
+
     this.bike.fullReset();
     this.chaseCamera.initialized = false;
     this.pedalCtrl = new PedalController(this.input);
@@ -1465,18 +1514,24 @@ class Game {
 
     // Y button (button 3) — save clip
     const y = gp.buttons[3] && gp.buttons[3].pressed;
+    // A button (button 0) — recalibrate tilt
+    const a = gp.buttons[0] && gp.buttons[0].pressed;
 
     if (up && !this._dpadPrevUp) this.safetyBtn.click();
     if (down && !this._dpadPrevDown) this.speedBtn.click();
     if (right && !this._dpadPrevRight) document.getElementById('reset-btn').click();
     if (left && !this._dpadPrevLeft) this._returnToLobby();
     if (y && !this._gpPrevY) this.recorder.saveClip();
+    if (a && !this._gpPrevA && (this.input.motionEnabled || this.input.gyroConnected)) {
+      this._recalibrateTilt();
+    }
 
     this._dpadPrevUp = up;
     this._dpadPrevDown = down;
     this._dpadPrevLeft = left;
     this._dpadPrevRight = right;
     this._gpPrevY = y;
+    this._gpPrevA = a;
   }
 
   _updateConnBadge() {
@@ -1610,6 +1665,7 @@ class Game {
           document.getElementById('disconnect-overlay').style.display !== 'none') this._pollOverlayGamepad();
       this.world.update(this.bike.position, this.bike.roadD);
       this.chaseCamera.update(this.bike, dt, roadPath);
+      if (this.archIndicator._visible) this.archIndicator.update(this.bike, 0, 0);
       this.renderer.render(this.scene, this.camera);
     }
 
@@ -1672,6 +1728,7 @@ class Game {
     }
 
     this.hud.update(this.bike, this.input, this.pedalCtrl, dt);
+    this.archIndicator.update(this.bike, balanceResult.leanInput);
     this.renderer.render(this.scene, this.camera);
     this.recorder.composite(this._buildRecordState(this.pedalCtrl));
   }
@@ -1773,6 +1830,7 @@ class Game {
     this._updateConnBadge();
     const remoteData = { remoteLean: this.remoteLean, remoteLastFoot: this._remoteLastFoot, remoteLastTapTime: this._remoteLastTapTime };
     this.hud.update(this.bike, this.input, this.sharedPedal, dt, remoteData);
+    this.archIndicator.update(this.bike, captainLean, this.remoteLean);
     this.renderer.render(this.scene, this.camera);
     this.recorder.composite(this._buildRecordState(this.sharedPedal, remoteData));
   }
@@ -1869,6 +1927,8 @@ class Game {
     this._updateConnBadge();
     const remoteData = { remoteLean: this.remoteLean, remoteLastFoot: this._remoteLastFoot, remoteLastTapTime: this._remoteLastTapTime };
     this.hud.update(this.bike, this.input, this.pedalCtrl, dt, remoteData);
+    const stokerLean = this.balanceCtrl.update().leanInput;
+    this.archIndicator.update(this.bike, stokerLean, this.remoteLean);
     this.renderer.render(this.scene, this.camera);
     this.recorder.composite(this._buildRecordState(this.pedalCtrl, remoteData));
   }


### PR DESCRIPTION
## Summary
- New `js/arch-indicator.js` — radial gauge arch with double-edged band, translucent fill, tick marks, and tapered dial needles that show lean input
- Only appears when using motion (device tilt) or controller gyroscope input
- Needles colored to match each player's bike preset; labels show "YOU CAPTAIN" / "YOU STOKER" / "YOU"
- In multiplayer, partner's needle + label shown at lower opacity on the outer arch edge
- Partner bike color synced via profile messages
- Adds tilt recalibration: tap center screen (mobile) or press A button (gamepad) during gameplay

## Test plan
- [ ] Solo mode with device tilt: verify arch appears, single "YOU" needle tracks lean, colored to match bike preset
- [ ] Change bike color in lobby: verify needle color updates
- [ ] Multiplayer captain: verify two needles — "YOU CAPTAIN" (inner) and "STOKER" (outer) with correct colors/opacities
- [ ] Multiplayer stoker: verify "YOU STOKER" (inner) and "CAPTAIN" (outer)
- [ ] Keyboard/gamepad stick only (no motion): verify arch does NOT appear
- [ ] Recalibrate by tapping screen center (mobile) or pressing A (gamepad) — verify calibrate flash
- [ ] Return to lobby: verify arch hides cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)