### PR TITLE
Add gyro HUD for controller overlay (#182)

### DIFF
--- a/controller-overlay/src/index.html
+++ b/controller-overlay/src/index.html
@@ -226,6 +226,16 @@
     text-align: center;
     padding: 4px 2px;
     font-size: 10px;
+    transition: background 0.15s, border-color 0.15s;
+  }
+  .camera-presets button.selected {
+    background: rgba(51,136,255,0.3);
+    border-color: rgba(51,136,255,0.6);
+    color: #fff;
+  }
+  .camera-presets button.nav-hover {
+    outline: 2px solid rgba(255,255,255,0.6);
+    outline-offset: 1px;
   }
 
   /* ── Status badges (top-right, left of gear) ── */
@@ -305,6 +315,54 @@
     opacity: 0.85;
   }
 
+  /* ── Gyro HUD (arc, arrows, calibration text) ── */
+  #gyro-hud {
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 40;
+  }
+  #gyro-hud.visible { display: block; position: fixed; }
+
+  #gyro-hud.pos-below { bottom: 4%; }
+  #gyro-hud.pos-above { top: 4%; }
+
+  #arc-svg {
+    display: block;
+    width: min(55vw, 240px);
+    height: auto;
+  }
+
+  .gyro-hud-footer {
+    position: absolute;
+    left: 0; right: 0;
+    top: 48%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+
+  #lean-arrow-left, #lean-arrow-right {
+    font-size: 18px;
+    opacity: 0.1;
+    transition: opacity 0.05s;
+    user-select: none;
+  }
+
+  #calib-hint {
+    font-size: 9px;
+    color: rgba(255,255,255,0.5);
+    text-align: center;
+    transition: opacity 0.5s;
+    min-width: 100px;
+  }
+  #calib-hint.hidden { opacity: 0; }
+
   /* ── Click-through indicator ── */
   #click-through-indicator {
     position: fixed;
@@ -378,13 +436,23 @@
   <div class="setting-row">
     <label>Camera</label>
   </div>
-  <div class="camera-presets">
+  <div class="camera-presets" data-row="0">
     <button data-preset="front">Front</button>
     <button data-preset="back">Back</button>
-    <button data-preset="top">Top</button>
     <button data-preset="left">Left</button>
     <button data-preset="right">Right</button>
+  </div>
+  <div class="camera-presets" data-row="1">
     <button data-preset="player">Player</button>
+    <button data-preset="top">Top</button>
+  </div>
+
+  <div class="setting-row">
+    <label>HUD Position</label>
+    <select id="hud-position">
+      <option value="above" selected>Above</option>
+      <option value="below">Below</option>
+    </select>
   </div>
 
   <hr class="settings-divider">
@@ -439,6 +507,25 @@
 <!-- Status indicator -->
 <div id="status-bar">
   <span class="status-badge" id="gamepad-status">No gamepad</span>
+</div>
+
+<!-- Gyro HUD -->
+<div id="gyro-hud">
+  <svg id="arc-svg" viewBox="-120 -105 240 115">
+    <!-- Arc band background -->
+    <path id="arc-band" d="" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.15)" stroke-width="0.5"/>
+    <!-- Tick marks -->
+    <g id="arc-ticks" stroke="rgba(255,255,255,0.3)" stroke-width="0.8"></g>
+    <!-- Needle -->
+    <line id="arc-needle" x1="0" y1="-4" x2="0" y2="-22" stroke="#fff" stroke-width="2.5" stroke-linecap="round"/>
+    <!-- Center dot -->
+    <circle cx="0" cy="0" r="2" fill="rgba(255,255,255,0.4)"/>
+  </svg>
+  <div class="gyro-hud-footer">
+    <span id="lean-arrow-left">&#x25C0;</span>
+    <span id="calib-hint" class="hidden"></span>
+    <span id="lean-arrow-right">&#x25B6;</span>
+  </div>
 </div>
 
 <!-- No-controller splash (shown until a gamepad connects) -->

--- a/controller-overlay/src/js/app.js
+++ b/controller-overlay/src/js/app.js
@@ -106,6 +106,132 @@ const _identityQuat = new THREE.Quaternion();
 const isDesktop = typeof window !== 'undefined' &&
   (window.electronAPI || navigator.userAgent.includes('Electron'));
 
