### PR TITLE
Port Switch Pro Bluetooth gyro fix from controller-overlay into main game

### DIFF
--- a/js/controllers/switch-pro-driver.js
+++ b/js/controllers/switch-pro-driver.js
@@ -30,38 +30,91 @@ export class SwitchProDriver extends ControllerDriver {
     this._packetNumber = 0;
     this._debugCount = 0;
     this._reportIds = new Set();
+    this._initSuccess = false;
+    // Declared byte count for output report 0x01. USB Switch Pro declares
+    // 48+ bytes, BT declares a smaller count. Computed from device.collections
+    // at init() time. Null means "unknown — use the USB default size of 49."
+    this._output01Size = null;
+  }
+
+  /**
+   * Inspect device.collections and find the declared byte size for an
+   * output report. Returns null if the report isn't declared anywhere —
+   * _sendSubCommand will then fall back to a sensible default.
+   */
+  _declaredOutputSize(reportId) {
+    if (!this.device || !this.device.collections) return null;
+    for (const col of this.device.collections) {
+      const reports = col.outputReports || [];
+      for (const r of reports) {
+        if (r.reportId !== reportId) continue;
+        let bits = 0;
+        for (const item of r.items || []) {
+          bits += (item.reportSize || 0) * (item.reportCount || 0);
+        }
+        if (bits > 0) return Math.ceil(bits / 8);
+      }
+    }
+    return null;
   }
 
   /**
    * Switch Pro requires sub-commands to enable IMU and full report mode.
-   * Must be called after device.open().
+   * Over BT, the output report 0x01 is declared with a smaller byte count
+   * than USB, so we size the sub-command buffer from device.collections
+   * instead of hard-coding 49. Retries in case the device isn't ready
+   * immediately after open().
    */
   async init() {
-    try {
-      // Enable IMU (sub-command 0x40, arg 0x01)
-      await this._sendSubCommand(0x40, [0x01]);
-      await SwitchProDriver._delay(100);
+    const MAX_ATTEMPTS = 3;
 
-      // Set input report mode to 0x30 (full report with IMU)
-      await this._sendSubCommand(0x03, [0x30]);
-      await SwitchProDriver._delay(100);
+    // Snapshot the declared output-report size so _sendSubCommand can match
+    // what the HID descriptor actually accepts. The previous hard-coded
+    // 49-byte buffer over-ran BT's declared size and made sendReport() fail
+    // with "Failed to write the report."
+    this._output01Size = this._declaredOutputSize(0x01);
+    console.log('Switch Pro: declared size for output 0x01 =',
+      this._output01Size == null ? 'unknown (using default 49)' : this._output01Size);
 
-      console.log('Switch Pro Controller: IMU enabled, full report mode set');
-    } catch (err) {
-      console.error('Switch Pro init failed:', err);
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        // Wait before sending commands — device needs time after open()
+        await SwitchProDriver._delay(attempt === 1 ? 200 : 500);
+
+        // Enable IMU (sub-command 0x40, arg 0x01)
+        await this._sendSubCommand(0x40, [0x01]);
+        await SwitchProDriver._delay(150);
+
+        // Set input report mode to 0x30 (full report with IMU)
+        await this._sendSubCommand(0x03, [0x30]);
+        await SwitchProDriver._delay(150);
+
+        this._initSuccess = true;
+        console.log('Switch Pro Controller: IMU enabled, full report mode set (attempt ' + attempt + ')');
+        return;
+      } catch (err) {
+        console.warn('Switch Pro init attempt ' + attempt + '/' + MAX_ATTEMPTS + ' failed:', err.message);
+        if (attempt < MAX_ATTEMPTS) {
+          await SwitchProDriver._delay(500);
+        }
+      }
     }
+
+    console.error('Switch Pro init failed after ' + MAX_ATTEMPTS + ' attempts');
   }
 
