### PR TITLE
Add ICP persona + local multiplayer spike plan

### DIFF
--- a/docs/ideal-customer-persona.md
+++ b/docs/ideal-customer-persona.md
@@ -1,0 +1,175 @@
+# Tandemonium — Ideal Customer Persona (ICP)
+
+A single, standardized persona document for the player we are building Tandemonium for. Uses a common B2C game-marketing persona template so it can be plugged into store-page copy, ad creative, playtest recruiting, and feature-prioritization decisions.
+
+---
+
+## 1. Persona Snapshot
+
+| Field | Value |
+|---|---|
+| **Persona name** | "Co-op Casey" |
+| **Archetype** | The Couch Co-op Enthusiast |
+| **Tagline** | *"If there's a second controller, I'm plugging it in."* |
+| **Photo / vibe** | Late-20s to mid-30s, headset around neck, one Switch Pro controller in hand, a DualSense on the coffee table, partner/roommate/kid on the couch next to them. |
+
+---
+
+## 2. Demographics
+
+| Field | Value |
+|---|---|
+| **Age range** | 24–40 (core), with a secondary 10–15 family segment reached via the primary buyer |
+| **Gender** | All; skews slightly toward mixed-gender couples and parent-child pairs |
+| **Location** | North America, UK, Western Europe, ANZ (English-first launch markets) |
+| **Household** | Lives with a partner, roommate, sibling, or young child they regularly play games with |
+| **Occupation** | Knowledge worker, student, teacher, creative, or stay-at-home parent |
+| **Household income** | $45k–$120k USD — comfortable with $10–$20 indie purchases and occasional DLC |
+| **Education** | College-educated or equivalent; tech-literate but not necessarily a "gamer identity" |
+| **Devices owned** | Gaming laptop or mid-range PC, Steam Deck, at least one modern gamepad (DualSense / Switch Pro / Xbox), a smartphone with a gyroscope, and a TV they can cast or HDMI to |
+
+---
+
+## 3. Psychographics
+
+- **Motivations**
+  - Shared laughter and "we did it together" moments over solo mastery.
+  - Lightweight, *pick-up-and-play* sessions that fit a 15–30 minute window.
+  - Novelty mechanics they can show off to friends ("wait, you both pedal?").
+  - Nostalgia for goofy physics games (QWOP, Human Fall Flat, Overcooked, Trackmania).
+- **Values**
+  - Inclusivity — games that a non-gamer partner can actually play without a tutorial wall.
+  - Fair, one-time purchases; skeptical of grindy monetization and battle passes.
+  - Creators and indie devs who ship polish over hype.
+- **Personality traits**
+  - Social, patient, forgiving of their own mistakes, and willing to teach.
+  - Prefers "funny failure" loops to punishing, skill-gated ones.
+- **Gaming identity**
+  - Calls themselves a "casual" or "cozy" gamer even if they play 5+ hours a week.
+  - 50–150 Steam games in library; 10–20 of them are co-op.
+
+---
+
+## 4. Goals & Jobs-to-be-Done
+
+When Casey "hires" Tandemonium, they hire it to:
+
+1. **Create a shared 20-minute laugh** with their partner or kid after dinner.
+2. **Break the ice** with a houseguest or long-distance friend (online co-op).
+3. **Feel coordinated together** — a light skill-expression loop that rewards rhythm, not reflexes.
+4. **Have something new to stream / TikTok** that looks funny in a 15-second clip.
+5. **Play on whatever's nearby** — phone in bed, Steam Deck on the couch, TV with two pads.
+
+---
+
+## 5. Pain Points & Frustrations
+
+- Most co-op games require **two copies, two accounts, or matchmaking lobbies**.
+- Partner/kid **bounces off tutorials** that assume gamer literacy.
+- Mobile co-op games are **pay-to-win or ad-riddled**.
+- Voice chat setup is a **nightmare** — they want to just send a link.
+- Physics/party games often feel **unfair or random** rather than *coordinated*.
+- Friends are in **different cities** — local co-op isn't an option anymore.
+- "Couch co-op" games that secretly require **one dominant player** carrying the other.
+
+---
+
+## 6. How Tandemonium Solves Their Problem
+
+| Pain | Tandemonium's answer |
+|---|---|
+| Two copies required | **One browser link** — stoker joins free via room code, no install, no account |
+| Tutorial wall | **Tutorial level** with coaching arrows, DDA, and no timer; anyone can finish their first ride |
+| Cross-device friction | Plays in **browser, Steam, Electron desktop, TV mode, and mobile with gyro** — captain on PC, stoker on phone works out of the box |
+| Unfair party chaos | **Offset-pedaling mechanic** turns coordination into the actual game — success feels earned, failure is funny, not random |
+| Friends in other cities | **PeerJS + Cloudflare relay fallback** — low-latency P2P that "just works" behind NAT |
+| Grindy monetization | **One-time purchase**, promo codes, optional cosmetic bikes; demo + Steam playtest available |
+| Carry dynamic | Captain and Stoker roles **depend on each other** — neither can win alone |
+
+---
+
+## 7. Buying Triggers
+
+- Sees a **15-second clip** of two players wobbling through Grandma's level on TikTok / Reels / YouTube Shorts.
+- A **Steam curator or indie newsletter** they trust ("Cozy Co-op Weekly") features it.
+- Partner says *"that looks fun, can we play it?"* — this is the highest-converting trigger.
+- **Steam Next Fest / Playtest demo** — they try the free demo, laugh once, wishlist.
+- A friend **sends them a room code link** and they're in the game before deciding to buy. (The stoker-CTA overlay exists for exactly this moment.)
+- **Holiday content** — Christmas-themed tracks ("Krampus Workshop", "Gold Rush") trigger seasonal gifting intent.
+
+---
+
+## 8. Buying Objections
+
+- *"Will my partner actually be able to play this?"* → Tutorial + safety mode + gyro tilt.
+- *"Is this just a phone game?"* → Steam page + TV/desktop mode + controller support.
+- *"Can I play with my friend in another city?"* → P2P multiplayer with relay fallback.
+- *"Is $X worth 2 hours of content?"* → Replay via leaderboards, achievements, bike unlocks, and multiple levels (Grandma's, The Castle, …).
+- *"Do I need to sign up for another account?"* → Optional Google/Steam sign-in; stoker needs nothing.
+
+---
+
+## 9. Channels — Where Casey Actually Is
+
+- **Steam** (wishlist, Next Fest, curators, Deck Verified badge)
+- **TikTok / Instagram Reels / YouTube Shorts** — short funny-fail clips
+- **YouTube** — couples/co-op channels, "games to play with your partner" lists
+- **Reddit** — r/CoopGaming, r/ShouldIBuyThisGame, r/IndieGaming, r/SteamDeck
+- **Discord** — indie game showcase servers, cozy-gaming communities
+- **Podcasts / newsletters** — Cohost-adjacent indie newsletters, Into the Aether-style pods
+- **Word of mouth** — the "send a room code" link is itself a channel
+
+---
+
+## 10. Messaging That Resonates
+
+Short, testable value props ordered by priority:
+
+1. **"A tandem bike. Two players. One crank. Good luck."**
+2. **"Send a link. Ride together."** — zero-friction co-op hook
+3. **"Pedal in sync. Or don't. It's funnier when you don't."**
+4. **"Works on your phone, your laptop, and your TV — even across the country."**
+5. **"Solo-friendly. Couch-friendly. Long-distance-friendly."**
+
+Avoid: hardcore-gamer framing, competitive/esports framing, "skill-based" framing.
+
+---
+
+## 11. Anti-Persona (who this is *not* for)
+
+- **Hardcore sim-racing fans** looking for realistic bike physics and setup depth.
+- **Competitive PvP players** who want ranked ladders and anti-cheat.
+- **Lone-wolf completionists** who never touch multiplayer — they can enjoy solo mode, but they are not the ICP.
+- **Free-to-play mobile whales** expecting gacha/loot systems.
+- **Kids under ~8** without a parent co-playing (reading / coordination curve).
+
+---
+
+## 12. A Day in Casey's Life (Scenario)
+
+> It's Tuesday, 9:40pm. Casey and their partner just finished dinner and an episode of a show. Partner says *"one more thing before bed?"* Casey opens the laptop, goes to Tandemonium on Steam, picks **Ride Together → Captain**, and reads a room code out loud. Partner opens the link on their phone, taps **Stoker**, and lands in the lobby 8 seconds later. They pick **Grandma's**, wobble off the start line, crash into a tree, laugh, restart, and finish the run 3 minutes later with a new personal best. Total session: 12 minutes. Casey wishlists the next level pack on the victory screen. They'll be back tomorrow.
+
+---
+
+## 13. Success Metrics for "Reaching Casey"
+
+| Signal | Target |
+|---|---|
+| **Stoker → Captain conversion** (stoker plays free, later buys to host) | ≥ 20% within 30 days |
+| **Second-session retention** (D1 return after first co-op session) | ≥ 45% |
+| **Wishlist → purchase** around Next Fest / seasonal sale | ≥ 12% |
+| **Clip shareability** (share sheet / record button uses per session) | ≥ 0.3 |
+| **Cross-device sessions** (captain desktop + stoker mobile) | ≥ 35% of MP sessions |
+
+---
+
+## 14. Template Source
+
+This document uses a standardized B2C persona template combining:
+
+- **Demographics + Psychographics** (traditional marketing persona)
+- **Jobs-to-be-Done** (Christensen)
+- **Pain / Gain / Message** (Value Proposition Canvas)
+- **Anti-persona** (product discovery best practice)
+
+Update this file when a playtest, survey, or analytics cohort materially changes who is actually buying and recommending Tandemonium.

--- a/docs/ideal-customer-persona.md
+++ b/docs/ideal-customer-persona.md
@@ -9,9 +9,11 @@ A single, standardized persona document for the player we are building Tandemoni
 | Field | Value |
 |---|---|
 | **Persona name** | "Co-op Casey" |
-| **Archetype** | The Couch Co-op Enthusiast |
-| **Tagline** | *"If there's a second controller, I'm plugging it in."* |
-| **Photo / vibe** | Late-20s to mid-30s, headset around neck, one Switch Pro controller in hand, a DualSense on the coffee table, partner/roommate/kid on the couch next to them. |
+| **Archetype** | The Remote Co-op Duo |
+| **Tagline** | *"Send me the link — I'll join from my phone."* |
+| **Photo / vibe** | Late-20s to mid-30s, laptop open on the kitchen table, phone propped against a coffee mug, on a voice call with their partner/sibling/best friend who is on their *own* device in another room — or another city. Two screens, two players, one bike. |
+
+> **Important:** Tandemonium is **online multiplayer, one-screen-per-player** (PeerJS P2P with Cloudflare relay fallback). There is no local split-screen or shared-controller mode, and the persona is deliberately built around that strength — not around couch co-op.
 
 ---
 
@@ -22,21 +24,22 @@ A single, standardized persona document for the player we are building Tandemoni
 | **Age range** | 24–40 (core), with a secondary 10–15 family segment reached via the primary buyer |
 | **Gender** | All; skews slightly toward mixed-gender couples and parent-child pairs |
 | **Location** | North America, UK, Western Europe, ANZ (English-first launch markets) |
-| **Household** | Lives with a partner, roommate, sibling, or young child they regularly play games with |
+| **Household** | Has a **regular play partner they see mostly online** — a long-distance partner, a sibling in another state, a college friend group, a parent/kid who plays from separate rooms, or a spouse who is happy to play from their own phone on the couch |
 | **Occupation** | Knowledge worker, student, teacher, creative, or stay-at-home parent |
 | **Household income** | $45k–$120k USD — comfortable with $10–$20 indie purchases and occasional DLC |
 | **Education** | College-educated or equivalent; tech-literate but not necessarily a "gamer identity" |
-| **Devices owned** | Gaming laptop or mid-range PC, Steam Deck, at least one modern gamepad (DualSense / Switch Pro / Xbox), a smartphone with a gyroscope, and a TV they can cast or HDMI to |
+| **Devices owned** | A gaming laptop or mid-range PC **plus** a smartphone with a gyroscope. Casey's play partner owns *at least* a smartphone — that's the minimum bar to join, and the whole point. Steam Deck, a TV, and modern gamepads (DualSense / Switch Pro / Xbox) are nice-to-haves, not requirements |
 
 ---
 
 ## 3. Psychographics
 
 - **Motivations**
-  - Shared laughter and "we did it together" moments over solo mastery.
+  - Shared laughter and "we did it together" moments over solo mastery — **especially with someone they can't be in the same room with**.
   - Lightweight, *pick-up-and-play* sessions that fit a 15–30 minute window.
-  - Novelty mechanics they can show off to friends ("wait, you both pedal?").
-  - Nostalgia for goofy physics games (QWOP, Human Fall Flat, Overcooked, Trackmania).
+  - Keeping a **ritual** with a long-distance partner, sibling, or friend group (think: weekly "game night over Discord").
+  - Novelty mechanics they can show off to friends ("wait, you both pedal from different houses?").
+  - Nostalgia for goofy physics games (QWOP, Human Fall Flat, Overcooked, Trackmania) — but without the "everyone has to own the same game" tax.
 - **Values**
   - Inclusivity — games that a non-gamer partner can actually play without a tutorial wall.
   - Fair, one-time purchases; skeptical of grindy monetization and battle passes.
@@ -54,23 +57,24 @@ A single, standardized persona document for the player we are building Tandemoni
 
 When Casey "hires" Tandemonium, they hire it to:
 
-1. **Create a shared 20-minute laugh** with their partner or kid after dinner.
-2. **Break the ice** with a houseguest or long-distance friend (online co-op).
-3. **Feel coordinated together** — a light skill-expression loop that rewards rhythm, not reflexes.
-4. **Have something new to stream / TikTok** that looks funny in a 15-second clip.
-5. **Play on whatever's nearby** — phone in bed, Steam Deck on the couch, TV with two pads.
+1. **Keep a ritual alive with someone they can't be in the room with** — long-distance partner, sibling, old college friend — in under 30 seconds of setup.
+2. **Create a shared 20-minute laugh** with their partner, kid, or roommate, each on their own device, already on a voice call or sitting nearby.
+3. **Feel coordinated with another human** — a light skill-expression loop that rewards rhythm, not reflexes, and *requires* two real people (no bots, no carry).
+4. **Have something new to stream / TikTok** that looks funny in a 15-second clip — ideally showing both players' faces via the built-in video/PiP.
+5. **Play on whatever device each person has** — captain on a laptop, stoker on a phone with gyro; no second purchase, no install on the stoker's side.
 
 ---
 
 ## 5. Pain Points & Frustrations
 
-- Most co-op games require **two copies, two accounts, or matchmaking lobbies**.
+- **Friends and family live in different cities** — local / couch co-op is literally not an option anymore.
+- Most online co-op games require **two copies, two accounts, and a matchmaking lobby**.
+- Their play partner **doesn't own a PC or a console** — only a phone.
 - Partner/kid **bounces off tutorials** that assume gamer literacy.
 - Mobile co-op games are **pay-to-win or ad-riddled**.
 - Voice chat setup is a **nightmare** — they want to just send a link.
 - Physics/party games often feel **unfair or random** rather than *coordinated*.
-- Friends are in **different cities** — local co-op isn't an option anymore.
-- "Couch co-op" games that secretly require **one dominant player** carrying the other.
+- Online co-op games that secretly require **one dominant player** carrying the other.
 
 ---
 
@@ -78,11 +82,12 @@ When Casey "hires" Tandemonium, they hire it to:
 
 | Pain | Tandemonium's answer |
 |---|---|
-| Two copies required | **One browser link** — stoker joins free via room code, no install, no account |
+| Friends in other cities | **PeerJS WebRTC P2P** with a **Cloudflare Worker relay fallback** — low-latency online play that "just works" behind NAT/firewalls |
+| Two copies required | **One browser link** — the stoker joins free via room code, no install, no account, no second Steam purchase |
+| Partner has no PC/console | **Captain on laptop, stoker on phone** with gyro tilt works out of the box — Tandemonium runs in the browser on both sides |
 | Tutorial wall | **Tutorial level** with coaching arrows, DDA, and no timer; anyone can finish their first ride |
-| Cross-device friction | Plays in **browser, Steam, Electron desktop, TV mode, and mobile with gyro** — captain on PC, stoker on phone works out of the box |
+| Cross-device friction | Plays in **browser, Steam, Electron desktop, TV mode, and mobile with gyro** — any captain device pairs with any stoker device |
 | Unfair party chaos | **Offset-pedaling mechanic** turns coordination into the actual game — success feels earned, failure is funny, not random |
-| Friends in other cities | **PeerJS + Cloudflare relay fallback** — low-latency P2P that "just works" behind NAT |
 | Grindy monetization | **One-time purchase**, promo codes, optional cosmetic bikes; demo + Steam playtest available |
 | Carry dynamic | Captain and Stoker roles **depend on each other** — neither can win alone |
 
@@ -90,12 +95,12 @@ When Casey "hires" Tandemonium, they hire it to:
 
 ## 7. Buying Triggers
 
-- Sees a **15-second clip** of two players wobbling through Grandma's level on TikTok / Reels / YouTube Shorts.
-- A **Steam curator or indie newsletter** they trust ("Cozy Co-op Weekly") features it.
-- Partner says *"that looks fun, can we play it?"* — this is the highest-converting trigger.
+- Sees a **15-second clip** of two players wobbling through Grandma's level on TikTok / Reels / YouTube Shorts — ideally with both webcams visible.
+- A **Steam curator or indie newsletter** they trust ("Cozy Co-op Weekly", "Long-Distance Co-op") features it.
+- Long-distance partner says *"I want to play something tonight — do you have a link?"* — highest-converting trigger.
 - **Steam Next Fest / Playtest demo** — they try the free demo, laugh once, wishlist.
-- A friend **sends them a room code link** and they're in the game before deciding to buy. (The stoker-CTA overlay exists for exactly this moment.)
-- **Holiday content** — Christmas-themed tracks ("Krampus Workshop", "Gold Rush") trigger seasonal gifting intent.
+- A friend **sends them a room code link** and they're in the game as a stoker *before* deciding to buy. They convert to captain later. (The stoker-CTA overlay exists for exactly this moment.)
+- **Holiday content** — Christmas-themed tracks ("Krampus Workshop", "Gold Rush") trigger seasonal gifting intent, especially for far-away family.
 
 ---
 
@@ -125,13 +130,13 @@ When Casey "hires" Tandemonium, they hire it to:
 
 Short, testable value props ordered by priority:
 
-1. **"A tandem bike. Two players. One crank. Good luck."**
-2. **"Send a link. Ride together."** — zero-friction co-op hook
-3. **"Pedal in sync. Or don't. It's funnier when you don't."**
-4. **"Works on your phone, your laptop, and your TV — even across the country."**
-5. **"Solo-friendly. Couch-friendly. Long-distance-friendly."**
+1. **"Send a link. Ride together."** — the zero-friction online-co-op hook
+2. **"A tandem bike. Two players. One crank. Good luck."**
+3. **"They don't need Steam. They don't need a PC. They need a phone and a room code."**
+4. **"Pedal in sync. Or don't. It's funnier when you don't."**
+5. **"Laptop here. Phone there. Same bike."**
 
-Avoid: hardcore-gamer framing, competitive/esports framing, "skill-based" framing.
+Avoid: "couch co-op" / "2nd controller" / "grab a friend on the couch" framing — the game does not support local multiplayer. Also avoid hardcore-gamer, competitive/esports, or "skill-based" framing.
 
 ---
 
@@ -142,12 +147,13 @@ Avoid: hardcore-gamer framing, competitive/esports framing, "skill-based" framin
 - **Lone-wolf completionists** who never touch multiplayer — they can enjoy solo mode, but they are not the ICP.
 - **Free-to-play mobile whales** expecting gacha/loot systems.
 - **Kids under ~8** without a parent co-playing (reading / coordination curve).
+- **Couch-co-op-only buyers** who want two controllers on one screen — Tandemonium is online-only, one-screen-per-player. If they don't have a remote play partner and aren't willing to hand a phone to the person next to them, this is not for them.
 
 ---
 
 ## 12. A Day in Casey's Life (Scenario)
 
-> It's Tuesday, 9:40pm. Casey and their partner just finished dinner and an episode of a show. Partner says *"one more thing before bed?"* Casey opens the laptop, goes to Tandemonium on Steam, picks **Ride Together → Captain**, and reads a room code out loud. Partner opens the link on their phone, taps **Stoker**, and lands in the lobby 8 seconds later. They pick **Grandma's**, wobble off the start line, crash into a tree, laugh, restart, and finish the run 3 minutes later with a new personal best. Total session: 12 minutes. Casey wishlists the next level pack on the victory screen. They'll be back tomorrow.
+> It's Tuesday, 9:40pm. Casey is on FaceTime with their partner who lives two time zones away. Partner says *"one more thing before bed?"* Casey opens the laptop, launches Tandemonium, picks **Ride Together → Captain**, and reads a room code into the call. Partner taps the shared link on their phone, selects **Stoker**, and lands in the lobby 8 seconds later — no install, no sign-in, nothing to buy on their side. They pick **Grandma's**, wobble off the start line, crash into a tree, laugh (the video PiP shows both their faces), restart, and finish the run 3 minutes later with a new personal best. Total session: 12 minutes. Casey wishlists the next level pack on the victory screen. Partner is already asking "same time tomorrow?"
 
 ---
 
@@ -159,7 +165,8 @@ Avoid: hardcore-gamer framing, competitive/esports framing, "skill-based" framin
 | **Second-session retention** (D1 return after first co-op session) | ≥ 45% |
 | **Wishlist → purchase** around Next Fest / seasonal sale | ≥ 12% |
 | **Clip shareability** (share sheet / record button uses per session) | ≥ 0.3 |
-| **Cross-device sessions** (captain desktop + stoker mobile) | ≥ 35% of MP sessions |
+| **Cross-device sessions** (captain desktop + stoker mobile) | ≥ 35% of MP sessions — this is the defining shape of the ICP |
+| **Repeat-pair sessions** (same two peer IDs / accounts playing together ≥ 2x) | ≥ 40% of MP pairs — proves the "ritual with a specific person" JTBD |
 
 ---
 

--- a/docs/local-multiplayer-spike.md
+++ b/docs/local-multiplayer-spike.md
@@ -1,0 +1,207 @@
+# Local Multiplayer Spike — Feasibility & Implementation Plan
+
+**Question:** Can we add same-screen, two-controller local co-op to Tandemonium without rewriting the game, and if so, what does it take?
+
+**Short answer:** Yes. The core physics, offset-pedaling logic, and two-input data model already exist and work — the network layer is the *only* thing that synthesizes the "stoker" input, and it can be bypassed. The realistic scope is **~400–700 lines across 5–6 files**, bounded by (a) splitting `InputManager` to accept a gamepad slot and (b) adding a new `_updateLocal(dt)` game-loop path plus a lobby entry point.
+
+This document captures the code-level findings from the spike and turns them into a concrete, staged plan.
+
+---
+
+## 1. What the spike found
+
+### 1.1 The offset-pedaling engine is already dual-source
+
+`js/shared-pedal-controller.js` takes `receiveTap(source, foot)` where `source` is `'captain' | 'stoker'`. It tracks per-player last-foot / last-time, computes offset quality, detects crank-fight, and maintains per-player stats — **entirely from the `source` label, with no assumption about where the tap came from.** Local MP just calls `receiveTap` twice, once per local player.
+
+> `js/shared-pedal-controller.js:33` — `receiveTap(source, foot)` is the single integration point. It does not know about networks.
+
+### 1.2 The captain already does exactly what local MP needs to do
+
+In `_updateCaptain(dt)` (`js/game.js:2982–2999`) the captain:
+
+1. Edge-detects its own pedal keys (`ArrowLeft`/`ArrowRight` = "up"/"down").
+2. Calls `this.sharedPedal.receiveTap('captain', foot)`.
+3. *Also* calls `this.net.sendPedal(foot)` to forward to the stoker.
+
+The stoker's taps arrive via `this.net.onPedalReceived = (source, foot) => this.sharedPedal.receiveTap(source, foot)` at `js/game.js:617–625`.
+
+**Local MP is literally: replace step 3 with a second edge-detect block driven by a second input source, targeting `'stoker'`.** No new physics, no new state machine, no network.
+
+### 1.3 Lean merging is already a simple average
+
+At `js/game.js:3009–3012`:
+```js
+balanceResult.leanInput = Math.max(-1, Math.min(1,
+  (balanceResult.leanInput + this.remoteLean) * 0.5
+));
+```
+For local MP, `this.remoteLean` becomes "P2's current lean from P2's InputManager/BalanceController" instead of "whatever arrived last from `net.onLeanReceived`."
+
+### 1.4 The game has a single `mode` string — easy to extend
+
+`this.mode = 'solo' | 'captain' | 'stoker'` is set in three places (`game.js:152, 581, 600, 2226`) and branched on throughout the file. Adding `'local'` as a fourth value and routing it through a new `_updateLocal(dt)` sibling of `_updateCaptain(dt)` is a surgical change. Most existing branches stay as-is; only the ones that assume `this.net` exists need a `|| mode === 'local'` guard (or equivalent).
+
+### 1.5 `InputManager` is the one real refactor
+
+**This is the biggest change in the spike.** Today `js/input-manager.js` is hard-wired to a *single* gamepad:
+
+- `this.gamepadIndex = null` (line 46) — a single slot.
+- `gamepadconnected` event handler claims the first gamepad it sees (line 422).
+- `pollGamepad()` walks `navigator.getGamepads()` and binds to the first non-null entry (line 460).
+
+To support two local players we need two independent input streams. The cleanest answer is **two `InputManager` instances**, each configured with a gamepad slot filter:
+
+```js
+this.inputP1 = new InputManager({ gamepadSlot: 0, keyboard: 'primary' });
+this.inputP2 = new InputManager({ gamepadSlot: 1, keyboard: 'none' });
+```
+
+This works because:
+
+- `BalanceController` and `PedalController` both take an `input` handle in their constructor (`game.js:135–136`) — they don't reach into globals.
+- All per-device state (`_smoothedLean`, `_driftEma`, gyro bias, WebHID driver) is already self-contained on the instance.
+- Motion / touch / iOS permission paths only need to run on P1. P2 on a desktop plays with a gamepad; the P2 `InputManager` can skip `_setupMotion` and `_setupTouch` entirely via the constructor options.
+- Existing solo / captain / stoker code paths keep using `this.input` (which becomes an alias for `inputP1`) — **no behavior change for existing modes**.
+
+### 1.6 What does NOT need to change
+
+- **Bike physics, chase camera, world, render loop** — same one-bike, one-camera setup. Tandemonium is a tandem bike: *there is literally one bike in the scene*. No split-screen.
+- **HUD partner gauge** (`js/hud.js:177, 313–331`) — it already reads a `remoteData` object with `remoteLean` / `remoteLastFoot` / `remoteLastTapTime`. In local MP we build that object from P2's inputs instead of from network callbacks. **Zero HUD code changes.**
+- **`SharedPedalController`** — works as-is.
+- **`RaceManager`, `CollectibleManager`, `ObstacleManager`** — unchanged; authoritative path is the same as captain.
+- **`ContributionTracker`** — already supports `'solo' | 'captain' | 'stoker'`. We instantiate it with `'captain'` in local mode (since the local game loop is the captain-equivalent) or add a new `'local'` value that mirrors the captain path. Trivial.
+- **Network stack** — untouched. Online MP keeps working. Local MP does not import `NetworkManager`.
+- **Recorder / video PiP** — no partner stream in local MP; we disable the partner-video composite for `mode === 'local'` and keep the single-player recording path.
+
+---
+
+## 2. File-by-file change list
+
+| File | Change | Est. LoC | Risk |
+|---|---|---|---|
+| `js/input-manager.js` | Accept `{ gamepadSlot, enableMotion, enableTouch, keyboard }` options; filter `_setupGamepad` / `pollGamepad` by slot; skip motion/touch for P2 on desktop; namespace keyboard bindings per instance | ~100 | **Medium** — the event-driven gamepadconnected flow needs careful slot assignment (first connected → P1 slot if empty, else P2) |
+| `js/game.js` | Add `this.inputP1` / `this.inputP2`; alias `this.input = inputP1`; add `'local'` mode; new `_updateLocal(dt)` method (fork of `_updateCaptain` minus network sends, plus P2 edge-detect); route `_loop` → `_updateLocal` when `mode === 'local'`; add `_onLocalMultiplayerReady()` lobby callback; local reset flow | ~250 | Medium — `_updateCaptain` is ~115 lines and the fork needs to stay in sync with future captain-side changes |
+| `js/balance-controller.js` | No change (already takes an input handle); instantiate a second one for P2 in `game.js` | 0 | None |
+| `js/pedal-controller.js` | No change (solo controller is unused in local MP; local MP uses `SharedPedalController` directly like captain does) | 0 | None |
+| `js/shared-pedal-controller.js` | No change | 0 | None |
+| `js/lobby.js` | New mode card "Local Co-op (Same Screen)"; new controller-assignment screen ("P1 press A / P2 press A"); route through existing level-select; emit `onLocalMultiplayerReady({ inputP1, inputP2, level })` | ~180 | Medium — lobby is a complex UI with gamepad nav; the new screen must integrate with `_stepItems` / `_moveFocus` |
+| `js/hud.js` | No change (already reads `remoteData`) | 0 | None |
+| `js/contribution-tracker.js` | Accept `'local'` and route like `'captain'` (or pass `'captain'` literal for local mode) | ~5 | None |
+| `index.html` | New lobby screen DOM for controller-assignment + new mode card | ~30 | None |
+| `js/game-recorder.js` | Guard partner-video composite behind `mode !== 'local'` | ~5 | None |
+| **Total** | | **~570 LoC** | |
+
+---
+
+## 3. Implementation plan — 4 stages
+
+Each stage is independently testable and mergeable. **Ship Stage 1 behind a `?localmp=1` URL flag first.**
+
+### Stage 1 — Prove the data path works (1–1.5 days)
+
+**Goal:** Two gamepads, one bike, offset pedaling works locally. No lobby UI. Triggered by `?localmp=1`.
+
+1. **Refactor `InputManager` to accept a slot.**
+   - Constructor takes `{ gamepadSlot = 'any', enableMotion = true, enableTouch = true }`.
+   - In `_setupGamepad`, only claim the first connected gamepad whose index matches the slot (or `'any'` for backward compat).
+   - In `pollGamepad`, only bind to `gamepads[i]` when `i === gamepadSlot` OR slot is `'any'`.
+   - For P2 instance pass `enableMotion: false, enableTouch: false`.
+2. **Add keyboard namespacing** (minimal for Stage 1).
+   - P1 InputManager reads `ArrowLeft/ArrowRight` (pedal) + `KeyA/KeyD` (lean) — unchanged.
+   - P2 InputManager ignores keyboard entirely (two-gamepad-only for the spike).
+   - Leave the fancier WASD-vs-IJKL split for Stage 4.
+3. **Add `_updateLocal(dt)` in `game.js`:**
+   - Fork of `_updateCaptain` minus every `this.net.*` line.
+   - P1 edge-detects pedals → `sharedPedal.receiveTap('captain', foot)`.
+   - P2 edge-detects pedals → `sharedPedal.receiveTap('stoker', foot)`.
+   - `balanceResult.leanInput = average(p1Lean, p2Lean)` (identical to captain path).
+   - Reuse `raceManager`, `collectibleManager`, `obstacleManager`, grass, camera, HUD.
+4. **Wire the URL flag** — if `?localmp=1`, skip the lobby, instantiate two `InputManager`s, set `mode = 'local'`, and drop into the default level.
+
+**Stage 1 exit criteria:**
+- Two DualSense / Switch Pro / Xbox controllers connected.
+- Both players can pedal; offset pedaling rewards coordination exactly like online MP.
+- Both players' lean averages correctly.
+- HUD partner gauge shows P2's lean (via `remoteData` populated from P2's InputManager).
+- No network, no room code, no errors in console.
+
+### Stage 2 — Lobby flow (1 day)
+
+**Goal:** First-class "Local Co-op" entry in the existing lobby.
+
+1. **New mode card** on `#lobby-mode`: "Same Screen Co-op" (next to SOLO and RIDE TOGETHER).
+2. **New lobby step `#lobby-local-pair`:**
+   - Prompts "Player 1: press A / Player 2: press A."
+   - Detects each gamepad index claim independently.
+   - Proceeds to `#lobby-level` when both claimed.
+   - Back button returns to mode select.
+3. **Level + difficulty flow reuses the existing `#lobby-level` cards** — no new UI.
+4. **Lobby emits `onLocalMultiplayerReady({ inputP1, inputP2 })`** which calls a new `Game._onLocalMultiplayerReady` — the same shape as `_onMultiplayerReady(net, mode)` but without a network.
+5. **Gamepad navigation integration** — add the new step to `_stepItems` / `_stepBack` so directional nav works.
+
+**Stage 2 exit criteria:** Player can start a Local Co-op ride entirely through the GUI with two gamepads and no URL flags.
+
+### Stage 3 — Polish + edge cases (0.5–1 day)
+
+1. **Controller hot-swap** — if P2 disconnects mid-ride, pause and show "Waiting for Player 2."
+2. **Single-gamepad fallback** — if only one gamepad is detected at lobby time, offer "Player 2 use keyboard (WASD + Q/E)" as an opt-in.
+3. **Options overlay + pause** — both players' Start buttons can open/close the options menu.
+4. **Achievements** — ensure achievements that require "multiplayer" don't mis-fire or mis-block on local (decide per-achievement: do we credit local co-op as "multiplayer" for achievement purposes? Probably yes.)
+5. **Analytics** — add a `mode: 'local'` dimension to `analytics.startRide()` so we can measure adoption.
+6. **Recorder** — disable partner-video composite; keep pedal-flash indicators for both players.
+
+### Stage 4 — Nice-to-haves (optional, post-launch)
+
+- **Gyro steering for both players simultaneously** — requires two WebHID device claims, one per player. The existing `InputManager.connectControllerGyro()` path should be re-entrant per instance; verify on real hardware.
+- **Split-keyboard mode** — P1 uses arrows + A/D, P2 uses IJKL + Q/E, so a couch session needs zero gamepads.
+- **Player-specific bike color / nameplate** in HUD.
+- **"Captain swap" button** to flip who's tracked as captain vs stoker in `sharedPedal` (affects offset-bonus attribution only, not gameplay).
+
+---
+
+## 4. Risks & open questions
+
+### 4.1 Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `_updateCaptain` drifts from `_updateLocal` as we polish online MP | Medium | Extract the shared body into `_updateTandemCore(dt, { isLocal })` and have both paths delegate to it. Worth doing in Stage 1 itself to avoid double-maintenance. |
+| Second gamepad isn't reliably detected (browser gamepad API has quirks) | Medium | Stage 1 uses polling fallback; Stage 2 shows a clear "Press any button on Player 2's controller" instruction screen with live detection feedback. |
+| Input permission prompts (WebHID) are per-device and per-user-gesture — two devices in rapid succession may confuse the user | Low-Medium | Do not require WebHID for Stage 1–3; standard gamepad API (the one `pollGamepad` uses) needs no permission. Gyro steering (WebHID) is Stage 4. |
+| "Captain" vs "stoker" labeling in `SharedPedalController` looks arbitrary locally | Low | Ship as-is; offset-pedaling stats still work because each player consistently taps from the same labeled source. |
+| Achievements / leaderboards that assume online co-op misreport for local | Low | Audit `js/achievements.js` in Stage 3; explicitly scope which achievements count local as multiplayer. |
+| Electron / Steam TV-mode build has a different input path | Low | The Electron build uses the same `InputManager`; the only delta is that `window.steam` is true. Local MP should work identically in Electron — verify on Deck hardware as part of Stage 3. |
+
+### 4.2 Open questions I want your call on
+
+1. **Captain/stoker asymmetry locally?** Online, captain runs physics and their lean is arguably "more authoritative." Locally, should both players be fully equal (lean averaged 50/50), or should one player be explicitly "the driver"? *My recommendation: equal, identical to the current captain-path averaging. Simplest and preserves the feel.*
+2. **Achievements gating:** does a local-co-op finish count toward a multiplayer achievement (e.g., "Finish a ride with a partner")? *My recommendation: yes, local counts as multiplayer for achievement purposes.*
+3. **Leaderboards:** should local-co-op runs submit to the leaderboard? *My recommendation: yes, tagged with `mode: 'local'` so you can filter later if it skews the boards.*
+4. **Keyboard-only local MP:** is it a Stage 3 must-have, or a Stage 4 nice-to-have? *My recommendation: Stage 4 — two gamepads is the marketing-critical path for Steam / couch / festival demos; keyboard-only local is a niche fallback.*
+5. **Demo tier:** does Local Co-op work in the free demo / stoker-link flow? *My recommendation: yes — local co-op is an amazing demo-expansion tool. Low abuse risk because it's local, not a shared session.*
+
+---
+
+## 5. Why this is worth doing now
+
+- **Steam discoverability.** "Local Multiplayer" + "Couch Co-op" are top Steam discovery tags. Without them, Tandemonium's store page looks like an online-only game in a category dominated by couch classics.
+- **Testing & iteration speed.** Local MP lets you exercise the full two-player offset-pedaling loop *without any network*. Every online MP bug you've been debugging becomes a one-controller-one-keyboard local repro. Worth it for dev velocity alone.
+- **Demos and streaming.** Handing a second controller at a festival is infinitely easier than "scan this QR code and let me explain room codes for 30 seconds."
+- **Expands the ICP.** The persona ("Remote Co-op Duo") gains a second pathway: *same room, two devices on one screen.* That's additive — existing online-MP messaging still holds.
+- **Leverages existing sunk cost.** Every line of `SharedPedalController`, the WebHID gyro drivers, the gamepad navigation in the lobby, the TV mode, and the Electron desktop shell was already built for two-player input and gamepad-first UX. Local MP is the feature that makes that investment land.
+
+## 6. What this plan explicitly does NOT do
+
+- **Does not touch the online multiplayer code path.** `NetworkManager`, PeerJS, the Cloudflare relay, remote bike state, and the stoker-CTA flow are untouched.
+- **Does not introduce split-screen.** One bike, one camera. This is correct for a tandem bike and saves substantial rendering work.
+- **Does not add local *versus* multiplayer.** This is tandem co-op. No racing two tandem bikes locally in this spike.
+- **Does not rewrite `InputManager`.** It extends it with a slot parameter — existing single-player code keeps working unchanged.
+
+---
+
+## 7. Recommendation
+
+**Do Stage 1 first as a half-day spike-in-code** (behind `?localmp=1`) before committing to the full feature. If Stage 1 feels good with two real gamepads on your desk, Stages 2–3 are low-risk follow-ups and the whole thing ships in under a week.
+
+If Stage 1 reveals something I missed — e.g., a hidden `InputManager` global or a physics path that assumes network-sourced stoker input — we'll know *before* touching the lobby, analytics, or achievements.