+// ── Gyro HUD ──
+const gyroHud = document.getElementById('gyro-hud');
+const arcNeedle = document.getElementById('arc-needle');
+const arcBand = document.getElementById('arc-band');
+const arcTicks = document.getElementById('arc-ticks');
+const leanArrowLeft = document.getElementById('lean-arrow-left');
+const leanArrowRight = document.getElementById('lean-arrow-right');
+const calibHint = document.getElementById('calib-hint');
+const GYRO_HUD_MAX_DEG = 40; // ±40° matches game's gyro sensitivity
+let calibHintTimer = null;
+let driftCheckAccum = 0;
+let driftCheckLastLean = 0;
+const _hudEuler = new THREE.Euler();
+
+// Build the static arc band and tick marks
+function initGyroHud() {
+  const R = 100; // arc radius in SVG units
+  const bandW = 10;
+  const maxRad = GYRO_HUD_MAX_DEG * Math.PI / 180;
+
+  // Arc band path (circular arc from -maxDeg to +maxDeg, opening downward)
+  const steps = 40;
+  let d = '';
+  for (let i = 0; i <= steps; i++) {
+    const a = -maxRad + (2 * maxRad * i / steps);
+    const x = Math.sin(a) * (R - bandW / 2);
+    const y = -Math.cos(a) * (R - bandW / 2);
+    d += (i === 0 ? 'M' : 'L') + x.toFixed(2) + ',' + y.toFixed(2);
+  }
+  for (let i = steps; i >= 0; i--) {
+    const a = -maxRad + (2 * maxRad * i / steps);
+    const x = Math.sin(a) * (R + bandW / 2);
+    const y = -Math.cos(a) * (R + bandW / 2);
+    d += 'L' + x.toFixed(2) + ',' + y.toFixed(2);
+  }
+  d += 'Z';
+  arcBand.setAttribute('d', d);
+
+  // Tick marks at 0%, ±25%, ±50%, ±75%, ±100%
+  let ticksHtml = '';
+  for (const pct of [0, 0.25, 0.5, 0.75, 1.0]) {
+    for (const sign of (pct === 0 ? [1] : [-1, 1])) {
+      const a = sign * pct * maxRad;
+      const isMajor = pct === 0 || pct === 1.0;
+      const inner = R - (isMajor ? 14 : 10);
+      const outer = R + (isMajor ? 14 : 10);
+      const x1 = Math.sin(a) * inner, y1 = -Math.cos(a) * inner;
+      const x2 = Math.sin(a) * outer, y2 = -Math.cos(a) * outer;
+      const sw = isMajor ? 1.2 : 0.6;
+      const op = isMajor ? 0.5 : 0.25;
+      ticksHtml += `<line x1="${x1.toFixed(2)}" y1="${y1.toFixed(2)}" x2="${x2.toFixed(2)}" y2="${y2.toFixed(2)}" stroke-width="${sw}" opacity="${op}"/>`;
+    }
+  }
+  arcTicks.innerHTML = ticksHtml;
+}
+
+function leanColor(t) {
+  // t: 0 (center) to 1 (max lean)
+  const abs = Math.min(1, Math.abs(t));
+  if (abs < 0.5) return '#ffffff';
+  if (abs < 0.75) return '#ffaa22';
+  return '#ff4444';
+}
+
+function updateGyroHud(leanDeg) {
+  if (!gyroHud.classList.contains('visible')) return;
+
+  const t = Math.max(-1, Math.min(1, leanDeg / GYRO_HUD_MAX_DEG)); // -1 to 1
+  const absT = Math.abs(t);
+  const R = 100;
+  const maxRad = GYRO_HUD_MAX_DEG * Math.PI / 180;
+
+  // Needle rotation
+  const needleAngle = t * maxRad;
+  const nx1 = Math.sin(needleAngle) * 4, ny1 = -Math.cos(needleAngle) * 4;
+  const nx2 = Math.sin(needleAngle) * 22, ny2 = -Math.cos(needleAngle) * 22;
+  // Use line from near-center to arc
+  const nx2f = Math.sin(needleAngle) * (R - 2);
+  const ny2f = -Math.cos(needleAngle) * (R - 2);
+  arcNeedle.setAttribute('x1', nx1.toFixed(2));
+  arcNeedle.setAttribute('y1', ny1.toFixed(2));
+  arcNeedle.setAttribute('x2', nx2f.toFixed(2));
+  arcNeedle.setAttribute('y2', ny2f.toFixed(2));
+  const color = leanColor(t);
+  arcNeedle.setAttribute('stroke', color);
+
+  // Arrows + calibration text match needle color
+  calibHint.style.color = color;
+  leanArrowLeft.style.opacity = t < -0.05 ? Math.min(1, absT * 1.5) : 0.1;
+  leanArrowLeft.style.color = t < -0.05 ? color : '#888';
+  leanArrowRight.style.opacity = t > 0.05 ? Math.min(1, absT * 1.5) : 0.1;
+  leanArrowRight.style.color = t > 0.05 ? color : '#888';
+}
+
+function showGyroHud() {
+  gyroHud.classList.add('visible');
+  applyHudPosition();
+}
+function hideGyroHud() { gyroHud.classList.remove('visible'); }
+
+function applyHudPosition() {
+  const pos = document.getElementById('hud-position')?.value || 'above';
+  gyroHud.classList.remove('pos-above', 'pos-below');
+  gyroHud.classList.add('pos-' + pos);
+}
+
+function showCalibHint(text, duration) {
+  calibHint.textContent = text;
+  calibHint.classList.remove('hidden');
+  if (calibHintTimer) clearTimeout(calibHintTimer);
+  if (duration) {
+    calibHintTimer = setTimeout(() => {
+      calibHint.classList.add('hidden');
+      calibHintTimer = null;
+    }, duration);
+  }
+}
+
+function hideCalibHint() {
+  calibHint.classList.add('hidden');
+  if (calibHintTimer) { clearTimeout(calibHintTimer); calibHintTimer = null; }
+}
+
+initGyroHud();
+applyHudPosition();
+
 // ── Initialize ──
 async function init() {
   // Detect what's connected — if nothing, don't load a model yet
@@ -392,6 +518,7 @@ async function connectControllerGyro() {
   gyroPermitted = true;
   connectGyroBtn.textContent = 'Connected';
   updateGyroToggle();
+  showGyroHud();
   console.log('Gyro connected:', device.productName);
 
   startCalibration();
@@ -420,6 +547,8 @@ async function disconnectGyro() {
   gyroBias.x = gyroBias.y = gyroBias.z = 0;
   connectGyroBtn.textContent = 'Connect';
   updateGyroToggle();
+  hideGyroHud();
+  hideCalibHint();
 }
 
 // ── Main loop ──
@@ -453,6 +582,28 @@ function loop() {
   }
 
   overlay.update(gamepad, gyroActive ? gyroOrientation : null);
+
+  // Update gyro HUD
+  if (gyroActive) {
+    _hudEuler.setFromQuaternion(gyroOrientation, 'XYZ');
+    const leanDeg = -_hudEuler.z * (180 / Math.PI);
+    updateGyroHud(leanDeg);
+
+    // Drift detection: lean angle changing while controller is stationary
+    if (!calibrating) {
+      const leanDelta = Math.abs(leanDeg - driftCheckLastLean);
+      driftCheckLastLean = leanDeg;
+      if (leanDelta > 0.02 && leanDelta < 0.5) {
+        driftCheckAccum += leanDelta;
+      } else {
+        driftCheckAccum = Math.max(0, driftCheckAccum - 0.1);
+      }
+      if (driftCheckAccum > 15) {
+        showCalibHint(comboName(combos.calibrate) + ' to recalibrate', 5000);
+        driftCheckAccum = 0;
+      }
+    }
+  }
 }
 
 function toggleSettings() {
@@ -469,10 +620,12 @@ async function toggleGyro() {
     gyroOrientation.identity();
     lastGyroTime = 0;
     updateGyroToggle();
+    hideGyroHud();
   } else if (gyroPermitted && hidDevice) {
     gyroActive = true;
     startCalibration();
     updateGyroToggle();
+    showGyroHud();
   } else {
     try { await connectControllerGyro(); } catch (e) { /* */ }
   }
@@ -483,7 +636,7 @@ let settingsFocusIndex = 0;
 const navPrevState = { up: false, down: false, left: false, right: false, a: false, b: false };
 
 function getSettingRows() {
-  return Array.from(settingsPanel.querySelectorAll('.setting-row'));
+  return Array.from(settingsPanel.querySelectorAll('.setting-row, .camera-presets'));
 }
 
 function navigateSettings(gamepad) {
@@ -509,23 +662,43 @@ function navigateSettings(gamepad) {
 
   const row = rows[settingsFocusIndex];
   if (row) {
-    const select = row.querySelector('select');
-    const checkbox = row.querySelector('input[type="checkbox"]');
-    const slider = row.querySelector('input[type="range"]');
-    const button = row.querySelector('button');
-    const colorInput = row.querySelector('input[type="color"]');
+    // Camera presets row — left/right highlights, A confirms selection
+    if (row.classList.contains('camera-presets')) {
+      const btns = Array.from(row.querySelectorAll('button'));
+      // Track a hover/focus index within this row
+      let hoverIdx = btns.findIndex(b => b.classList.contains('nav-hover'));
+      if (hoverIdx === -1) hoverIdx = btns.findIndex(b => b.classList.contains('selected'));
 
-    if (left && !navPrevState.left) {
-      if (select) { select.selectedIndex = Math.max(0, select.selectedIndex - 1); select.dispatchEvent(new Event('change')); }
-      if (slider) { slider.value = Math.max(+slider.min, +slider.value - 5); slider.dispatchEvent(new Event('input')); }
-    }
-    if (right && !navPrevState.right) {
-      if (select) { select.selectedIndex = Math.min(select.options.length - 1, select.selectedIndex + 1); select.dispatchEvent(new Event('change')); }
-      if (slider) { slider.value = Math.min(+slider.max, +slider.value + 5); slider.dispatchEvent(new Event('input')); }
-    }
-    if (a && !navPrevState.a) {
-      if (checkbox) { checkbox.checked = !checkbox.checked; checkbox.dispatchEvent(new Event('change')); }
-      if (button) button.click();
+      if (left && !navPrevState.left) {
+        hoverIdx = Math.max(0, (hoverIdx === -1 ? btns.length : hoverIdx) - 1);
+        highlightPresetBtn(btns, hoverIdx);
+      }
+      if (right && !navPrevState.right) {
+        hoverIdx = Math.min(btns.length - 1, (hoverIdx === -1 ? -1 : hoverIdx) + 1);
+        highlightPresetBtn(btns, hoverIdx);
+      }
+      if (a && !navPrevState.a && hoverIdx >= 0 && hoverIdx < btns.length) {
+        selectCameraPreset(btns[hoverIdx].dataset.preset);
+        clearPresetHover();
+      }
+    } else {
+      const select = row.querySelector('select');
+      const checkbox = row.querySelector('input[type="checkbox"]');
+      const slider = row.querySelector('input[type="range"]');
+      const button = row.querySelector('button');
+
+      if (left && !navPrevState.left) {
+        if (select) { select.selectedIndex = Math.max(0, select.selectedIndex - 1); select.dispatchEvent(new Event('change')); }
+        if (slider) { slider.value = Math.max(+slider.min, +slider.value - 5); slider.dispatchEvent(new Event('input')); }
+      }
+      if (right && !navPrevState.right) {
+        if (select) { select.selectedIndex = Math.min(select.options.length - 1, select.selectedIndex + 1); select.dispatchEvent(new Event('change')); }
+        if (slider) { slider.value = Math.min(+slider.max, +slider.value + 5); slider.dispatchEvent(new Event('input')); }
+      }
+      if (a && !navPrevState.a) {
+        if (checkbox) { checkbox.checked = !checkbox.checked; checkbox.dispatchEvent(new Event('change')); }
+        if (button) button.click();
+      }
     }
   }
 
@@ -538,7 +711,16 @@ function navigateSettings(gamepad) {
   navPrevState.a = a; navPrevState.b = b;
 }
 
+function highlightPresetBtn(btns, idx) {
+  btns.forEach((b, i) => b.classList.toggle('nav-hover', i === idx));
+}
+
+function clearPresetHover() {
+  document.querySelectorAll('.camera-presets button.nav-hover').forEach(b => b.classList.remove('nav-hover'));
+}
+
 function updateSettingsFocus() {
+  clearPresetHover();
   const rows = getSettingRows();
   rows.forEach((r, i) => {
     r.style.background = i === settingsFocusIndex ? 'rgba(51,136,255,0.15)' : '';
@@ -674,6 +856,9 @@ function startCalibration() {
   calibRetries = 0;
   gyroOrientation.identity();
   lastGyroTime = 0;
+  // Reset camera to selected preset on calibration
+  overlay.setCameraPreset(selectedCameraPreset);
+  showCalibHint('Calibrating...', null);
 }
 
 function finishCalibration() {
@@ -711,6 +896,9 @@ function finishCalibration() {
   calibSamples = [];
   gyroOrientation.identity();
   lastGyroTime = 0;
+  driftCheckAccum = 0;
+  driftCheckLastLean = 0;
+  showCalibHint(comboName(combos.calibrate) + ' to recalibrate', 3000);
   console.log('Gyro calibrated, bias:', gyroBias, 'stddev:', maxStd.toFixed(1));
 }
 
@@ -784,6 +972,8 @@ connectGyroBtn.addEventListener('click', async () => {
   }
 });
 
+document.getElementById('hud-position').addEventListener('change', () => applyHudPosition());
+
 driftModeSelect.addEventListener('change', (e) => {
   driftMode = e.target.value;
 });
@@ -801,9 +991,24 @@ const accentColorInput = document.getElementById('accent-color');
 bodyColorInput.addEventListener('input', (e) => overlay.setBodyColor(e.target.value));
 accentColorInput.addEventListener('input', (e) => overlay.setAccentColor(e.target.value));
 
-document.querySelectorAll('.camera-presets button').forEach((btn) => {
-  btn.addEventListener('click', () => overlay.setCameraPreset(btn.dataset.preset));
+// Camera presets — one selected at a time, used as calibration view
+let selectedCameraPreset = 'player';
+const cameraPresetBtns = document.querySelectorAll('.camera-presets button');
+
+function selectCameraPreset(preset) {
+  selectedCameraPreset = preset;
+  if (overlay) overlay.setCameraPreset(preset);
+  cameraPresetBtns.forEach(b => {
+    b.classList.toggle('selected', b.dataset.preset === preset);
+  });
+}
+
+cameraPresetBtns.forEach((btn) => {
+  btn.addEventListener('click', () => selectCameraPreset(btn.dataset.preset));
 });
+
+// Set default selection (overlay not ready yet, just highlights the button)
+selectCameraPreset('player');
 
 // ── Window display toggles (cosmetic only — never affects functionality) ──
 const showTitleCheck = document.getElementById('show-title');

--- a/index.html
+++ b/index.html
@@ -4234,7 +4234,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.8e8017e | 04-03-2026 23:03</span></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.1d2896f | 04-04-2026 00:22</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">


### PR DESCRIPTION
## Summary

Adds a gyro feedback HUD to the controller overlay for real-time lean visualization while playing Tandemonium.

- **Arc sweep indicator** — ±40° arc with needle, tick marks, color gradient (white → orange → red)
- **Lean direction arrows** — ◀/▶ at arc midpoint, opacity scales with lean
- **Calibration hints** — contextual text matching needle color, drift detection
- **HUD position setting** — above (default) or below controller
- **Camera presets** — two-row layout, toggle selection, calibration resets to selected preset
- **Gamepad navigation** — left/right highlights presets, A confirms

Closes #182

## Test plan
- [ ] Connect DualSense — arc appears, needle tracks lean
- [ ] Lean left/right — arrows light up, colors shift
- [ ] L3+R3 calibrate — hint shows, camera resets to preset
- [ ] Switch HUD position in settings
- [ ] Navigate camera presets with gamepad
- [ ] Swap to Switch Pro — same behavior
- [ ] Toggle gyro off — HUD hides

🤖 Generated with [Claude Code](https://claude.com/claude-code)