-  destroy() {}
+  destroy() {
+    this._initSuccess = false;
+  }
 
   parseReport(reportId, data) {
-    // Debug: log first 20 reports and all report IDs seen
+    // Log new report IDs for debugging
     if (!this._reportIds.has(reportId)) {
       this._reportIds.add(reportId);
       console.log('Switch Pro: new report ID 0x' + reportId.toString(16) +
         ', length=' + data.byteLength);
     }
-    if (this._debugCount < 20) {
+    if (this._debugCount < 5) {
       this._debugCount++;
       const bytes = [];
       for (let i = 0; i < Math.min(data.byteLength, 50); i++) {
@@ -75,24 +128,19 @@ export class SwitchProDriver extends ControllerDriver {
     if (reportId !== 0x30) return null;
 
     // Report 0x30 layout (DataView excludes report ID):
-    // Byte 0: timer
-    // Byte 1: battery + connection info
-    // Bytes 2-4: button status (3 bytes)
-    // Bytes 5-7: left stick (3 bytes packed)
-    // Bytes 8-10: right stick (3 bytes packed)
-    // Byte 11: vibrator input report
-    // Byte 12: padding
-    // Bytes 13-48: 3 IMU frames × 12 bytes each
+    //   Byte 0:     timer
+    //   Byte 1:     battery + connection info
+    //   Bytes 2-4:  button status (3 bytes)
+    //   Bytes 5-7:  left stick (3 bytes packed)
+    //   Bytes 8-10: right stick (3 bytes packed)
+    //   Byte 11:    vibrator input report
+    //   Bytes 12-47: 3 IMU frames × 12 bytes each
+    //     Each frame: [accelX(2), accelY(2), accelZ(2), gyroX(2), gyroY(2), gyroZ(2)]
     //
-    // Each IMU frame (12 bytes):
-    //   [accelX(2), accelY(2), accelZ(2), gyroX(2), gyroY(2), gyroZ(2)]
+    // Wire size: BT sends exactly 48 bytes; USB pads further. We only read the
+    // first IMU frame, so the true minimum is 24 bytes (header + frame 0).
 
-    if (data.byteLength < 49) {
-      if (this._debugCount <= 20) {
-        console.warn('Switch Pro: report too short:', data.byteLength);
-      }
-      return null;
-    }
+    if (data.byteLength < 24) return null;
 
     // IMU data starts at offset 12 (no padding byte after vibrator report)
     // Frame 0: offset 12, Frame 1: offset 24, Frame 2: offset 36
@@ -107,12 +155,6 @@ export class SwitchProDriver extends ControllerDriver {
     const rawGyroX = r(data, imuOffset + 6);
     const rawGyroY = r(data, imuOffset + 8);
     const rawGyroZ = r(data, imuOffset + 10);
-
-    // Debug: log first few parsed IMU values
-    if (this._debugCount <= 5) {
-      console.log('Switch Pro IMU raw: accel=(' + rawAccelX + ',' + rawAccelY + ',' + rawAccelZ +
-        ') gyro=(' + rawGyroX + ',' + rawGyroY + ',' + rawGyroZ + ')');
-    }
 
     // Remap axes to match DualSense convention so the game's steering (gz)
     // and drift correction (atan2(accelX, accelY)) work unchanged.
@@ -136,9 +178,24 @@ export class SwitchProDriver extends ControllerDriver {
   // ── Sub-command protocol ──
 
   async _sendSubCommand(subCmd, args = []) {
-    // Output report 0x01: rumble + sub-command
-    // Padded to 49 bytes (some firmware requires fixed report size)
-    const buf = new Uint8Array(49);
+    // Output report 0x01 layout (shared by USB and BT):
+    //   byte 0:    packet counter (nibble)
+    //   bytes 1-8: rumble data (8 bytes, neutral here)
+    //   byte 9:    sub-command ID
+    //   byte 10+:  sub-command args
+    //
+    // The total buffer size has to match what the HID descriptor declares
+    // for report 0x01 on this device — USB declares 48+ bytes, BT declares
+    // a smaller count. Over-sizing on BT causes sendReport to reject with
+    // "Failed to write the report." Under-sizing on USB truncates the
+    // rumble payload.
+    const minSize = 10 + args.length;
+    const declared = this._output01Size;
+    const bufSize = declared != null
+      ? Math.max(declared, minSize)
+      : Math.max(49, minSize);           // USB default when descriptor is silent
+
+    const buf = new Uint8Array(bufSize);
     buf[0] = this._packetNumber & 0x0F;
     this._packetNumber = (this._packetNumber + 1) & 0x0F;
 


### PR DESCRIPTION
## Summary

Port the Bluetooth Switch Pro gyro fix from petegordon/tandemonium#191 (which landed in the `controller-overlay/` sub-project) into the main game's parallel copy of the Switch Pro driver at `js/controllers/switch-pro-driver.js`.

The main game has been carrying the same two BT-breaking bugs that the overlay fix identified:

1. **`parseReport()` rejected reports shorter than 49 bytes.** BT 0x30 input reports arrive at exactly 48 bytes (12-byte header + 3 × 12-byte IMU frames). USB pads further, so the old threshold *accidentally* worked there. Lowered the gate to 24 bytes — the real minimum for the single IMU frame we actually read.
2. **`_sendSubCommand()` hard-coded a 49-byte output buffer.** BT Switch Pro's HID descriptor declares output report `0x01` at a smaller byte count, so `sendReport()` rejected the oversize write with *"Failed to write the report"* — `init()` failed all retries, the IMU enable (`0x40`) and report-mode (`0x03`) sub-commands never landed, and the controller streamed `0x30` framing with all-zero IMU bytes. Now reads the declared size from `device.collections` via a new `_declaredOutputSize(reportId)` helper and sizes the sub-command buffer to match, falling back to `49` when no size is declared (USB path — descriptor is silent there, preserving the old behavior).

Also ports:
- The matching `init()` changes: retry up to 3× with longer delays (200 ms initial, 500 ms on retry; 150 ms between sub-commands instead of 100 ms).
- `_initSuccess` bookkeeping + `destroy()` reset.
- `parseReport()` debug-log cleanup (log first 5 reports instead of first 20).

The ported file is byte-for-byte identical to `controller-overlay/src/js/controllers/switch-pro-driver.js` in its executable code. Only a handful of inline comments differ in wording.

## What's intentionally NOT in this PR

- **`detectConnectionType()` stays hard-coded `'usb'`** — matches the overlay. The Switch Pro driver never reads `this.connectionType` in `parseReport()` or `init()`, so this is cosmetic. A proper BT detector wouldn't fix any real bug and would risk false positives on unusual HID descriptors.
- **DualSense Bluetooth full support** (port of petegordon/tandemonium#190) — the overlay's fix reads feature report `0x05` to unlock DualSense's full-report mode, but Chromium's Gamepad API *stops seeing the device* once it's in that mode. The overlay works around this by synthesizing a Gamepad-shaped object from parsed HID reports, which would require modifying `InputManager.pollGamepad` in the main game to fall through to HID-parsed state when `navigator.getGamepads()` returns nothing. That's a meaningfully larger refactor; deserves its own PR. I'll file a follow-up issue to track it.
- **Rumble via WebHID for DualSense on macOS** — separate issue, tracked at petegordon/tandemonium#193.

## Why this PR exists separately from the local multiplayer feature branch

This is a standalone correctness fix that benefits solo / online MP / local MP identically. Landing it on `main` first means:
- The upcoming local-MP feature PR (`feature/local-multiplayer`) can be rebased to pick it up and its BT test plan works out of the box.
- Anyone running solo mode on `main` with a BT Switch Pro also gets the fix immediately, without waiting for the local-MP work.

## Test plan

Needs manual hardware testing — no automated coverage for controller drivers.

- [ ] **Switch Pro over Bluetooth, solo ride:** gyro steers the bike (motion toggle lights up, lean responds to tilt). Console log should show `"Switch Pro: declared size for output 0x01 = <small number>"` and `"Switch Pro Controller: IMU enabled, full report mode set (attempt 1)"`.
- [ ] **Switch Pro over USB, solo ride:** gyro still works (regression check). Console log should show `"Switch Pro: declared size for output 0x01 = unknown (using default 49)"` or a larger declared size, and init succeeds on attempt 1.
- [ ] **Hot-swap BT→USB** on the same Switch Pro: gyro re-auto-connects correctly (uses the hot-swap path from the recent lobby-side fix on the feature branch, but this PR doesn't depend on that).
- [ ] **DualSense over USB, solo ride:** unchanged behavior — this PR doesn't touch the DualSense driver.
- [ ] **Online MP with BT Switch Pro as captain or stoker:** gyro feeds the expected side's lean.

## References

- **petegordon/tandemonium#191** — the original controller-overlay fix this PR ports.
- **petegordon/tandemonium#190** — DualSense BT support, deliberately deferred.
- **petegordon/tandemonium#192** — macOS Electron/Steam build issue where BT testing matters.
- **petegordon/tandemonium#193** — DualSense rumble on macOS (unrelated but same driver family).

https://claude.ai/code/session_01V3htCwRTeJvCosMgJCnXKf