--- a/docs/local-multiplayer-spike.md
+++ b/docs/local-multiplayer-spike.md
@@ -2,9 +2,61 @@
 
 **Question:** Can we add same-screen, two-controller local co-op to Tandemonium without rewriting the game, and if so, what does it take?
 
-**Short answer:** Yes. The core physics, offset-pedaling logic, and two-input data model already exist and work — the network layer is the *only* thing that synthesizes the "stoker" input, and it can be bypassed. The realistic scope is **~400–700 lines across 5–6 files**, bounded by (a) splitting `InputManager` to accept a gamepad slot and (b) adding a new `_updateLocal(dt)` game-loop path plus a lobby entry point.
+**Short answer:** Yes. The core physics, offset-pedaling logic, and two-input data model already exist and work — the network layer is the *only* thing that synthesizes the "stoker" input, and it can be bypassed. The realistic scope is **~800 lines across ~13 files**, bounded by (a) splitting `InputManager` to accept a gamepad/keyboard slot and (b) adding a new `_updateLocal(dt)` game-loop path plus a JOIN RIDE button on the existing host room page.
 
 This document captures the code-level findings from the spike and turns them into a concrete, staged plan.
+
+## TL;DR — final design (after review)
+
+- **Entry point:** existing RIDE TOGETHER → CAPTAIN → host room-code page (`#lobby-host`). No new mode card. A new JOIN RIDE button is added to that page.
+- **Unified host page:** the host page waits for *either* an online stoker (via TNDM-XXXX code / QR) *or* a local JOIN RIDE. Whichever happens first wins the room; the other is rejected.
+- **Player colors:** P1 = existing bright light green. P2 = coral red `#ff4560`.
+- **Input matrix:** one of every pair must be a gamepad. Allowed combos: gamepad+gamepad, gamepad+keyboard, keyboard+gamepad. Blocked: keyboard+keyboard (key collision).
+- **JOIN RIDE button states:** 🎮 coral when unclaimed gamepad present; ⌨️ white when P1-not-on-keyboard and keyboard available; greyed with tooltip otherwise.
+- **P2 input-mode toggles** (joystick / gyro) appear beside JOIN RIDE only when P2 is a gamepad. The gyro toggle click itself is the WebHID user gesture.
+- **Equal lean:** P1 and P2 average 50/50, identical to the current captain path. No "driver" asymmetry.
+- **Disconnect handling:** mid-ride pad disconnect → pause + reconnect overlay → 30s Quit fallback saves partial run as `incomplete`.
+- **Achievements + leaderboard:** local runs count as multiplayer; submit under P1's account tagged `mode: 'local'`.
+- **Nothing about the online MP stack changes** except adding a `destroy()` method for clean teardown when local JOIN RIDE wins the race.
+
+---
+
+## 0. Design decisions (confirmed)
+
+These were decided in review after the initial spike:
+
+| Decision | Choice |
+|---|---|
+| Captain/stoker asymmetry locally | **Full equality** — 50/50 lean average, identical to the online captain path |
+| Achievements gating | **Local counts as multiplayer** — local co-op runs credit the same achievements as online MP |
+| Leaderboard submission | **Yes**, tagged `mode: 'local'` in the backend run metadata |
+| Keyboard + keyboard local MP | **Not supported** — one keyboard can't serve two players (key collisions on pedal/lean bindings) |
+| Local MP entry point | **Option A — existing host room-code page.** No new mode card. The captain goes RIDE TOGETHER → CAPTAIN → host page as today, and a new JOIN RIDE button is added to the host page. |
+| Minimum input bar | **At least one gamepad** — because the only other path is "one keyboard shared," which is blocked. Controller-only and controller+keyboard are both allowed. |
+| P1 color | **Bright light green** (existing) |
+| P2 color | **Coral red `#ff4560`** — classic Player 2 pairing, maximum contrast with P1 green |
+| Pre-claim gamepad identification | **First gamepad to send input** becomes the P1 candidate; the other becomes P2 candidate |
+| Disconnection mid-ride | **Pause + "Reconnect Player 2 or Quit" overlay**, auto-resume on reconnect, 30s Quit fallback saves partial progress tagged incomplete |
+| Online ↔ local race on the host page | **Local JOIN RIDE wins** — pressing JOIN RIDE tears down the PeerJS room, invalidates the TNDM-XXXX code, and starts local. Online stokers trying to connect after that get a "Room not found" error. |
+| Lobby menu navigation before JOIN RIDE | P1 candidate (first-to-input gamepad) drives menu nav; P2 candidate's button presses only fire JOIN RIDE and P2 input-mode toggles |
+| Bike preset | **Shared** — one tandem bike, P1's preset applies |
+| Contribution bar / HUD partner gauge | Re-colored to P1 green + P2 coral in local mode |
+| Second-pad discoverability hint | Small "Connect a 2nd controller for local co-op" hint on single-gamepad host pages |
+
+---
+
+## 0.5. Input matrix (what pairings are allowed)
+
+| P1 input | P2 input | JOIN RIDE appearance | Allowed? |
+|---|---|---|---|
+| Gamepad | 2nd gamepad | 🎮 in coral red | ✅ |
+| Gamepad | Keyboard | ⌨️ keyboard emoji (white) | ✅ |
+| Keyboard | Gamepad | 🎮 in coral red | ✅ |
+| Gamepad | Both available | 🎮 ⌨️ (both shown, first input wins) | ✅ |
+| Keyboard | Keyboard | — | ❌ (key collision) |
+| Motion-only (mobile) | — | — | ❌ (local MP is desktop-only) |
+
+**Rule of thumb:** at least one of the two players must be on a gamepad. JOIN RIDE is greyed out on the host page only when neither a second gamepad NOR a "P1-is-not-on-keyboard + keyboard present" condition is met.
 
 ---
 
