### PR TITLE
Extract shared ride helpers from _updateSolo / _updateCaptain

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2908,10 +2908,7 @@ class Game {
     this.bike.update(pedalResult, balanceResult, dt, this.safetyMode, this.autoSpeed);
     this._checkTreeCollision();
 
-    // Record balance crash (bike fell from lean, not from tree/obstacle)
-    if (!wasFallen && this.bike.fallen && !this._lastCrashCause) {
-      this._recordCrash('balance');
-    }
+    this._recordBalanceCrashIfNew(wasFallen);
 
     // Race progress + contribution tracking
     if (this.raceManager) {
@@ -2928,18 +2925,7 @@ class Game {
       this.contributionTracker.update(dt, this.bike, balanceResult.leanInput, 0, this.pedalCtrl.stats);
     }
 
-    // Collectibles
-    if (this.collectibleManager) {
-      const collected = this.collectibleManager.update(dt, this.bike.distanceTraveled, this.bike.position);
-      if (collected.length > 0) {
-        this._onCollect(collected.length);
-      }
-    }
-
-    // Obstacles
-    if (this.obstacleManager) {
-      this.obstacleManager.update(dt, this.bike.distanceTraveled, this.bike.position);
-    }
+    this._updateItems(dt);
 
     // Achievements
     this._checkAchievements(dt);
@@ -2961,13 +2947,7 @@ class Game {
 
     this.grassParticles.update(this.bike, dt);
     this._hapticOffRoadCheck();
-    this.world.update(this.bike.position, this.bike.roadD, dt);
-    this.chaseCamera.update(this.bike, dt, this.world.roadPath);
-
-    // Camera shake on crash
-    if (this.bike.fallen && this.bike.fallTimer > 1.8) {
-      this.chaseCamera.shakeAmount = 0.15;
-    }
+    this._updateWorldAndCamera(dt);
 
     this.hud.update(this.bike, this.input, this.pedalCtrl, dt);
     this.archIndicator.update(this.bike, balanceResult.leanInput);
@@ -3015,10 +2995,7 @@ class Game {
     this.bike.update(pedalResult, balanceResult, dt, this.safetyMode, this.autoSpeed);
     this._checkTreeCollision();
 
-    // Record balance crash (bike fell from lean, not from tree/obstacle)
-    if (!wasFallen && this.bike.fallen && !this._lastCrashCause) {
-      this._recordCrash('balance');
-    }
+    this._recordBalanceCrashIfNew(wasFallen);
 
     // Race progress + contribution tracking (captain is authoritative)
     // Freeze race timer while reconnecting
@@ -3042,18 +3019,7 @@ class Game {
       }
     }
 
-    // Collectibles (captain is authoritative)
-    if (this.collectibleManager) {
-      const collected = this.collectibleManager.update(dt, this.bike.distanceTraveled, this.bike.position);
-      if (collected.length > 0) {
-        this._onCollect(collected.length);
-      }
-    }
-
-    // Obstacles
-    if (this.obstacleManager) {
-      this.obstacleManager.update(dt, this.bike.distanceTraveled, this.bike.position);
-    }
+    this._updateItems(dt);
 
     // Achievements
     this._checkAchievements(dt);
@@ -3078,12 +3044,7 @@ class Game {
       this.net.sendLean(captainLean);
     }
 
-    this.world.update(this.bike.position, this.bike.roadD, dt);
-    this.chaseCamera.update(this.bike, dt, this.world.roadPath);
-
-    if (this.bike.fallen && this.bike.fallTimer > 1.8) {
-      this.chaseCamera.shakeAmount = 0.15;
-    }
+    this._updateWorldAndCamera(dt);
 
     this._updateConnBadge();
     const remoteData = this._remoteData;
@@ -3094,6 +3055,41 @@ class Game {
     this.archIndicator.update(this.bike, captainLean, this.remoteLean);
     this.renderer.render(this.scene, this.camera);
     this.recorder.composite(this._buildRecordState(this.sharedPedal, remoteData));
+  }
+
+  // ============================================================
+  // SHARED RIDE HELPERS
+  // Extracted from _updateSolo / _updateCaptain to keep a single
+  // source of truth for logic that both paths run identically.
+  // ============================================================
+
+  /** Record a balance-caused crash (fell from lean, not from collision). */
+  _recordBalanceCrashIfNew(wasFallen) {
+    if (!wasFallen && this.bike.fallen && !this._lastCrashCause) {
+      this._recordCrash('balance');
+    }
+  }
+
+  /** Advance collectibles + obstacles; trigger _onCollect for any picked up this frame. */
+  _updateItems(dt) {
+    if (this.collectibleManager) {
+      const collected = this.collectibleManager.update(dt, this.bike.distanceTraveled, this.bike.position);
+      if (collected.length > 0) {
+        this._onCollect(collected.length);
+      }
+    }
+    if (this.obstacleManager) {
+      this.obstacleManager.update(dt, this.bike.distanceTraveled, this.bike.position);
+    }
+  }
+
+  /** Advance the world streaming, chase camera, and apply crash-recovery camera shake. */
+  _updateWorldAndCamera(dt) {
+    this.world.update(this.bike.position, this.bike.roadD, dt);
+    this.chaseCamera.update(this.bike, dt, this.world.roadPath);
+    if (this.bike.fallen && this.bike.fallTimer > 1.8) {
+      this.chaseCamera.shakeAmount = 0.15;
+    }
   }
 
   // ============================================================


### PR DESCRIPTION
## Summary

Pure refactor — pulls three byte-identical blocks out of `_updateSolo` and `_updateCaptain` in `js/game.js` into a new `SHARED RIDE HELPERS` section, so both ride-update paths call the same helpers instead of maintaining duplicated logic.

**New helpers (defined once, called from both solo and captain):**

- **`_recordBalanceCrashIfNew(wasFallen)`** — records a `'balance'` crash when the bike just fell this frame and no other crash cause is set.
- **`_updateItems(dt)`** — advances collectibles + obstacles and triggers `_onCollect` for any items picked up this frame.
- **`_updateWorldAndCamera(dt)`** — advances world streaming, chase camera, and applies the crash-recovery camera shake.

## Why

- Removes 3 duplicated blocks (6 occurrences across solo + captain).
- Single source of truth: future tweaks to e.g. crash shake or items update now live in one method instead of needing to be mirrored.
- Sets up a clean reuse surface for the upcoming `_updateLocal(dt)` that will run local multiplayer against the same shared bike physics — the local path will be able to call the same helpers without forking yet more duplicated logic.

## Intentionally out of scope

- **No rename** of `_updateCaptain`. Its semantic generalization can happen later in the local-MP feature branch where a non-captain caller justifies it.
- **No extraction of the race-progress / contribution-tracker blocks.** Those differ non-trivially between solo (uses `timerEnabled` level flag) and captain (uses `_reconnecting` to freeze the timer), so merging them would either change behavior or require parameterization that adds more complexity than it removes.
- **No extraction of the 2-line `grassParticles + hapticOffRoadCheck` pair**, because they don't carry enough body to justify a helper and in captain mode there's a network-send block interleaved between them and the world/camera block.

## Diff shape

```
 js/game.js | 86 ++++++++++++++++++++++++++++++--------------------------------
 1 file changed, 41 insertions(+), 45 deletions(-)
```

Net −4 LoC; three helpers added, six duplicated blocks collapsed to call sites.

## Test plan

Because there are no automated tests for the ride-update loop, this needs a manual regression pass on a dev machine:

- [ ] **Solo keyboard** — tutorial + Grandma's level, verify crash recording, collectible pickup, obstacle collision, and chase-camera crash shake all work identically.
- [ ] **Solo gamepad** — same as above but with a DualSense / Xbox controller.
- [ ] **Online captain** (host a room, connect a stoker) — verify the captain path still runs the full race, picks up items, and handles crash/reset.
- [ ] **Online stoker** — no changes to `_updateStoker`, but verify nothing regressed because captain's state-send timing is unchanged.
- [ ] **Electron / Steam build** — same code path, should be identical, but worth a smoke test since this file is the hot loop.
- [ ] `node --check js/game.js` passes (verified locally).

## Dependencies / blockers

None. This is a standalone cleanup that can merge in any order. The upcoming `feature/local-multiplayer` branch will build on top of a main that includes this refactor.

https://claude.ai/code/session_01V3htCwRTeJvCosMgJCnXKf