### PR TITLE
Batch submitScore DB writes and add leaderboard time index

### DIFF
--- a/index.html
+++ b/index.html
@@ -2450,7 +2450,7 @@ ON</button>
       </div>
     </div>
 
-    <p class="lobby-credits">Users First Games <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span class="lobby-version" id="lobby-version">v.8131234 | 03-05-2026 19:02</span></p>
+    <p class="lobby-credits">Users First Games <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span class="lobby-version" id="lobby-version">v.9aad932 | 03-05-2026 19:23</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
 </div>

--- a/worker/leaderboard.js
+++ b/worker/leaderboard.js
@@ -119,30 +119,39 @@ async function submitScore(request, env, corsOrigin, userId) {
 
   const scoreId = scoreRes.meta.last_row_id;
 
-  // Insert contributions
+  // Batch insert contributions and achievements in a single round-trip
+  const batchStmts = [];
+
   if (contributions) {
     for (const [role, stats] of Object.entries(contributions)) {
-      await env.DB.prepare(
-        `INSERT INTO score_contributions
-         (score_id, role, player_user_id, contribution_pct, pedal_taps, pedal_correct, pedal_wrong, pedal_power,
-          balance_safe_pct, balance_danger_pct, on_road_pct, center_pct, avg_lateral_offset)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      ).bind(
-        scoreId, role, stats.userId || null, stats.overallPct || 0,
-        stats.totalTaps || 0, stats.correctTaps || 0, stats.wrongTaps || 0, stats.totalPower || 0,
-        stats.safePct || 0, stats.dangerPct || 0, stats.onRoadPct || 0, stats.centerPct || 0,
-        stats.avgLateral || 0
-      ).run();
+      batchStmts.push(
+        env.DB.prepare(
+          `INSERT INTO score_contributions
+           (score_id, role, player_user_id, contribution_pct, pedal_taps, pedal_correct, pedal_wrong, pedal_power,
+            balance_safe_pct, balance_danger_pct, on_road_pct, center_pct, avg_lateral_offset)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).bind(
+          scoreId, role, stats.userId || null, stats.overallPct || 0,
+          stats.totalTaps || 0, stats.correctTaps || 0, stats.wrongTaps || 0, stats.totalPower || 0,
+          stats.safePct || 0, stats.dangerPct || 0, stats.onRoadPct || 0, stats.centerPct || 0,
+          stats.avgLateral || 0
+        )
+      );
     }
   }
 
-  // Save achievements
   if (newAchievements && Array.isArray(newAchievements)) {
     for (const achId of newAchievements) {
-      await env.DB.prepare(
-        'INSERT OR IGNORE INTO user_achievements (user_id, achievement_id, score_id) VALUES (?, ?, ?)'
-      ).bind(userId, achId, scoreId).run();
+      batchStmts.push(
+        env.DB.prepare(
+          'INSERT OR IGNORE INTO user_achievements (user_id, achievement_id, score_id) VALUES (?, ?, ?)'
+        ).bind(userId, achId, scoreId)
+      );
     }
+  }
+
+  if (batchStmts.length > 0) {
+    await env.DB.batch(batchStmts);
   }
 
   // Check if personal best

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS scores (
 );
 
 CREATE INDEX IF NOT EXISTS idx_scores_level_dist ON scores(level_id, distance DESC);
+CREATE INDEX IF NOT EXISTS idx_scores_level_time ON scores(level_id, time_ms ASC);
 CREATE INDEX IF NOT EXISTS idx_scores_user ON scores(user_id);
 
 CREATE TABLE IF NOT EXISTS score_contributions (


### PR DESCRIPTION
## Summary
- **#54**: Replace sequential `INSERT` loops in `submitScore` with a single `env.DB.batch()` call — reduces N DB round-trips to 1 for contributions + achievements
- **#53**: Add `idx_scores_level_time` index on `(level_id, time_ms ASC)` to match the leaderboard `ORDER BY` clause, eliminating table scans
- **#52**: Closed as already fixed — leaderboard endpoint already uses batch `IN (...)` queries

Fixes #53, fixes #54

## Test plan
- [ ] Run `wrangler dev` and submit a score with contributions + achievements — verify response is identical
- [ ] Verify leaderboard endpoint returns same results as before
- [ ] Run `EXPLAIN QUERY PLAN` on leaderboard query to confirm `idx_scores_level_time` is used
- [ ] Check Worker CPU time for score submission is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)