@@ -80,17 +132,23 @@ This works because:
 
 | File | Change | Est. LoC | Risk |
 |---|---|---|---|
-| `js/input-manager.js` | Accept `{ gamepadSlot, enableMotion, enableTouch, keyboard }` options; filter `_setupGamepad` / `pollGamepad` by slot; skip motion/touch for P2 on desktop; namespace keyboard bindings per instance | ~100 | **Medium** — the event-driven gamepadconnected flow needs careful slot assignment (first connected → P1 slot if empty, else P2) |
-| `js/game.js` | Add `this.inputP1` / `this.inputP2`; alias `this.input = inputP1`; add `'local'` mode; new `_updateLocal(dt)` method (fork of `_updateCaptain` minus network sends, plus P2 edge-detect); route `_loop` → `_updateLocal` when `mode === 'local'`; add `_onLocalMultiplayerReady()` lobby callback; local reset flow | ~250 | Medium — `_updateCaptain` is ~115 lines and the fork needs to stay in sync with future captain-side changes |
-| `js/balance-controller.js` | No change (already takes an input handle); instantiate a second one for P2 in `game.js` | 0 | None |
-| `js/pedal-controller.js` | No change (solo controller is unused in local MP; local MP uses `SharedPedalController` directly like captain does) | 0 | None |
-| `js/shared-pedal-controller.js` | No change | 0 | None |
-| `js/lobby.js` | New mode card "Local Co-op (Same Screen)"; new controller-assignment screen ("P1 press A / P2 press A"); route through existing level-select; emit `onLocalMultiplayerReady({ inputP1, inputP2, level })` | ~180 | Medium — lobby is a complex UI with gamepad nav; the new screen must integrate with `_stepItems` / `_moveFocus` |
-| `js/hud.js` | No change (already reads `remoteData`) | 0 | None |
-| `js/contribution-tracker.js` | Accept `'local'` and route like `'captain'` (or pass `'captain'` literal for local mode) | ~5 | None |
-| `index.html` | New lobby screen DOM for controller-assignment + new mode card | ~30 | None |
-| `js/game-recorder.js` | Guard partner-video composite behind `mode !== 'local'` | ~5 | None |
-| **Total** | | **~570 LoC** | |
+| `js/input-manager.js` | Accept `{ gamepadSlot, enableKeyboard, enableMotion, enableTouch }` options; filter `_setupGamepad` / `pollGamepad` to a specific slot index; skip motion/touch setup when disabled; independent WebHID `connectControllerGyro()` per instance (second device claim) | ~120 | **Medium** — WebHID path was written single-device; need to verify two simultaneous `requestDevice` claims work on the same browser tab |
+| `js/game.js` | Add `this.inputP1` / `this.inputP2`; alias `this.input = inputP1`; add `'local'` mode; new `_updateLocal(dt)` method forked from `_updateCaptain` minus network sends plus P2 edge-detect; route `_loop` → `_updateLocal` when `mode === 'local'`; add `_onLocalMultiplayerReady()` callback; local reset flow; pause/reconnect overlay wiring | ~270 | Medium — extract `_updateTandemCore(dt, { isLocal })` so captain and local share the body and don't drift |
+| `js/balance-controller.js` | No change — already takes an input handle | 0 | None |
+| `js/pedal-controller.js` | No change — solo controller unused in local MP | 0 | None |
+| `js/shared-pedal-controller.js` | No change — already dual-source | 0 | None |
+| `js/lobby.js` | JOIN RIDE button on `#lobby-host`; second-gamepad detection service; P2 input-mode toggles; P2 gamepad polling branch; keyboard-Enter JOIN RIDE handler; `_onLocalJoinRide(sourceType, gamepadIndex?)` transition; scope gamepad-nav to P1's claimed slot; discoverability hint; online ↔ local race teardown | ~220 | Medium — lobby is a complex UI; the new host-page wiring must integrate with `_stepItems` / `_moveFocus` and not break `_pollGamepadNav` |
+| `js/network-manager.js` | Add `destroy()` method (if not present) that closes PeerJS peer + relay WS + cancels reconnects, so local JOIN RIDE can win the race cleanly | ~15 | Low |
+| `js/hud.js` | Pick up P2 coral color in local mode via CSS var; relabel captain/stoker as P1/P2 in local contribution bar | ~15 | None |
+| `js/contribution-tracker.js` | Accept `'local'` mode value and route like `'captain'` | ~5 | None |
+| `js/achievements.js` | Audit + ensure multiplayer-gated achievements treat `mode === 'local'` the same as `mode === 'captain'` | ~10 | Low |
+| `js/analytics.js` | Add `mode: 'local'` dimension + `local_coop_sessions` counter + `room_local_claimed` event | ~10 | None |
+| `index.html` | JOIN RIDE button + P2 toggles DOM on `#lobby-host`; disconnect/reconnect overlay DOM | ~50 | None |
+| `css/*.css` (or inline) | `--tandem-player2: #ff4560` token; JOIN RIDE styles; P2 badge; contribution bar segment colors in local mode; HUD gauge re-skin | ~80 | None |
+| `js/game-recorder.js` | Guard partner-video composite behind `mode !== 'local'`; color P2 pedal-flash indicators with coral | ~10 | None |
+| **Total** | | **~805 LoC** | |
+
+(Up from the original ~570 LoC estimate because the design is now richer: JOIN RIDE button + P2 toggles + disconnect overlay + color tokens + analytics add substantive UI work. Still well below rewriting the network stack.)
 
 ---
 
