### PR TITLE
Show Learn to Ride on first visit to level select

### DIFF
--- a/index.html
+++ b/index.html
@@ -3698,7 +3698,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits">Users First Games <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.959dd1d | 03-14-2026 23:28</span></p>
+    <p class="lobby-credits">Users First Games <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.482117e | 03-14-2026 23:35</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -757,11 +757,10 @@ export class Lobby {
     // Tutorial button sits between level cards and difficulty
     const tutBtn = document.getElementById('btn-tutorial');
     if (tutBtn) {
-      // Show for demo users or motion/gyro users
-      const hasMotion = this.motionActive && (
-        (this.input && this.input.motionEnabled) ||
-        (this.input && this.input.gyroConnected)
-      );
+      // Show for demo users or motion/gyro users.
+      // Use motionActive (toggle on) rather than motionEnabled (events fired)
+      // so the button appears on the first visit before gyro events arrive.
+      const hasMotion = this.motionActive || (this.input && this.input.gyroConnected);
       if (isDemo || hasMotion) {
         tutBtn.style.display = '';
         const isGyro = this.input && this.input.gyroConnected;


### PR DESCRIPTION
## Summary
- Tutorial button checked `motionActive && motionEnabled`, but `motionEnabled` is false until gyro events actually fire — which hasn't happened on the first visit
- Now checks just `motionActive` (toggle is on) so the button appears immediately on mobile

Fixes #113

## Test plan
- [ ] On mobile, tap SOLO RIDE — Learn to Ride button should be visible on first visit
- [ ] On desktop with gamepad gyro, Learn to Ride with Gyro should still show
- [ ] On desktop without motion, button should still be hidden (unless demo user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)