### PR TITLE
Controller overlay: DualSense Bluetooth gyro + buttons via HID

### DIFF
--- a/controller-overlay/src/js/app.js
+++ b/controller-overlay/src/js/app.js
@@ -40,6 +40,13 @@ let hidDevice = null;
 let controllerDriver = null;
 let gyroActive = false;          // true when gyro is connected and feeding data
 let gyroPermitted = false;       // true once gyro has been connected at least once
+
+// Synthetic gamepad built from HID input reports. Needed because DualSense
+// over Bluetooth, once switched into 0x31 full-report mode, disappears from
+// Chromium's Gamepad API entirely. When that happens we parse sticks, buttons,
+// and triggers directly from the HID report and expose them in a Gamepad-
+// shaped object that the rest of the app consumes via readGamepad().
+let syntheticGamepad = null;
 const gyroOrientation = new THREE.Quaternion();
 let lastGyroTime = 0;
 let gyroScale = (2000.0 / 32768.0) * (Math.PI / 180.0);
@@ -279,7 +286,15 @@ async function init() {
   // Check for already-connected gamepad (may have connected before
   // our event listeners were attached). Same approach as the game's
   // pollGamepad() fallback in input-manager.js.
-  checkForExistingGamepad();
+  const foundViaGamepadAPI = checkForExistingGamepad();
+
+  // If the Gamepad API has nothing, fall back to probing WebHID directly.
+  // This recovers the cold-start case where a DualSense is still in 0x31
+  // full-report mode from a previous session — Gamepad API is blind to it,
+  // but navigator.hid.getDevices() still lists the granted device.
+  if (!foundViaGamepadAPI) {
+    bootstrapFromHID();
+  }
 }
 
 /**
@@ -300,6 +315,7 @@ function detectInitialController() {
 /**
  * Check for a gamepad that was connected before event listeners were set up.
  * Triggers the full switchController flow including gyro auto-connect.
+ * @returns {boolean} true if a gamepad was found and claimed
  */
 function checkForExistingGamepad() {
   const gamepads = navigator.getGamepads();
@@ -307,9 +323,48 @@ function checkForExistingGamepad() {
     if (gamepads[i]) {
       console.log('Found existing gamepad at startup:', gamepads[i].id);
       switchController(gamepads[i]);
-      return;
+      return true;
     }
   }
+  return false;
+}
+
+/**
+ * Cold-start fallback when the Gamepad API shows nothing: probe WebHID for
+ * any previously-granted gyro-capable device and drive the overlay from its
+ * HID reports. Synthesizes a Gamepad-shaped stub so switchController() can
+ * run unchanged.
+ */
+async function bootstrapFromHID() {
+  if (!navigator.hid) return;
+  let devices;
+  try {
+    devices = await navigator.hid.getDevices();
+  } catch (err) {
+    console.log('bootstrapFromHID: getDevices failed:', err.message);
+    return;
+  }
+  for (const d of devices) {
+    const drv = ControllerRegistry.getDriver(d.vendorId, d.productId);
+    if (!drv || !drv.capabilities.gyro) continue;
+    console.log('bootstrapFromHID: found', d.productName,
+      'vid:' + d.vendorId.toString(16), 'pid:' + d.productId.toString(16));
+    const stub = {
+      id: d.productName || drv.driverName,
+      index: -1,
+      axes: [0, 0, 0, 0],
+      buttons: Array.from({ length: 17 }, () => ({ pressed: false, value: 0 })),
+    };
+    await switchController(stub);
+    // switchController() calls disconnectGyro() which nulls syntheticGamepad,
+    // so seed it *after* — this gives readGamepad() neutral state to return
+    // during the 2s window before HID reports start flowing.
+    if (!syntheticGamepad) {
+      syntheticGamepad = createSyntheticGamepad(d.productName);
+    }
+    return;
+  }
+  console.log('bootstrapFromHID: no granted gyro-capable device found');
 }
 
 // =====================================================================
@@ -544,6 +599,8 @@ async function disconnectGyro() {
   }
   gyroActive = false;
   gyroPermitted = false;
+  syntheticGamepad = null;
+  _firstReportLogged = false;
   gyroOrientation.identity();
   lastGyroTime = 0;
   calibrating = false;