@@ -126,37 +184,86 @@ Each stage is independently testable and mergeable. **Ship Stage 1 behind a `?lo
 - HUD partner gauge shows P2's lean (via `remoteData` populated from P2's InputManager).
 - No network, no room code, no errors in console.
 
-### Stage 2 — Lobby flow (1 day)
+### Stage 2 — Lobby flow (1–1.5 days)
 
-**Goal:** First-class "Local Co-op" entry in the existing lobby.
+**Goal:** JOIN RIDE button on the existing multiplayer host room-code page, with correct device-aware visual state. No new lobby screens; no new mode card. Entry point is the existing RIDE TOGETHER → CAPTAIN → host flow.
 
-1. **New mode card** on `#lobby-mode`: "Same Screen Co-op" (next to SOLO and RIDE TOGETHER).
-2. **New lobby step `#lobby-local-pair`:**
-   - Prompts "Player 1: press A / Player 2: press A."
-   - Detects each gamepad index claim independently.
-   - Proceeds to `#lobby-level` when both claimed.
-   - Back button returns to mode select.
-3. **Level + difficulty flow reuses the existing `#lobby-level` cards** — no new UI.
-4. **Lobby emits `onLocalMultiplayerReady({ inputP1, inputP2 })`** which calls a new `Game._onLocalMultiplayerReady` — the same shape as `_onMultiplayerReady(net, mode)` but without a network.
-5. **Gamepad navigation integration** — add the new step to `_stepItems` / `_stepBack` so directional nav works.
+1. **Extend `#lobby-host` (the host room-code page) with a JOIN RIDE button.**
+   - Positioned below (or next to) the TNDM-XXXX code + QR, clearly separated as a "local option."
+   - Always rendered; its visual state depends on detected inputs.
+   - Label: "JOIN RIDE" + one or both of 🎮 / ⌨️ icons per the input matrix (see §0.5).
+   - 🎮 icon styled in P2 coral red `#ff4560` when an unclaimed gamepad is ready.
+   - ⌨️ icon in white when P1 is NOT on keyboard AND a keyboard is available.
+   - Greyed-out state + tooltip "Plug in a controller for local co-op" when neither condition is met.
+2. **Second-gamepad detection service.**
+   - A small polling helper (`getUnclaimedGamepadIndex()`) that scans `navigator.getGamepads()` for any index that is NOT P1's. Polled from the host page's existing RAF nav loop.
+   - Updates the JOIN RIDE button visual whenever the detected set changes (hot-plug support).
+   - Fires a state change event so the P2 input-mode toggles (§step 4) can show/hide.
+3. **JOIN RIDE click handlers, per input source:**
+   - **P2 gamepad path:** a dedicated polling branch watches the unclaimed gamepad's A button; pressing it fires `_onLocalJoinRide('gamepad', gamepadIndex)`.
+   - **P2 keyboard path:** the host page listens for Enter/Space while JOIN RIDE has the ⌨️ state visible; fires `_onLocalJoinRide('keyboard')`.
+   - First one to fire wins; the other path is disabled.
+4. **P2 input-mode toggles beside JOIN RIDE.**
+   - Shown only when the second gamepad is present (keyboard-P2 has no sub-modes).
+   - Toggles: `joystick` (left stick for lean) and `gyro` (WebHID gyro for lean).
+   - Defaults match P1: joystick ON, gyro OFF.
+   - Tapping the gyro toggle *is* the user gesture for P2's WebHID `requestDevice()` call — this conveniently satisfies the browser permission requirement without any extra UI.
+   - State is session-scoped, not persisted.
+5. **`_onLocalJoinRide(sourceType, gamepadIndex?)` — the transition into local mode.**
+   - Tears down the online MP attempt: `this.net.destroy()` (closes PeerJS peer, invalidates TNDM-XXXX, stops ICE). Subsequent online stoker connects fail naturally.
+   - Instantiates a second `InputManager` for P2 per the matrix:
+     - `sourceType === 'gamepad'` → `new InputManager({ gamepadSlot: gamepadIndex, enableKeyboard: false, enableMotion: false, enableTouch: false })`
+     - `sourceType === 'keyboard'` → `new InputManager({ gamepadSlot: null, enableKeyboard: true, enableMotion: false, enableTouch: false })` and P1's InputManager is reconfigured to NOT read keyboard (it already isn't, since P1 claimed a gamepad to get here).
+   - Instantiates a second `BalanceController` bound to `inputP2`.
+   - Calls `game._onLocalMultiplayerReady({ inputP1, inputP2, balanceCtrlP2 })` which sets `this.mode = 'local'`, creates a fresh `SharedPedalController`, applies saved tuning, routes to `_updateLocal(dt)` in the game loop.
+6. **Online ↔ local race rule (implemented in §5 above):** JOIN RIDE wins over any in-flight online stoker connection. If an online stoker was mid-handshake, their connection is rejected. Analytics event `room_local_claimed` so we can measure how often this happens.
+7. **Gamepad navigation scoping on the host page.**
+   - Before JOIN RIDE is clicked, P1's claimed gamepad drives all menu nav (existing behavior, unchanged).
+   - The unclaimed gamepad's axes/buttons are ignored by the nav loop EXCEPT for the A button, which is routed to JOIN RIDE only.
+   - This prevents "P2 accidentally scrolling P1's cursor" before the handoff.
+8. **Discoverability hint (optional polish).**
+   - When the host page is open and only P1's gamepad is detected (no second gamepad, and P1 is on that gamepad so keyboard isn't a valid P2 either), render a small dim hint next to JOIN RIDE: "Connect a 2nd controller for local co-op." This is visible until JOIN RIDE becomes eligible.
 
