### PR TITLE
Use CDN Three.js for web deployment

### DIFF
--- a/controller-overlay/src/index.html
+++ b/controller-overlay/src/index.html
@@ -549,13 +549,18 @@
 <!-- WebGL canvas -->
 <canvas id="canvas"></canvas>
 
-<script type="importmap">
-{
-  "imports": {
-    "three": "./lib/three.module.js",
-    "three/addons/": "./lib/addons/"
-  }
-}
+<script>
+// Dynamic importmap: use local vendor files in Electron, CDN on the web
+(function() {
+  const isElectron = navigator.userAgent.includes('Electron');
+  const map = isElectron
+    ? { "three": "./lib/three.module.js", "three/addons/": "./lib/addons/" }
+    : { "three": "https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.module.js", "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/" };
+  const el = document.createElement('script');
+  el.type = 'importmap';
+  el.textContent = JSON.stringify({ imports: map });
+  document.currentScript.after(el);
+})();
 </script>
 <script type="module" src="js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Dynamic importmap uses jsdelivr CDN for Three.js 0.161.0 on the web, local vendor files in Electron
- Fixes 404 errors on the deployed site (controller-overlay-web) where `src/lib/` was gitignored and never deployed

## Test plan
- [ ] Verify controller-overlay-web loads without 404s on the live site
- [ ] Verify Electron app still works with local vendor files

https://claude.ai/code/session_01WQJPexKE2UMWW6r4SaFXkF