@@ -805,6 +862,21 @@ document.querySelectorAll('[data-remap]').forEach(btn => {
 });
 
 function readGamepad() {
+  // Preferred source: the real Gamepad API, if it still owns this slot.
+  if (gamepadIndex !== null) {
+    const gp = navigator.getGamepads()[gamepadIndex];
+    if (gp) return gp;
+  }
+
+  // Fallback: HID-derived synthetic gamepad. Required for DualSense BT in
+  // 0x31 full-report mode, which is invisible to Chromium's Gamepad API.
+  // Presence of syntheticGamepad implies an active HID-synthetic session —
+  // disconnectGyro() clears it so stale state can't leak.
+  if (syntheticGamepad) {
+    return syntheticGamepad;
+  }
+
+  // No slot yet and no HID → probe the Gamepad API for a fresh connection.
   if (gamepadIndex === null) {
     const gamepads = navigator.getGamepads();
     for (let i = 0; i < gamepads.length; i++) {
@@ -816,28 +888,91 @@ function readGamepad() {
     return null;
   }
 
-  const gp = navigator.getGamepads()[gamepadIndex];
-  if (!gp) {
-    onGamepadDisconnected(gamepadIndex);
-    return null;
-  }
-  return gp;
+  // Had a slot, the Gamepad API dropped it, and we have no HID fallback.
+  onGamepadDisconnected(gamepadIndex);
+  return null;
 }
 
 // =====================================================================
 // GYRO INPUT
 // =====================================================================
 
+function createSyntheticGamepad(id) {
+  return {
+    id: id || 'HID Controller',
+    index: -1,
+    axes: [0, 0, 0, 0],
+    buttons: Array.from({ length: 17 }, () => ({ pressed: false, value: 0 })),
+    _synthetic: true,
+  };
+}
+
+// Map parsed HID fields into the Standard Gamepad layout used by controller-profiles.js.
+function updateSyntheticFromParsed(parsed) {
+  if (!syntheticGamepad) {
+    syntheticGamepad = createSyntheticGamepad(hidDevice?.productName);
+  }
+  const g = syntheticGamepad;
+
+  if (parsed.sticks) {
+    g.axes[0] = parsed.sticks.lx;
+    g.axes[1] = parsed.sticks.ly;
+    g.axes[2] = parsed.sticks.rx;
+    g.axes[3] = parsed.sticks.ry;
+  }
+
+  if (parsed.buttons) {
+    const b = parsed.buttons;
+    const set = (i, pressed, value) => {
+      const slot = g.buttons[i];
+      slot.pressed = !!pressed;
+      slot.value = value === undefined ? (pressed ? 1 : 0) : value;
+    };
+    set(0, b.cross);
+    set(1, b.circle);
+    set(2, b.square);
+    set(3, b.triangle);
+    set(4, b.l1);
+    set(5, b.r1);
+    const l2v = parsed.triggers?.l2 ?? 0;
+    const r2v = parsed.triggers?.r2 ?? 0;
+    set(6, b.l2 || l2v > 0.05, l2v);
+    set(7, b.r2 || r2v > 0.05, r2v);
+    set(8, b.create);
+    set(9, b.options);
+    set(10, b.l3);
+    set(11, b.r3);
+    set(12, b.dpadUp);
+    set(13, b.dpadDown);
+    set(14, b.dpadLeft);
+    set(15, b.dpadRight);
+    set(16, b.ps);
+  }
+}
+
+let _firstReportLogged = false;
 function handleInputReport(event) {
-  if (!controllerDriver || !gyroActive) return;
+  if (!controllerDriver) return;
+  if (!_firstReportLogged) {
+    _firstReportLogged = true;
+    console.log('First HID inputreport: reportId=0x' + event.reportId.toString(16),
+      'byteLength=' + event.data.byteLength);
+  }
   const parsed = controllerDriver.parseReport(event.reportId, event.data);
   if (!parsed) return;
+
+  // Keep sticks/buttons flowing even when gyro is toggled off — otherwise
+  // turning gyro off on a BT DualSense (stuck in 0x31) would silently lose
+  // all stick/button input since the Gamepad API can't see it either.
+  if (parsed.sticks || parsed.buttons || parsed.triggers) {
+    updateSyntheticFromParsed(parsed);
+  }
 
   if (parsed.touchpad) {
     overlay.updateTouchpad(parsed.touchpad, parsed.touchpadButton);
   }
 
-  if (!parsed.gyro) return;
+  if (!gyroActive || !parsed.gyro) return;
 
   gyroScale = parsed.gyroScale * (Math.PI / 180.0);
   const now = performance.now();

--- a/controller-overlay/src/js/controllers/dualsense-driver.js
+++ b/controller-overlay/src/js/controllers/dualsense-driver.js
@@ -15,15 +15,34 @@ export class DualSenseDriver extends ControllerDriver {
     return { gyro: true, accel: true, touchpad: true };
   }
 
-  // DualSense streams full reports by default — no init needed.
+  async init() {
+    // Over Bluetooth, DualSense defaults to a compatibility mode that only
+    // streams report 0x01 (sticks/buttons, no IMU). Reading feature report
+    // 0x05 (calibration) switches it into full-report mode, after which it
+    // streams 0x31 reports containing gyro and accel. Same trick used by
+    // Linux's hid-playstation driver.
+    if (this.connectionType === 'bluetooth') {
+      try {
+        await this.device.receiveFeatureReport(0x05);
+        console.log('DualSense BT: enabled full report mode via feature 0x05');
+      } catch (err) {
+        console.warn('DualSense BT: feature 0x05 query failed:', err.message);
+      }
+    }
+  }
 
   parseReport(reportId, data) {
-    let gyroOffset, touchOffset;
+    // USB 0x01 and BT 0x31 share a common input-report layout, shifted by
+    // one byte: BT prefixes with a sequence/counter byte. baseOffset handles
+    // the shift so everything downstream stays symmetric.
+    let baseOffset, gyroOffset, touchOffset;
 
     if (this.connectionType === 'usb' && reportId === 0x01) {
+      baseOffset = 0;
       gyroOffset = 15;
       touchOffset = 32;
     } else if (this.connectionType === 'bluetooth' && reportId === 0x31) {
+      baseOffset = 1;
       gyroOffset = 16;
       touchOffset = 33;
     } else {
@@ -32,7 +51,54 @@ export class DualSenseDriver extends ControllerDriver {
 
     const r = ControllerDriver.readSigned16;
 
-    // Gyro (6 bytes) + Accel (6 bytes immediately after)
+    // ── Sticks (4 bytes, unsigned 0-255, center ~128) ──
+    const rawLX = data.getUint8(baseOffset + 0);
+    const rawLY = data.getUint8(baseOffset + 1);
+    const rawRX = data.getUint8(baseOffset + 2);
+    const rawRY = data.getUint8(baseOffset + 3);
+    const sticks = {
+      lx: (rawLX - 128) / 128,
+      ly: (rawLY - 128) / 128,
+      rx: (rawRX - 128) / 128,
+      ry: (rawRY - 128) / 128,
+    };
+
+    // ── Triggers (analog 0-255 → 0-1) ──
+    const triggers = {
+      l2: data.getUint8(baseOffset + 4) / 255,
+      r2: data.getUint8(baseOffset + 5) / 255,
+    };
+
+    // ── Buttons + dpad ──
+    // byte +7: dpad nibble (0-7 = dir, 8 = neutral) | face buttons
+    // byte +8: shoulders / options / stick clicks
+    // byte +9: PS / touchpad click / mute
+    const faceByte = data.getUint8(baseOffset + 7);
+    const optByte  = data.getUint8(baseOffset + 8);
+    const psByte   = data.getUint8(baseOffset + 9);
+
+    const dpadDir = faceByte & 0x0F;
+    const buttons = {
+      square:   !!(faceByte & 0x10),
+      cross:    !!(faceByte & 0x20),
+      circle:   !!(faceByte & 0x40),
+      triangle: !!(faceByte & 0x80),
+      l1:       !!(optByte & 0x01),
+      r1:       !!(optByte & 0x02),
+      l2:       !!(optByte & 0x04),
+      r2:       !!(optByte & 0x08),
+      create:   !!(optByte & 0x10),
+      options:  !!(optByte & 0x20),
+      l3:       !!(optByte & 0x40),
+      r3:       !!(optByte & 0x80),
+      ps:       !!(psByte  & 0x01),
+      dpadUp:    dpadDir === 7 || dpadDir === 0 || dpadDir === 1,
+      dpadRight: dpadDir === 1 || dpadDir === 2 || dpadDir === 3,
+      dpadDown:  dpadDir === 3 || dpadDir === 4 || dpadDir === 5,
+      dpadLeft:  dpadDir === 5 || dpadDir === 6 || dpadDir === 7,
+    };
+
+    // ── Gyro (6 bytes) + Accel (6 bytes immediately after) ──
     const gyro = {
       x: r(data, gyroOffset),
       y: r(data, gyroOffset + 2),
@@ -44,21 +110,19 @@ export class DualSenseDriver extends ControllerDriver {
       z: r(data, gyroOffset + 10)
     };
 
-    // Touchpad — 2 touch points, 4 bytes each
+    // ── Touchpad — 2 touch points, 4 bytes each ──
     const touchpad = [
       DualSenseDriver._parseTouchPoint(data, touchOffset),
       DualSenseDriver._parseTouchPoint(data, touchOffset + 4)
     ];
 
-    // Touchpad button
-    let touchpadButton = false;
-    if (this.connectionType === 'usb') {
-      touchpadButton = !!(data.getUint8(9) & 0x02);
-    } else {
-      touchpadButton = !!(data.getUint8(10) & 0x02);
-    }
+    // Touchpad click: bit 1 of the PS byte
+    const touchpadButton = !!(psByte & 0x02);
 
     return {
+      sticks,
+      triggers,
+      buttons,
       gyro,
       accel,
       touchpad,

--- a/index.html
+++ b/index.html
@@ -4234,7 +4234,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.b6f91f8 | 04-04-2026 01:25</span></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.8416ba6 | 04-11-2026 11:27</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">


### PR DESCRIPTION
## Summary

- Fixes the 3D controller overlay on Bluetooth-paired DualSense: gyro now works *and* sticks/buttons keep working, in the same session and across launches.
- `DualSenseDriver` sends feature report `0x05` on BT connect (the Linux `hid-playstation` trick) to unlock the `0x31` full-report stream, and now also parses sticks/triggers/buttons/dpad out of that report.
- `app.js` synthesizes a Gamepad-shaped object from HID reports when Chromium's Gamepad API drops the device (which it does as soon as DualSense leaves the `0x01` compat mode), adds a ``bootstrapFromHID()`` cold-start path for the case where a DualSense is still stuck in `0x31` mode from a prior session, and keeps stick/button input flowing even when the gyro toggle is off.

## Background

DualSense over Bluetooth defaults to a compatibility mode that only streams report `0x01` — sticks and buttons, no IMU. Reading feature report `0x05` (calibration) switches the controller into full-report mode (`0x31`), which carries gyro and accel. The tradeoff: once in `0x31` mode, Chromium's Gamepad API mapper no longer recognizes the controller as a Standard Gamepad, so ``navigator.getGamepads()`` goes blind to it. Previously that meant enabling gyro silently killed all stick/button input, and on the next launch the controller was invisible until the user power-cycled it.

## Changes

**``controller-overlay/src/js/controllers/dualsense-driver.js``**
- ``init()``: sends ``receiveFeatureReport(0x05)`` when connected over Bluetooth to switch into full-report mode.
- ``parseReport()``: extended to also return ``sticks``, ``triggers``, and ``buttons`` (face, shoulders, options, stick clicks, dpad, PS) alongside the existing gyro/accel/touchpad fields. USB 0x01 and BT 0x31 share a common layout with a single-byte shift, handled via a ``baseOffset`` constant.

**``controller-overlay/src/js/app.js``**
- New module state ``syntheticGamepad`` + helpers ``createSyntheticGamepad()`` and ``updateSyntheticFromParsed()`` that map the parsed HID fields into Chrome's Standard Gamepad layout.
- ``handleInputReport()`` populates the synthetic gamepad regardless of whether gyro is toggled on — otherwise turning gyro off on a BT DualSense would strand the user with no input source.
- ``readGamepad()`` prefers the real Gamepad API when available, falls back to the synthetic gamepad when it isn't. USB DualSense, Switch Pro, and Xbox paths all keep using the Gamepad API unchanged.
- ``bootstrapFromHID()`` probes ``navigator.hid.getDevices()`` at launch when the Gamepad API shows nothing, recovering the cold-start case where the controller is still in `0x31` mode from the previous session.
- ``disconnectGyro()`` clears ``syntheticGamepad`` and the first-report log flag so stale state can't leak across reconnects.

## Test plan

Tested on real hardware (macOS, Electron dev build):

- [x] **BT DualSense — fresh pair**: power-cycle controller, launch overlay. ``gamepadconnected`` fires, HID connects 2s later, both gyro and sticks/buttons work.
- [x] **BT DualSense — cold start in `0x31` mode**: quit and relaunch without power-cycling. ``bootstrapFromHID`` finds the granted device, HID connects, both gyro and sticks/buttons work — no power-cycle required.
- [x] **USB DualSense**: unchanged — Gamepad API path remains authoritative.
- [x] **Switch Pro**: unchanged — not a DualSense, ``init()`` no-ops the BT trick.

## Deferred

A known multi-controller edge case (Switch Pro USB + DualSense BT, ``connectControllerGyro`` picks the wrong HID device) is documented on #189 and explicitly deferred to the local-multiplayer work — the same comment explains why WebHID device ↔ Gamepad API slot binding is a prerequisite for main-game local co-op with gyro.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)