-**Stage 2 exit criteria:** Player can start a Local Co-op ride entirely through the GUI with two gamepads and no URL flags.
+**Stage 2 exit criteria:**
+- A player can go RIDE TOGETHER → CAPTAIN → host page and start a local-MP ride via JOIN RIDE.
+- All four allowed input combinations from §0.5 actually work end-to-end.
+- Local JOIN RIDE wins the race vs. an in-flight online stoker.
+- No regression in the pure online MP path (online stoker still joins normally when JOIN RIDE is not pressed).
 
-### Stage 3 — Polish + edge cases (0.5–1 day)
+### Stage 3 — Polish + edge cases (1 day)
 
-1. **Controller hot-swap** — if P2 disconnects mid-ride, pause and show "Waiting for Player 2."
-2. **Single-gamepad fallback** — if only one gamepad is detected at lobby time, offer "Player 2 use keyboard (WASD + Q/E)" as an opt-in.
-3. **Options overlay + pause** — both players' Start buttons can open/close the options menu.
-4. **Achievements** — ensure achievements that require "multiplayer" don't mis-fire or mis-block on local (decide per-achievement: do we credit local co-op as "multiplayer" for achievement purposes? Probably yes.)
-5. **Analytics** — add a `mode: 'local'` dimension to `analytics.startRide()` so we can measure adoption.
-6. **Recorder** — disable partner-video composite; keep pedal-flash indicators for both players.
+1. **Mid-ride disconnection — pause + reconnect overlay.**
+   - When P2's gamepad disconnects during a local ride, pause the game (freeze physics, stop the race timer) and show a full-screen overlay: "Player 2 disconnected — reconnect their controller to resume."
+   - Resume button is greyed until the same or another unclaimed gamepad appears.
+   - 30s idle timer shows a "Quit to lobby (save progress)" secondary button. Taking Quit ends the ride, submits partial progress to the leaderboard tagged `incomplete: true, mode: 'local'`.
+   - If P2 was on the keyboard, there's no disconnection event — skip this overlay entirely (keyboard can't "disconnect").
+2. **Single-gamepad fallback at lobby time.** Implemented in Stage 2 already — JOIN RIDE's ⌨️ state covers this. No extra work.
+3. **Options overlay + pause.** Either P1 or P2's input source can open/close the pause overlay (P1 via existing Start button, P2 via their gamepad Start or keyboard Escape).
+4. **Achievements audit.** Walk `js/achievements.js` and verify:
+   - Multiplayer-gated achievements fire for `mode === 'local'` the same as `mode === 'captain'`.
+   - No achievement is gated on "has a partner peer ID" or similar online-only signals.
+   - Tag analytics events with `coop_type: 'local' | 'online'` so the marketing dashboard can split the two.
+5. **Analytics.** Add `mode: 'local'` dimension to `analytics.startRide()`. Add new `local_coop_sessions` counter. Fire `room_local_claimed` whenever JOIN RIDE wins a race vs. an online stoker.
+6. **Leaderboard submission.** Runs submit under P1's signed-in account (Steam/Google) with `mode: 'local'` metadata. P2 has no account identity in the submission — that's fine. Achievements fire on P1's account only (documented limitation; acceptable for v1).
+7. **Recorder.** Disable partner-video composite branch for `mode === 'local'`. Keep pedal-flash indicators for both players, colored P1 green + P2 coral.
+8. **Contribution bar + HUD partner gauge re-color.**
+   - The existing captain/stoker contribution bar already splits into two segments. In `mode === 'local'`, apply CSS variables `--p1-color: #00ff7a; --p2-color: #ff4560;` to the segments and label them "P1 / P2" instead of "Captain / Stoker."
+   - Partner gauge border + needle pick up `--p2-color` in local mode.
+9. **CSS token for P2 color.** Add `--tandem-player2: #ff4560;` to the global stylesheet and reuse it in:
+   - JOIN RIDE button styling
+   - P2 gamepad-connected badge
+   - P2 input-mode toggles (joystick / gyro)
+   - Contribution bar P2 segment
+   - HUD partner gauge in local mode
+   - Pedal-flash indicators for P2 in the recorder overlay
 
 ### Stage 4 — Nice-to-haves (optional, post-launch)
 
