### PR TITLE
Auto-refresh expired JWT on license check and room creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3698,7 +3698,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits">Users First Games <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.482117e | 03-14-2026 23:35</span></p>
+    <p class="lobby-credits">Users First Games <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.b9fbe4c | 03-14-2026 23:40</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/js/auth.js
+++ b/js/auth.js
@@ -130,6 +130,48 @@ export class AuthManager {
     return false;
   }
 
+  /** Check if the stored server JWT is expired (or will expire within marginSec). */
+  isTokenExpired(marginSec = 60) {
+    if (!this.token) return true;
+    try {
+      const payload = JSON.parse(atob(this.token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+      return !payload.exp || payload.exp < Math.floor(Date.now() / 1000) + marginSec;
+    } catch {
+      return true;
+    }
+  }
+
+  /**
+   * Ensure the server JWT is valid. If expired, attempt refresh via stored
+   * GSI credential first, then fall back to prompting a new Google sign-in.
+   * Returns true if a valid token is available afterward.
+   */
+  async ensureValidToken() {
+    if (!this.isTokenExpired()) return true;
+
+    // Try re-exchanging the stored GSI credential (may still be valid)
+    if (await this.retryTokenExchange()) return true;
+
+    // GSI credential also expired — need a fresh Google sign-in.
+    // Trigger the prompt and wait briefly for the callback.
+    return new Promise((resolve) => {
+      const prevCallback = this._onLoginCallback;
+      const timeout = setTimeout(() => {
+        this._onLoginCallback = prevCallback;
+        resolve(false);
+      }, 5000);
+
+      this._onLoginCallback = (user) => {
+        clearTimeout(timeout);
+        this._onLoginCallback = prevCallback;
+        if (prevCallback) prevCallback(user);
+        resolve(!!this.token && !this.isTokenExpired());
+      };
+
+      this.login();
+    });
+  }
+
   login() {
     if (typeof google === 'undefined' || !google.accounts) return;
     google.accounts.id.prompt();

--- a/js/license.js
+++ b/js/license.js
@@ -149,9 +149,21 @@ export class LicenseManager {
       const serverId = this.auth.user ? this.auth.user.serverId : null;
       if (!serverId) return;
 
-      const res = await fetch(`${STORE_API}/license/${serverId}/tandemonium`, {
+      let res = await fetch(`${STORE_API}/license/${serverId}/tandemonium`, {
         headers: { 'Authorization': `Bearer ${this.auth.token}` },
       });
+
+      // On 401, attempt to refresh the JWT and retry once
+      if (res.status === 401 && this.auth.ensureValidToken) {
+        console.warn('License: 401 — attempting token refresh');
+        const refreshed = await this.auth.ensureValidToken();
+        if (refreshed) {
+          res = await fetch(`${STORE_API}/license/${serverId}/tandemonium`, {
+            headers: { 'Authorization': `Bearer ${this.auth.token}` },
+          });
+        }
+      }
+
       if (res.ok) {
         this._license = await res.json();
         this._cachedAt = Date.now();

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -949,19 +949,27 @@ export class Lobby {
     // Restore UI if already logged in from localStorage
     if (this.auth.isLoggedIn()) {
       updateUI(this.auth.getUser());
-      // Check license and update mode buttons + level cards
-      this.license.check().then(() => {
-        this._updateModeButtons();
-        this._rebuildLevelCards();
-      }).catch(() => {});
-      // Sync achievements from D1 for returning users
-      this.auth.getMe().then(me => {
-        if (me && me.achievements) {
-          this._achievements.mergeFromServer(
-            me.achievements.map(a => ({ id: a.achievement_id, earnedAt: a.earned_at }))
-          );
-        }
-      }).catch(() => {});
+
+      // Proactively refresh expired JWT before anything needs it
+      const tokenReady = this.auth.isTokenExpired()
+        ? this.auth.ensureValidToken().catch(() => false)
+        : Promise.resolve(true);
+
+      tokenReady.then(() => {
+        // Check license and update mode buttons + level cards
+        this.license.check().then(() => {
+          this._updateModeButtons();
+          this._rebuildLevelCards();
+        }).catch(() => {});
+        // Sync achievements from D1 for returning users
+        this.auth.getMe().then(me => {
+          if (me && me.achievements) {
+            this._achievements.mergeFromServer(
+              me.achievements.map(a => ({ id: a.achievement_id, earnedAt: a.earned_at }))
+            );
+          }
+        }).catch(() => {});
+      });
     }
     this._updateModeButtons();
   }
@@ -2291,13 +2299,21 @@ export class Lobby {
       statusEl.className = 'conn-status error';
     };
 
-    // Auth error: token was rejected by relay — clear and re-login
-    this.net.onAuthError = () => {
-      console.warn('LOBBY: Relay auth failed for captain — refreshing login');
-      statusEl.textContent = 'Session expired, signing in...';
+    // Auth error: token was rejected by relay — try silent refresh first
+    this.net.onAuthError = async () => {
+      console.warn('LOBBY: Relay auth failed for captain — refreshing token');
+      statusEl.textContent = 'Session expired, refreshing...';
       statusEl.className = 'conn-status';
-      this.auth.refreshLogin();
-      this._pendingCreateRoom = true;
+      const refreshed = await this.auth.ensureValidToken();
+      if (refreshed) {
+        // Token refreshed — retry room creation
+        const freshToken = await this.auth.getRelayToken(code, 'captain');
+        if (freshToken) this.net._relayToken = freshToken;
+        this.net.enterRoom(code, 'captain');
+      } else {
+        statusEl.textContent = 'Sign-in required...';
+        this._pendingCreateRoom = true;
+      }
     };
 
     this.net.enterRoom(code, 'captain');
@@ -2359,21 +2375,24 @@ export class Lobby {
       }
     };
 
-    // Auth error: token was rejected by relay — clear and re-login
+    // Auth error: token was rejected by relay — try silent refresh first
     this.net.onAuthError = async () => {
-      console.warn('LOBBY: Relay auth failed for stoker — attempting token refresh');
-      statusEl.textContent = 'Session expired, retrying...';
+      console.warn('LOBBY: Relay auth failed for stoker — refreshing token');
+      statusEl.textContent = 'Session expired, refreshing...';
       statusEl.className = 'conn-status';
 
-      // Try getting a fresh token first (in case server JWT is still valid)
-      const freshToken = await this.auth.getRelayToken(code, 'stoker');
-      if (freshToken) {
-        statusEl.textContent = 'Reconnecting...';
-        this.net.retryWithToken(freshToken);
+      const refreshed = await this.auth.ensureValidToken();
+      if (refreshed) {
+        const freshToken = await this.auth.getRelayToken(code, 'stoker');
+        if (freshToken) {
+          statusEl.textContent = 'Reconnecting...';
+          this.net.retryWithToken(freshToken);
+        } else {
+          statusEl.textContent = 'Sign-in required...';
+          this._pendingAutoJoinCode = code;
+        }
       } else {
-        // Server JWT is also bad — need full re-login
         statusEl.textContent = 'Sign-in required...';
-        this.auth.refreshLogin();
         this._pendingAutoJoinCode = code;
       }
     };


### PR DESCRIPTION
## Summary
- **`auth.js`**: Added `isTokenExpired()` (decodes JWT `exp` claim client-side) and `ensureValidToken()` which tries silent GSI credential re-exchange before falling back to a Google sign-in prompt
- **`license.js`**: On 401 from store API, calls `ensureValidToken()` and retries once — paid users no longer appear unlicensed with expired tokens
- **`lobby.js`**: Proactively checks token expiry on page load. Room creation/join auth errors now use `ensureValidToken()` for silent refresh instead of immediately prompting Google sign-in

Fixes #111
Fixes #106

## Test plan
- [ ] Log in, manually expire the JWT in localStorage (edit the `exp` claim or wait 30 days), reload — should silently refresh without prompting
- [ ] With expired JWT, tap RIDE TOGETHER → START A RIDE — should refresh token and create room without re-prompting Google
- [ ] With expired JWT + expired GSI credential, license check should fall back to Google sign-in prompt
- [ ] Verify licensed users still see ✅ after page reload with valid token

🤖 Generated with [Claude Code](https://claude.com/claude-code)