-- **Gyro steering for both players simultaneously** — requires two WebHID device claims, one per player. The existing `InputManager.connectControllerGyro()` path should be re-entrant per instance; verify on real hardware.
-- **Split-keyboard mode** — P1 uses arrows + A/D, P2 uses IJKL + Q/E, so a couch session needs zero gamepads.
-- **Player-specific bike color / nameplate** in HUD.
-- **"Captain swap" button** to flip who's tracked as captain vs stoker in `sharedPedal` (affects offset-bonus attribution only, not gameplay).
+- **Dual-gyro steering** is in Stage 1/3 now (baked into the per-instance InputManager). Stage 4 is just hardware validation across real DualSense + Switch Pro + Xbox combinations.
+- **Player 2 nameplate** over the tandem bike's rear rider — a small "P2" tag in coral.
+- **Captain swap** button on the pause overlay to flip who's tracked as captain vs stoker in `sharedPedal` (affects offset-bonus attribution only, not gameplay).
+- **Per-player bike cosmetic slot** — P2 picks a second color stripe on the shared tandem so both players feel ownership. Low priority.
+- **Recording with P1/P2 labels baked in** — GameRecorder overlay puts the coral/green labels on the composited video clip for shareability.
 
 ---
 
@@ -173,13 +280,13 @@ Each stage is independently testable and mergeable. **Ship Stage 1 behind a `?lo
 | Achievements / leaderboards that assume online co-op misreport for local | Low | Audit `js/achievements.js` in Stage 3; explicitly scope which achievements count local as multiplayer. |
 | Electron / Steam TV-mode build has a different input path | Low | The Electron build uses the same `InputManager`; the only delta is that `window.steam` is true. Local MP should work identically in Electron — verify on Deck hardware as part of Stage 3. |
 
-### 4.2 Open questions I want your call on
+### 4.2 Open questions — resolved
 
-1. **Captain/stoker asymmetry locally?** Online, captain runs physics and their lean is arguably "more authoritative." Locally, should both players be fully equal (lean averaged 50/50), or should one player be explicitly "the driver"? *My recommendation: equal, identical to the current captain-path averaging. Simplest and preserves the feel.*
-2. **Achievements gating:** does a local-co-op finish count toward a multiplayer achievement (e.g., "Finish a ride with a partner")? *My recommendation: yes, local counts as multiplayer for achievement purposes.*
-3. **Leaderboards:** should local-co-op runs submit to the leaderboard? *My recommendation: yes, tagged with `mode: 'local'` so you can filter later if it skews the boards.*
-4. **Keyboard-only local MP:** is it a Stage 3 must-have, or a Stage 4 nice-to-have? *My recommendation: Stage 4 — two gamepads is the marketing-critical path for Steam / couch / festival demos; keyboard-only local is a niche fallback.*
-5. **Demo tier:** does Local Co-op work in the free demo / stoker-link flow? *My recommendation: yes — local co-op is an amazing demo-expansion tool. Low abuse risk because it's local, not a shared session.*
+All initial open questions have been resolved during design review (see §0). Remaining unknowns are hardware-validation items, not design decisions:
+
+1. **Does `navigator.hid.requestDevice()` work cleanly for two simultaneous WebHID claims in the same tab?** Needs a real-hardware test with DualSense + Switch Pro both requesting gyro. If the browser throws on the second claim, we fall back to "P2 joystick-only" gracefully and file a Stage 4 follow-up.
+2. **Does the Electron desktop build behave identically?** Expected yes — same input stack — but needs a Deck/TV-mode pass.
+3. **Does the free demo include local co-op?** Confirmed yes per review. Low abuse risk; it's a great demo-expansion tool.
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only PR adding two new planning documents under `docs/`:

- **`docs/ideal-customer-persona.md`** — "Co-op Casey", the Remote Co-op Duo. Standardized B2C persona (demographics, psychographics, JTBD, pain→solution, channels, messaging, anti-persona, metrics) built around Tandemonium's actual shape: online-only, one-screen-per-player, PeerJS P2P + Cloudflare relay, cross-device captain/stoker pairing. Explicitly calls out that this is NOT a couch-co-op game so the messaging stays aligned with the product.

- **`docs/local-multiplayer-spike.md`** — Feasibility spike + 4-stage implementation plan for adding same-screen local multiplayer. Includes code-level findings (the offset-pedaling engine is already dual-source via `SharedPedalController.receiveTap(source, foot)`, so local MP is primarily an `InputManager` refactor plus an `_updateLocal(dt)` fork of `_updateCaptain`), a final design section locking in decisions from review (JOIN RIDE button lives on the existing host room-code page, P2 = coral red `#ff4560`, full lean equality, local runs submit to leaderboard tagged `mode: 'local'`, etc.), file-by-file change estimates, and staged rollout.

No code changes. No behavior changes. Pure planning artifacts.

## Test plan

- [x] Markdown renders correctly on GitHub
- [ ] Persona doc reviewed for accuracy vs. product positioning
- [ ] Spike plan reviewed for design decisions (baked-in from discussion)

https://claude.ai/code/session_01V3htCwRTeJvCosMgJCnXKf