### PR TITLE
Local multiplayer: same-screen co-op via JOIN RIDE on the host page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1874,6 +1874,28 @@
   .lobby-btn-accent:active {
     background: rgba(60,200,80,0.4);
   }
+  /* Player 2 color token for local multiplayer (JOIN RIDE, contribution bar, etc.) */
+  :root {
+    --tandem-player2: #ff4560;
+  }
+  .lobby-btn-p2 {
+    background: rgba(255, 69, 96, 0.22);
+    border-color: rgba(255, 69, 96, 0.7);
+    color: var(--tandem-player2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: calc(1 * var(--ls));
+  }
+  .lobby-btn-p2:hover { background: rgba(255, 69, 96, 0.35); border-color: rgba(255, 69, 96, 0.9); }
+  .lobby-btn-p2:active { background: rgba(255, 69, 96, 0.5); }
+  .btn-local-join-icons {
+    display: inline-flex;
+    gap: calc(0.6 * var(--ls));
+    font-size: 0.9em;
+  }
+  .btn-local-join-icons .join-icon-gp { color: var(--tandem-player2); }
+  .btn-local-join-icons .join-icon-kb { color: #ffffff; opacity: 0.9; }
   .lobby-layout {
     display: flex;
     align-items: center;
@@ -4041,6 +4063,14 @@ ON</button>
           <div id="room-url" class="room-url"></div>
           <p class="lobby-hint">Long-press URL or QR code to copy link</p>
           <div id="host-status" class="conn-status"></div>
+          <!-- Local multiplayer: JOIN RIDE offers same-screen co-op as an
+               alternative to waiting for a remote stoker. Visibility is
+               driven by _startLocalJoinMonitor in lobby.js. -->
+          <button class="lobby-btn lobby-btn-p2" id="btn-local-join-ride" style="display:none;">
+            <span class="btn-local-join-label">JOIN RIDE</span>
+            <span class="btn-local-join-icons" id="btn-local-join-icons"></span>
+          </button>
+          <p id="host-local-hint" class="lobby-hint" style="display:none;">Plug in a 2nd controller for local co-op</p>
           <button class="lobby-back" id="btn-back-role-host">&larr; Back</button>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -682,6 +682,9 @@
     background: #a6f;
     transition: width 0.5s;
   }
+  /* Local co-op: P1 green + P2 coral, replacing the online blue/purple. */
+  body.mode-local #contrib-captain { background: #00ff7a; }
+  body.mode-local #contrib-stoker { background: var(--tandem-player2); }
 
   /* ── Victory overlay ── */
   #victory-overlay {

--- a/index.html
+++ b/index.html
@@ -1881,7 +1881,8 @@
   :root {
     --tandem-player2: #ff4560;
   }
-  .lobby-btn-p2 {
+  /* Gamepad-P2 JOIN RIDE button: coral-red, flex layout for label + icon + pad name */
+  .lobby-btn-p2-gp {
     background: rgba(255, 69, 96, 0.22);
     border-color: rgba(255, 69, 96, 0.7);
     color: var(--tandem-player2);
@@ -1890,15 +1891,22 @@
     justify-content: center;
     gap: calc(1 * var(--ls));
   }
-  .lobby-btn-p2:hover { background: rgba(255, 69, 96, 0.35); border-color: rgba(255, 69, 96, 0.9); }
-  .lobby-btn-p2:active { background: rgba(255, 69, 96, 0.5); }
-  .btn-local-join-icons {
-    display: inline-flex;
-    gap: calc(0.6 * var(--ls));
-    font-size: 0.9em;
+  .lobby-btn-p2-gp:hover { background: rgba(255, 69, 96, 0.35); border-color: rgba(255, 69, 96, 0.9); }
+  .lobby-btn-p2-gp:active { background: rgba(255, 69, 96, 0.5); }
+  /* Keyboard-P2 JOIN RIDE button: neutral white/grey so it reads as "the other option" */
+  .lobby-btn-p2-kb {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.5);
+    color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: calc(1 * var(--ls));
   }
-  .btn-local-join-icons .join-icon-gp { color: var(--tandem-player2); }
-  .btn-local-join-icons .join-icon-kb { color: #ffffff; opacity: 0.9; }
+  .lobby-btn-p2-kb:hover { background: rgba(255, 255, 255, 0.2); border-color: rgba(255, 255, 255, 0.7); }
+  .lobby-btn-p2-kb:active { background: rgba(255, 255, 255, 0.3); }
+  .btn-local-join-icon { font-size: 1.1em; }
+  .btn-local-join-padname { font-size: 0.85em; opacity: 0.9; }
   .lobby-layout {
     display: flex;
     align-items: center;
@@ -4066,12 +4074,19 @@ ON</button>
           <div id="room-url" class="room-url"></div>
           <p class="lobby-hint">Long-press URL or QR code to copy link</p>
           <div id="host-status" class="conn-status"></div>
-          <!-- Local multiplayer: JOIN RIDE offers same-screen co-op as an
-               alternative to waiting for a remote stoker. Visibility is
-               driven by _startLocalJoinMonitor in lobby.js. -->
-          <button class="lobby-btn lobby-btn-p2" id="btn-local-join-ride" style="display:none;">
-            <span class="btn-local-join-label">JOIN RIDE</span>
-            <span class="btn-local-join-icons" id="btn-local-join-icons"></span>
+          <!-- Local multiplayer: one JOIN RIDE button per available P2 path.
+               The monitor (lobby._startLocalJoinMonitor) shows/hides each
+               button based on connected devices. Each button commits to a
+               specific P2 device — no auto-picking. -->
+          <button class="lobby-btn lobby-btn-p2-gp" id="btn-local-join-gp" style="display:none;">
+            <span>JOIN RIDE</span>
+            <span class="btn-local-join-icon">&#127918;</span>
+            <span class="btn-local-join-padname" id="btn-local-join-gp-name">CONTROLLER</span>
+          </button>
+          <button class="lobby-btn lobby-btn-p2-kb" id="btn-local-join-kb" style="display:none;">
+            <span>JOIN RIDE</span>
+            <span class="btn-local-join-icon">&#9000;&#65039;</span>
+            <span>KEYBOARD</span>
           </button>
           <p id="host-local-hint" class="lobby-hint" style="display:none;">Plug in a 2nd controller for local co-op</p>
           <button class="lobby-back" id="btn-back-role-host">&larr; Back</button>

--- a/index.html
+++ b/index.html
@@ -1881,15 +1881,17 @@
   :root {
     --tandem-player2: #ff4560;
   }
-  /* Gamepad-P2 JOIN RIDE button: coral-red, flex layout for label + icon + pad name */
+  /* Gamepad-P2 JOIN RIDE button: coral-red, two-line stacked layout (label + icon on top, device name below in smaller type) */
   .lobby-btn-p2-gp {
     background: rgba(255, 69, 96, 0.22);
     border-color: rgba(255, 69, 96, 0.7);
     color: var(--tandem-player2);
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: calc(1 * var(--ls));
+    gap: calc(0.5 * var(--ls));
+    line-height: 1.1;
   }
   .lobby-btn-p2-gp:hover { background: rgba(255, 69, 96, 0.35); border-color: rgba(255, 69, 96, 0.9); }
   .lobby-btn-p2-gp:active { background: rgba(255, 69, 96, 0.5); }
@@ -1899,14 +1901,26 @@
     border-color: rgba(255, 255, 255, 0.5);
     color: #ffffff;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: calc(1 * var(--ls));
+    gap: calc(0.5 * var(--ls));
+    line-height: 1.1;
   }
   .lobby-btn-p2-kb:hover { background: rgba(255, 255, 255, 0.2); border-color: rgba(255, 255, 255, 0.7); }
   .lobby-btn-p2-kb:active { background: rgba(255, 255, 255, 0.3); }
-  .btn-local-join-icon { font-size: 1.1em; }
-  .btn-local-join-padname { font-size: 0.85em; opacity: 0.9; }
+  .btn-local-join-main {
+    display: inline-flex;
+    align-items: center;
+    gap: calc(0.8 * var(--ls));
+  }
+  .btn-local-join-icon { font-size: 1em; }
+  .btn-local-join-padname {
+    font-size: 0.6em;
+    opacity: 0.85;
+    letter-spacing: 0.12em;
+    font-weight: 600;
+  }
   .lobby-layout {
     display: flex;
     align-items: center;
@@ -4079,14 +4093,12 @@ ON</button>
                button based on connected devices. Each button commits to a
                specific P2 device — no auto-picking. -->
           <button class="lobby-btn lobby-btn-p2-gp" id="btn-local-join-gp" style="display:none;">
-            <span>JOIN RIDE</span>
-            <span class="btn-local-join-icon">&#127918;</span>
+            <span class="btn-local-join-main">JOIN RIDE <span class="btn-local-join-icon">&#127918;</span></span>
             <span class="btn-local-join-padname" id="btn-local-join-gp-name">CONTROLLER</span>
           </button>
           <button class="lobby-btn lobby-btn-p2-kb" id="btn-local-join-kb" style="display:none;">
-            <span>JOIN RIDE</span>
-            <span class="btn-local-join-icon">&#9000;&#65039;</span>
-            <span>KEYBOARD</span>
+            <span class="btn-local-join-main">JOIN RIDE <span class="btn-local-join-icon">&#9000;&#65039;</span></span>
+            <span class="btn-local-join-padname">KEYBOARD</span>
           </button>
           <p id="host-local-hint" class="lobby-hint" style="display:none;">Plug in a 2nd controller for local co-op</p>
           <button class="lobby-back" id="btn-back-role-host">&larr; Back</button>

--- a/js/contribution-tracker.js
+++ b/js/contribution-tracker.js
@@ -5,7 +5,7 @@
 
 export class ContributionTracker {
   constructor(mode) {
-    this.mode = mode; // 'solo' | 'captain' | 'stoker'
+    this.mode = mode; // 'solo' | 'captain' | 'stoker' | 'local'
 
     // Per-player stats
     this.captain = this._emptyStats();

--- a/js/controllers/controller-registry.js
+++ b/js/controllers/controller-registry.js
@@ -70,16 +70,45 @@ export class ControllerRegistry {
    * Find a previously-approved device from navigator.hid.getDevices()
    * that matches any registered driver with the requested capability.
    * @param {string} capability — 'gyro', 'accel', or 'touchpad'
+   * @param {{vendorId?: number, productId?: number}} [filter] — optional
+   *   vendor/product filter so a caller can demand a SPECIFIC physical
+   *   device rather than "any approved gyro device" (critical for local
+   *   multiplayer where two controllers are attached and each player
+   *   needs their own gyro pipeline wired to the correct physical pad).
    * @returns {Promise<HIDDevice|null>}
    */
-  static async findApprovedDevice(capability) {
+  static async findApprovedDevice(capability, filter = null) {
     if (!navigator.hid) return null;
     const devices = await navigator.hid.getDevices();
     for (const device of devices) {
       const D = ControllerRegistry.getDriver(device.vendorId, device.productId);
-      if (D && D.capabilities[capability]) return device;
+      if (!D || !D.capabilities[capability]) continue;
+      if (filter) {
+        if (filter.vendorId !== undefined && device.vendorId !== filter.vendorId) continue;
+        if (filter.productId !== undefined && device.productId !== filter.productId) continue;
+      }
+      return device;
     }
     return null;
+  }
+
+  /**
+   * Parse the vendor and product IDs out of a Gamepad API `gamepad.id`
+   * string. Browsers format these as e.g.
+   *   "DualSense Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 0ce6)"
+   * This helper extracts the hex values so callers can pass them as a
+   * filter to findApprovedDevice() or navigator.hid.requestDevice().
+   * @param {string} idString
+   * @returns {{vendorId: number, productId: number}|null}
+   */
+  static parseGamepadVendorProduct(idString) {
+    if (!idString) return null;
+    const m = String(idString).match(/Vendor:\s*([0-9a-fA-F]+)\s+Product:\s*([0-9a-fA-F]+)/);
+    if (!m) return null;
+    const vendorId = parseInt(m[1], 16);
+    const productId = parseInt(m[2], 16);
+    if (Number.isNaN(vendorId) || Number.isNaN(productId)) return null;
+    return { vendorId, productId };
   }
 
   /**

--- a/js/game.js
+++ b/js/game.js
@@ -23,7 +23,7 @@ import { GrassParticles } from './grass-particles.js';
 import { Lobby } from './lobby.js';
 import { GameRecorder } from './game-recorder.js';
 import { ArchIndicator } from './arch-indicator.js';
-import { hapticCrash, hapticTreeHit, hapticCheckpoint, hapticFinish, hapticOffRoad } from './haptics.js';
+import { hapticCrash, hapticTreeHit, hapticCheckpoint, hapticFinish, hapticOffRoad, setHapticSources } from './haptics.js';
 import { DDAManager } from './dda-manager.js';
 import * as analytics from './analytics.js';
 import { perfProbe } from './perf-probe.js';
@@ -133,6 +133,9 @@ class Game {
 
     // Components
     this.input = new InputManager();
+    // Default haptic target: P1's InputManager. Updated in _onLocalReady
+    // to include P2's InputManager so both players rumble on shared events.
+    setHapticSources([this.input]);
     this.pedalCtrl = new PedalController(this.input);
     this.balanceCtrl = new BalanceController(this.input);
     this.world = new World(this.scene, { lowEnd: this._lowQuality });
@@ -912,6 +915,10 @@ class Game {
     // Tag the body so local-mode-specific CSS (contribution bar recolor, etc.)
     // can take effect. Cleared in _returnToLobby.
     document.body.classList.add('mode-local');
+
+    // Route haptics to BOTH players in local MP so shared events (crash,
+    // checkpoint, off-road, finish) rumble each controller independently.
+    setHapticSources([this.input, this.inputP2]);
 
     // Auto-connect P2's WebHID gyro if P2 is on a gyro-capable gamepad.
     // Pinned to P2's specific vendor/product so P2's gyro pipeline lands
@@ -2362,6 +2369,8 @@ class Game {
       this.input.keyboardActive = true;
     }
     document.body.classList.remove('mode-local');
+    // Route haptics back to P1 only now that we're out of local MP.
+    setHapticSources([this.input]);
     // Room stays in recent rooms list for 5 min so players can rejoin
     this.mode = 'solo';
     this._lobbyBtn.textContent = 'LOBBY';

--- a/js/game.js
+++ b/js/game.js
@@ -907,6 +907,10 @@ class Game {
     const partnerTitle = document.querySelector('#partner-gauge .gauge-title');
     if (partnerTitle) partnerTitle.textContent = 'PLAYER 2';
 
+    // Tag the body so local-mode-specific CSS (contribution bar recolor, etc.)
+    // can take effect. Cleared in _returnToLobby.
+    document.body.classList.add('mode-local');
+
     // Show instructions (tap to start)
     this.state = 'instructions';
     this.instructionsEl.classList.remove('hidden');
@@ -2291,6 +2295,7 @@ class Game {
       // Re-enable P1 keyboard in case local MP had parked it (P2-keyboard case)
       this.input.keyboardActive = true;
     }
+    document.body.classList.remove('mode-local');
     // Room stays in recent rooms list for 5 min so players can rejoin
     this.mode = 'solo';
     this._lobbyBtn.textContent = 'LOBBY';

--- a/js/game.js
+++ b/js/game.js
@@ -149,11 +149,18 @@ class Game {
     }
 
     // Mode
-    this.mode = 'solo'; // 'solo' | 'captain' | 'stoker'
+    this.mode = 'solo'; // 'solo' | 'captain' | 'stoker' | 'local'
     this.net = null;
     this.sharedPedal = null;
     this.remoteBikeState = null;
     this.remoteLean = 0;
+    // Local multiplayer (same-screen): second InputManager + balance controller for P2.
+    // Created in _onLocalReady when P2 clicks JOIN RIDE on the host page; null otherwise.
+    this.inputP2 = null;
+    this.balanceCtrlP2 = null;
+    this._localP2Type = null; // 'gamepad' | 'keyboard'
+    this._mpPrevUpP2 = false;
+    this._mpPrevDownP2 = false;
     this._partnerHasTilt = undefined; // undefined = unknown, true/false = received
     this._onPartnerTiltStatus = null;
     this._partnerServerId = null;
@@ -456,6 +463,7 @@ class Game {
     this.lobby = new Lobby({
       onSolo: () => this._onSolo(),
       onMultiplayerReady: (net, mode) => this._onMultiplayerReady(net, mode),
+      onLocalReady: (opts) => this._onLocalReady(opts),
       input: this.input
     });
 
@@ -849,6 +857,57 @@ class Game {
     }
 
     // Show instructions
+    this.state = 'instructions';
+    this.instructionsEl.classList.remove('hidden');
+    this._setupStartHandler();
+  }
+
+  /**
+   * Enter local multiplayer mode. Called from the lobby when P2 clicks JOIN RIDE
+   * on the host room page. Sets up a second InputManager / BalanceController for P2
+   * and transitions to the pre-ride instructions screen.
+   *
+   * @param {Object} opts
+   * @param {InputManager} opts.inputP2 — pre-constructed P2 input manager
+   * @param {'gamepad'|'keyboard'} opts.sourceType — how P2 is driving input
+   */
+  _onLocalReady({ inputP2, sourceType }) {
+    this.mode = 'local';
+    this.net = null;
+    this.inputP2 = inputP2;
+    this._localP2Type = sourceType;
+    this.balanceCtrlP2 = new BalanceController(inputP2);
+    this._lobbyBtn.textContent = 'LOBBY';
+    this.bike.applyPreset(this.lobby.selectedPreset);
+    this._loadSavedTuning();
+
+    // Shared pedal controller: P1 taps as 'captain', P2 taps as 'stoker'.
+    this.sharedPedal = new SharedPedalController();
+
+    // If P2 is keyboard, P1 must release its keyboard subscription so random
+    // typing doesn't double-fire into both players.
+    if (sourceType === 'keyboard') {
+      this.input.keyboardActive = false;
+      this.input.keys = {};
+    }
+
+    // Reset edge-detect + remote-tap state for both players
+    this._mpPrevUp = false;
+    this._mpPrevDown = false;
+    this._mpPrevUpP2 = false;
+    this._mpPrevDownP2 = false;
+    this._remoteLastFoot = null;
+    this._remoteLastTapTime = 0;
+    this.remoteLean = 0;
+
+    // Partner gauge: show P2 lean + pedal indicators (reuses the online MP HUD)
+    document.getElementById('partner-gauge').style.display = '';
+    document.getElementById('partner-pedal-up').style.display = 'flex';
+    document.getElementById('partner-pedal-down').style.display = 'flex';
+    const partnerTitle = document.querySelector('#partner-gauge .gauge-title');
+    if (partnerTitle) partnerTitle.textContent = 'PLAYER 2';
+
+    // Show instructions (tap to start)
     this.state = 'instructions';
     this.instructionsEl.classList.remove('hidden');
     this._setupStartHandler();
@@ -2222,6 +2281,16 @@ class Game {
     this.recorder.clearPartnerStream();
     updateBadgeDisplay('partner-badges', []);
     if (this.net) { this.net.destroy(); this.net = null; }
+    // Local multiplayer teardown: release P2 InputManager + restore P1 keyboard
+    if (this.inputP2) {
+      this.inputP2 = null;
+      this.balanceCtrlP2 = null;
+      this._localP2Type = null;
+      this._mpPrevUpP2 = false;
+      this._mpPrevDownP2 = false;
+      // Re-enable P1 keyboard in case local MP had parked it (P2-keyboard case)
+      this.input.keyboardActive = true;
+    }
     // Room stays in recent rooms list for 5 min so players can rejoin
     this.mode = 'solo';
     this._lobbyBtn.textContent = 'LOBBY';
@@ -2836,6 +2905,7 @@ class Game {
 
     // Poll gamepad every frame before reading any input
     this.input.pollGamepad();
+    if (this.inputP2) this.inputP2.pollGamepad();
 
     // Start button → options overlay (available in all states)
     this._pollStartButton();
@@ -2870,6 +2940,8 @@ class Game {
         this._updateCaptain(dt);
       } else if (this.mode === 'stoker') {
         this._updateStoker(dt);
+      } else if (this.mode === 'local') {
+        this._updateLocal(dt);
       }
     } else {
       // Lobby / countdown / instructions / victory / gameover: render static scene
@@ -2885,6 +2957,7 @@ class Game {
 
     // Clear buffered tap flags after all input has been read this frame
     this.input.consumeTaps();
+    if (this.inputP2) this.inputP2.consumeTaps();
   }
 
   // ============================================================
@@ -3055,6 +3128,54 @@ class Game {
     this.archIndicator.update(this.bike, captainLean, this.remoteLean);
     this.renderer.render(this.scene, this.camera);
     this.recorder.composite(this._buildRecordState(this.sharedPedal, remoteData));
+  }
+
+  // ============================================================
+  // LOCAL UPDATE — same-screen co-op, no network
+  // P1 drives `this.input`; P2 drives `this.inputP2`.
+  // Reuses _updateCaptain for all physics/race/HUD logic by
+  // pre-populating `this.remoteLean` and the _remoteLastFoot/Time
+  // fields from P2's local inputs, so the captain path (which
+  // already averages captain + remote lean and feeds stoker taps
+  // into the shared pedal controller) works unchanged.
+  // ============================================================
+
+  _updateLocal(dt) {
+    // Feed bike speed to P2 input for velocity-dependent sensitivity
+    this.inputP2.bikeSpeed = this.bike.speed;
+    this.inputP2.bikeMaxSpeed = TUNE.maxSpeed || 19;
+
+    // Compute P2's lean via their own balance controller. The captain path
+    // will average (captainLean + this.remoteLean) * 0.5, so stashing P2's
+    // lean into this.remoteLean makes the existing math Just Work.
+    const balanceResultP2 = this.balanceCtrlP2.update(this.bike, 0, null, null);
+    this.remoteLean = balanceResultP2.leanInput;
+
+    // Edge-detect P2 pedals → feed as the 'stoker' source into the shared
+    // pedal controller. The captain path does the same for its own ('captain')
+    // inputs, so offset pedaling emerges naturally.
+    const upHeld2 = this.inputP2.isPressed('ArrowLeft');
+    const downHeld2 = this.inputP2.isPressed('ArrowRight');
+    const now = performance.now();
+    if (upHeld2 && !this._mpPrevUpP2) {
+      this.sharedPedal.receiveTap('stoker', 'up');
+      this._remoteLastFoot = 'up';
+      this._remoteLastTapTime = now;
+    }
+    if (downHeld2 && !this._mpPrevDownP2) {
+      this.sharedPedal.receiveTap('stoker', 'down');
+      this._remoteLastFoot = 'down';
+      this._remoteLastTapTime = now;
+    }
+    this._mpPrevUpP2 = upHeld2;
+    this._mpPrevDownP2 = downHeld2;
+
+    // Delegate to the captain update path. It reads `this.input` for P1 pedals
+    // + own lean, and `this.remoteLean` / `this._remoteLastFoot` / `this._remoteLastTapTime`
+    // for P2's contribution (already populated above). All network sends in
+    // _updateCaptain are guarded by `if (this.net)` which is null in local mode,
+    // so they no-op safely.
+    this._updateCaptain(dt);
   }
 
   // ============================================================

--- a/js/game.js
+++ b/js/game.js
@@ -161,6 +161,7 @@ class Game {
     this._localP2Type = null; // 'gamepad' | 'keyboard'
     this._mpPrevUpP2 = false;
     this._mpPrevDownP2 = false;
+    this._localP2Disconnected = false;
     this._partnerHasTilt = undefined; // undefined = unknown, true/false = received
     this._onPartnerTiltStatus = null;
     this._partnerServerId = null;
@@ -2292,6 +2293,7 @@ class Game {
       this._localP2Type = null;
       this._mpPrevUpP2 = false;
       this._mpPrevDownP2 = false;
+      this._localP2Disconnected = false;
       // Re-enable P1 keyboard in case local MP had parked it (P2-keyboard case)
       this.input.keyboardActive = true;
     }
@@ -3146,6 +3148,28 @@ class Game {
   // ============================================================
 
   _updateLocal(dt) {
+    // Mid-ride disconnect: if P2 is on a gamepad that just dropped, pause the
+    // ride and show a reconnect overlay. Physics + race timer freeze until the
+    // gamepad comes back (or the player quits via the overlay's Return button).
+    if (this._localP2Type === 'gamepad' && !this.inputP2.gamepadConnected) {
+      if (!this._localP2Disconnected) {
+        this._localP2Disconnected = true;
+        this._reconnecting = true; // shared flag with online MP freezes raceManager
+        this._showDisconnect('Player 2 controller disconnected');
+      }
+      // Render a still frame so the world doesn't look crashed, but skip
+      // physics, race progress, input reads, and P2 polling entirely.
+      this.renderer.render(this.scene, this.camera);
+      return;
+    }
+    if (this._localP2Disconnected) {
+      // Gamepad came back — hide overlay and resume.
+      this._localP2Disconnected = false;
+      this._reconnecting = false;
+      document.getElementById('disconnect-overlay').style.display = 'none';
+      if (this._clearOverlayButtons) this._clearOverlayButtons();
+    }
+
     // Feed bike speed to P2 input for velocity-dependent sensitivity
     this.inputP2.bikeSpeed = this.bike.speed;
     this.inputP2.bikeMaxSpeed = TUNE.maxSpeed || 19;

--- a/js/game.js
+++ b/js/game.js
@@ -1129,6 +1129,7 @@ class Game {
     this.raceManager = new RaceManager(level);
     this.hud.raceManager = this.raceManager;
     this.balanceCtrl.resetSteerFrames();
+    if (this.balanceCtrlP2) this.balanceCtrlP2.resetSteerFrames();
     this.contributionTracker = new ContributionTracker(this.mode);
     if (this.collectibleManager) this.collectibleManager.destroy();
     this.collectibleManager = new CollectibleManager(this.scene, this.world.roadPath, level, this.camera, difficultyName);
@@ -1892,7 +1893,9 @@ class Game {
     const level = this.lobby.selectedLevel;
     // Victory title includes role in multiplayer
     const victoryTitle = document.getElementById('victory-title');
-    if (this.mode === 'captain' || this.mode === 'stoker') {
+    if (this.mode === 'local') {
+      victoryTitle.textContent = 'YOU BOTH MADE IT!';
+    } else if (this.mode === 'captain' || this.mode === 'stoker') {
       victoryTitle.textContent = 'YOU MADE IT ' + this.mode.toUpperCase() + '!';
     } else {
       victoryTitle.textContent = 'YOU MADE IT!';
@@ -1937,7 +1940,10 @@ class Game {
       if (summary.collectibles > 0) {
         right.push({ icon: collectIcon, value: '' + summary.collectibles });
       }
-      if (summary.inputSource && summary.inputSource !== 'none') {
+      // Top grid shows a single input source for solo / online MP. In local
+      // mode we skip it here because the contribution breakdown below shows
+      // BOTH players' input sources per-column (no need to duplicate P1's).
+      if (this.mode !== 'local' && summary.inputSource && summary.inputSource !== 'none') {
         right.push({ icon: inputSourceEmoji[summary.inputSource] || '', value: summary.inputSource });
       }
 
@@ -1977,15 +1983,33 @@ class Game {
 
       statsEl.innerHTML = html;
 
-      // Multiplayer contribution breakdown
+      // Multiplayer contribution breakdown (online captain/stoker OR local co-op)
       if (soloStats && soloStats.mode === 'multiplayer') {
         const contrib = soloStats;
+        const isLocal = this.mode === 'local';
+        // In local mode we know both players' input sources because both
+        // InputManagers live on this machine; in online mode we only know
+        // our own side's, so the partner column is left without an icon.
+        const p1SteerSource = this.balanceCtrl ? this.balanceCtrl.getSteerSource() : 'none';
+        const p2SteerSource = (isLocal && this.balanceCtrlP2) ? this.balanceCtrlP2.getSteerSource() : 'none';
+        const sourceIcon = (src) => {
+          if (!src || src === 'none') return '';
+          return inputSourceEmoji[src] || '';
+        };
+        const captainLabel = isLocal ? 'P1 CAPTAIN' : 'CAPTAIN';
+        const stokerLabel = isLocal ? 'P2 STOKER' : 'STOKER';
+        const p1SourceRow = isLocal && p1SteerSource !== 'none'
+          ? '<div>' + sourceIcon(p1SteerSource) + ' <strong>' + p1SteerSource + '</strong></div>'
+          : '';
+        const p2SourceRow = isLocal && p2SteerSource !== 'none'
+          ? '<div>' + sourceIcon(p2SteerSource) + ' <strong>' + p2SteerSource + '</strong></div>'
+          : '';
         const contribDiv = document.createElement('div');
         contribDiv.className = 'victory-contrib';
         contribDiv.innerHTML =
           '<div class="victory-contrib-header">' +
-            '<span class="contrib-label captain-label">CAPTAIN ' + contrib.captain.overallPct + '%</span>' +
-            '<span class="contrib-label stoker-label">STOKER ' + contrib.stoker.overallPct + '%</span>' +
+            '<span class="contrib-label captain-label">' + captainLabel + ' ' + contrib.captain.overallPct + '%</span>' +
+            '<span class="contrib-label stoker-label">' + stokerLabel + ' ' + contrib.stoker.overallPct + '%</span>' +
           '</div>' +
           '<div class="victory-contrib-bar">' +
             '<div class="contrib-fill-captain" style="width:' + contrib.captain.overallPct + '%"></div>' +
@@ -1993,11 +2017,13 @@ class Game {
           '</div>' +
           '<div class="victory-contrib-detail">' +
             '<div class="contrib-col">' +
+              p1SourceRow +
               '<div>\uD83E\uDDB6 <strong>' + contrib.captain.totalTaps + '</strong></div>' +
               '<div>\u2696\uFE0F <strong>' + contrib.captain.safePct + '%</strong></div>' +
               '<div>\uD83D\uDEE3\uFE0F <strong>' + contrib.captain.onRoadPct + '%</strong></div>' +
             '</div>' +
             '<div class="contrib-col">' +
+              p2SourceRow +
               '<div>\uD83E\uDDB6 <strong>' + contrib.stoker.totalTaps + '</strong></div>' +
               '<div>\u2696\uFE0F <strong>' + contrib.stoker.safePct + '%</strong></div>' +
               '<div>\uD83D\uDEE3\uFE0F <strong>' + contrib.stoker.onRoadPct + '%</strong></div>' +

--- a/js/game.js
+++ b/js/game.js
@@ -28,6 +28,7 @@ import { DDAManager } from './dda-manager.js';
 import * as analytics from './analytics.js';
 import { perfProbe } from './perf-probe.js';
 import { detectHardware, getCachedProfile, clearHardwareCache } from './hardware-detect.js';
+import { ControllerRegistry } from './controllers/controller-registry.js';
 
 // Demo checkpoint limit removed — demo users play the tutorial instead
 const TUNING_KEY_PREFIX = 'tandemonium_motion_tuning';
@@ -912,10 +913,47 @@ class Game {
     // can take effect. Cleared in _returnToLobby.
     document.body.classList.add('mode-local');
 
+    // Auto-connect P2's WebHID gyro if P2 is on a gyro-capable gamepad.
+    // Pinned to P2's specific vendor/product so P2's gyro pipeline lands
+    // on P2's physical device — not whichever gyro-capable HID device
+    // findApprovedDevice happens to return first.
+    if (sourceType === 'gamepad') {
+      this._autoConnectP2Gyro();
+    }
+
     // Show instructions (tap to start)
     this.state = 'instructions';
     this.instructionsEl.classList.remove('hidden');
     this._setupStartHandler();
+  }
+
+  /**
+   * Try to wire P2's WebHID gyro to its physical gamepad in local MP.
+   * Parallels the lobby's _autoConnectGyro for P1 but targets this.inputP2,
+   * and pins the claim by vendor/product so it can't grab P1's device.
+   * Best-effort: if P2's controller hasn't been WebHID-approved before,
+   * silently skip. P2 still plays with joystick lean.
+   */
+  _autoConnectP2Gyro() {
+    if (!this.inputP2) return;
+    const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
+    const gp = gamepads[this.inputP2._gamepadSlot];
+    if (!gp) return;
+    const info = ControllerRegistry.identifyFromGamepadId(gp.id);
+    if (!info || !info.hasGyro) return;
+    const filter = ControllerRegistry.parseGamepadVendorProduct(gp.id);
+    if (!filter) return;
+    console.log('Auto-connecting P2 gyro for', info.driverName, filter);
+    this.inputP2.connectControllerGyro(filter).then(() => {
+      if (this.inputP2 && this.inputP2.gyroConnected) {
+        // Ensure P2's motion pipeline is armed so balanceCtrlP2 reads lean.
+        this.inputP2.motionEnabled = true;
+        this.inputP2.startTiltCalibration();
+        console.log('P2 gyro auto-connected');
+      }
+    }).catch((err) => {
+      console.warn('P2 gyro auto-connect failed:', err && err.message);
+    });
   }
 
   // ============================================================

--- a/js/haptics.js
+++ b/js/haptics.js
@@ -18,9 +18,52 @@ if (typeof document !== 'undefined') {
 
 let _offRoadThrottleUntil = 0;
 
+// Targeted haptic sources: a list of objects (typically InputManager
+// instances) whose `.gamepadIndex` property identifies which gamepads
+// should rumble. In solo / online MP this is just [P1's InputManager];
+// in local multiplayer it's [P1 InputManager, P2 InputManager] so both
+// players feel shared events like crashes and checkpoints. Resolving
+// indices fresh on each call handles hot-swap automatically — when a
+// controller is unplugged the source's gamepadIndex goes null and we
+// skip it, and when a new pad is plugged in the updated index is read
+// on the next rumble. When null, fall back to the legacy "first pad
+// with a vibration actuator" behavior so this module stays usable
+// standalone.
+let _hapticSources = null;
+
+/**
+ * Set the list of input sources whose gamepads should receive haptic
+ * feedback. Each entry is an object with a numeric `gamepadIndex`
+ * property (null when no gamepad is claimed). Pass null to clear.
+ * @param {Array<{gamepadIndex: number|null}>|null} sources
+ */
+export function setHapticSources(sources) {
+  _hapticSources = sources && sources.length > 0 ? sources : null;
+}
+
 function _gamepadRumble(strong, weak, duration) {
   try {
     const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
+    if (_hapticSources) {
+      // Targeted: rumble the specific gamepad index of each source.
+      // Multiple sources in local MP means both players feel the event.
+      for (const src of _hapticSources) {
+        if (!src) continue;
+        const idx = src.gamepadIndex;
+        if (idx == null) continue;
+        const gp = gamepads[idx];
+        if (!gp || !gp.vibrationActuator) continue;
+        gp.vibrationActuator.playEffect('dual-rumble', {
+          startDelay: 0,
+          duration,
+          weakMagnitude: weak,
+          strongMagnitude: strong,
+        });
+      }
+      return;
+    }
+    // Fallback: first-found pad (legacy behavior for modules that
+    // haven't registered targets yet).
     for (const gp of gamepads) {
       if (!gp || !gp.vibrationActuator) continue;
       gp.vibrationActuator.playEffect('dual-rumble', {

--- a/js/hud.js
+++ b/js/hud.js
@@ -234,12 +234,18 @@ export class HUD {
       this.touchLeftEl.classList.toggle('idle-pulse', isIdle);
       this.touchRightEl.classList.toggle('idle-pulse', isIdle);
 
-      // Stoker self-flash: instant visual confirmation of own pedal taps
+      // Stoker self-flash: instant visual confirmation of own pedal taps.
+      // SharedPedalController.wasCorrect/wasWrong fire on ANY tap (captain OR
+      // stoker), so we only attribute a flash to the local pedal button when
+      // the local player is actually holding a pedal this frame. Without this
+      // gate, a stoker tap (online partner, or P2 keyboard in local MP) would
+      // phantom-flash the captain's own big pedal button — which is the bug
+      // seen in local MP where pressing P2's arrow key lit up P1's pedal.
       const newCorrect = pedalCtrl.wasCorrect && !this._prevOwnCorrect;
       const newWrong = pedalCtrl.wasWrong && !this._prevOwnWrong;
       this._prevOwnCorrect = !!pedalCtrl.wasCorrect;
       this._prevOwnWrong = !!pedalCtrl.wasWrong;
-      if (newCorrect || newWrong) {
+      if ((newCorrect || newWrong) && (leftHeld || rightHeld)) {
         this._ownFlashTimer = 0.2;
         this._ownFlashFoot = leftHeld ? 'left' : 'right';
         this._ownFlashWrong = newWrong;

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -9,7 +9,23 @@ import * as analytics from './analytics.js';
 const GYRO_CALIB_COUNT = 150;         // ~1.5s at 100Hz
 
 export class InputManager {
-  constructor() {
+  /**
+   * @param {Object} [options]
+   * @param {number|null} [options.gamepadSlot=null] — if set, only claim the gamepad at this index (for local-MP P2). null = claim first available (legacy behavior).
+   * @param {boolean} [options.enableKeyboard=true] — subscribe to window keydown/keyup.
+   * @param {boolean} [options.enableTouch=true] — subscribe to mobile touch events (still guarded by isMobile).
+   * @param {boolean} [options.enableMotion=true] — subscribe to device motion/orientation (still guarded by isMobile).
+   */
+  constructor(options = {}) {
+    const {
+      gamepadSlot = null,
+      enableKeyboard = true,
+      enableTouch = true,
+      enableMotion = true,
+    } = options;
+    this._gamepadSlot = gamepadSlot;
+    this.keyboardActive = enableKeyboard;
+
     this.keys = {};
     this.touchLeft = false;
     this.touchRight = false;
@@ -76,12 +92,12 @@ export class InputManager {
     this._accelRawZ = 0;
     this._accelRoll = 0;
 
-    this._setupKeyboard();
+    if (enableKeyboard) this._setupKeyboard();
     this._setupGamepad();
     if (isMobile) {
-      this._setupTouch();
-      this._setupMotion();
-      this._setupCalibration();
+      if (enableTouch) this._setupTouch();
+      if (enableMotion) this._setupMotion();
+      if (enableTouch || enableMotion) this._setupCalibration();
     }
   }
 
@@ -419,6 +435,10 @@ export class InputManager {
 
   _setupGamepad() {
     window.addEventListener('gamepadconnected', (e) => {
+      // Slot filter: if this instance is scoped to a specific gamepad index, ignore others.
+      if (this._gamepadSlot !== null && e.gamepad.index !== this._gamepadSlot) return;
+      // Sticky claim: once we've bound a gamepad, don't silently switch to a newly-connected one.
+      if (this.gamepadIndex !== null) return;
       this.gamepadIndex = e.gamepad.index;
       this.gamepadConnected = true;
       this._gpName = e.gamepad.id;
@@ -461,20 +481,27 @@ export class InputManager {
     // Polling fallback: detect gamepads even without events
     if (this.gamepadIndex === null) {
       const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
-      for (let i = 0; i < gamepads.length; i++) {
-        if (gamepads[i]) {
-          this.gamepadIndex = i;
-          this.gamepadConnected = true;
-          this._gpName = gamepads[i].id;
-          const pollInfo = ControllerRegistry.identifyFromGamepadId(gamepads[i].id);
-          analytics.setController(pollInfo ? pollInfo.driverName : gamepads[i].id, 'standard');
-          if (!this.suppressGamepadBadge) {
-            const badge = document.getElementById('gamepad-badge');
-            if (badge) badge.style.display = 'block';
-          }
-          const pedalBar = document.getElementById('pedal-bar');
-          if (pedalBar) pedalBar.classList.add('gamepad-active');
-          break;
+      // Slot filter: if scoped to a specific index, only try that one; otherwise take the first non-null.
+      const tryClaim = (i) => {
+        if (!gamepads[i]) return false;
+        this.gamepadIndex = i;
+        this.gamepadConnected = true;
+        this._gpName = gamepads[i].id;
+        const pollInfo = ControllerRegistry.identifyFromGamepadId(gamepads[i].id);
+        analytics.setController(pollInfo ? pollInfo.driverName : gamepads[i].id, 'standard');
+        if (!this.suppressGamepadBadge) {
+          const badge = document.getElementById('gamepad-badge');
+          if (badge) badge.style.display = 'block';
+        }
+        const pedalBar = document.getElementById('pedal-bar');
+        if (pedalBar) pedalBar.classList.add('gamepad-active');
+        return true;
+      };
+      if (this._gamepadSlot !== null) {
+        tryClaim(this._gamepadSlot);
+      } else {
+        for (let i = 0; i < gamepads.length; i++) {
+          if (tryClaim(i)) break;
         }
       }
     }
@@ -506,9 +533,13 @@ export class InputManager {
   }
 
   isPressed(code) {
-    if (code === 'ArrowLeft') return !!this.keys[code] || this.touchLeft || this._leftTapped || this._gpTriggerLeftPressed;
-    if (code === 'ArrowRight') return !!this.keys[code] || this.touchRight || this._rightTapped || this._gpTriggerRightPressed;
-    return !!this.keys[code];
+    // keyboardActive gates the raw key state so an InputManager instance can
+    // "release" the keyboard to another instance (local MP: P1 on gamepad
+    // stops reading keys when P2 is on keyboard).
+    const keyDown = this.keyboardActive && !!this.keys[code];
+    if (code === 'ArrowLeft') return keyDown || this.touchLeft || this._leftTapped || this._gpTriggerLeftPressed;
+    if (code === 'ArrowRight') return keyDown || this.touchRight || this._rightTapped || this._gpTriggerRightPressed;
+    return keyDown;
   }
 
   /** Clear buffered tap flags — call once per frame after all input reading. */

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -550,23 +550,39 @@ export class InputManager {
 
   // ── WebHID gyro (PlayStation controllers) ──────────────────
 
-  async connectControllerGyro() {
+  /**
+   * Request WebHID access to a controller's gyro and wire up the report
+   * handler. In local multiplayer two InputManager instances call this
+   * independently (one per player) and MUST land on their own physical
+   * device — pass a vendor/product filter to prevent cross-wiring.
+   *
+   * @param {{vendorId?: number, productId?: number}} [filter] — when
+   *   provided, both findApprovedDevice and the requestDevice fallback
+   *   are scoped to this specific physical controller. Without a filter
+   *   the first approved gyro device wins, which in a two-controller
+   *   session is non-deterministic.
+   */
+  async connectControllerGyro(filter = null) {
     if (this.gyroConnected || !navigator.hid) return;
 
-    const filters = ControllerRegistry.getHIDFilters();
+    // If a filter is supplied, narrow the WebHID request to just that
+    // physical device. Otherwise ask for all known gyro-capable drivers.
+    const hidFilters = filter
+      ? [{ vendorId: filter.vendorId, productId: filter.productId }]
+      : ControllerRegistry.getHIDFilters();
     let device;
 
     // In Electron/Steam, try getDevices() first (no user gesture needed),
     // then fall back to requestDevice() which triggers the auto-select handler.
     const isDesktop = window.steam || navigator.userAgent.includes('Electron');
     if (isDesktop) {
-      device = await ControllerRegistry.findApprovedDevice('gyro');
+      device = await ControllerRegistry.findApprovedDevice('gyro', filter);
       if (!device) {
-        const devices = await navigator.hid.requestDevice({ filters });
+        const devices = await navigator.hid.requestDevice({ filters: hidFilters });
         device = devices && devices[0];
       }
     } else {
-      const devices = await navigator.hid.requestDevice({ filters });
+      const devices = await navigator.hid.requestDevice({ filters: hidFilters });
       device = devices && devices[0];
     }
     if (!device) return;

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -473,6 +473,13 @@ export class InputManager {
         if (badge) badge.style.display = 'none';
         const pedalBar = document.getElementById('pedal-bar');
         if (pedalBar) pedalBar.classList.remove('gamepad-active');
+        // Tear down the WebHID gyro pipeline too — the controller that was
+        // feeding it is gone, so its inputreport handler is dead. Without
+        // this, gyroConnected stays true pointing at a stale device and
+        // subsequent connect events can't re-claim gyro for a new pad.
+        if (this.gyroConnected) {
+          this.disconnectControllerGyro();
+        }
       }
     });
   }

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -292,6 +292,7 @@ export class Lobby {
     this._setup();
     this._buildLeaderboardTabs();
     this._initBikeCarousel();
+    this._setupGamepadHotSwap();
 
 
 
@@ -1606,6 +1607,48 @@ export class Lobby {
     if (isDesktop && !this.motionActive) {
       setTimeout(() => this._autoConnectGyro(), 1000);
     }
+  }
+
+  /**
+   * Hot-swap support: when the user unplugs their active controller mid-lobby
+   * and plugs in a different one, clear the stale gyro-permission flags and
+   * retry auto-connect so the new device's gyro pipeline comes online. Without
+   * this, _motionPermitted stays true pointing at a dead HID device and
+   * _autoConnectGyro early-returns on subsequent controller plug-ins.
+   *
+   * InputManager's own gamepaddisconnected handler has already torn down
+   * gyroConnected + gyroDevice by the time our listeners fire (registration
+   * order: InputManager first from Game ctor, Lobby second).
+   */
+  _setupGamepadHotSwap() {
+    window.addEventListener('gamepaddisconnected', () => {
+      if (!this.input) return;
+      // If the unplugged controller was our active one AND we had motion
+      // wired to it, clear the motion state so the UI reflects reality and
+      // so a subsequent plug-in can re-auto-connect on the new device.
+      if (!this.input.gyroConnected && !this.input.gamepadConnected) {
+        if (this._motionPermitted || this.motionActive) {
+          console.log('Lobby: active gamepad disconnected, clearing motion state');
+          this._motionPermitted = false;
+          this.motionActive = false;
+          this._setToggleActive('motion', false);
+        }
+      }
+    });
+
+    window.addEventListener('gamepadconnected', () => {
+      if (!this.input || !navigator.hid) return;
+      // Only re-auto-connect if we aren't already wired to gyro. If we are,
+      // the existing claim is fine — leave it alone.
+      if (this._motionPermitted || this.motionActive) return;
+      // Defer a tick so Chromium has time to populate navigator.getGamepads()
+      // for the freshly-connected pad before _checkGamepadGyro reads it.
+      setTimeout(() => {
+        if (this.input && this.input.gamepadConnected) {
+          this._checkGamepadGyro();
+        }
+      }, 300);
+    });
   }
 
   /** Auto-connect gyro in Electron/Steam — no user gesture needed since

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -37,6 +37,7 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { NetworkManager } from './network-manager.js';
+import { InputManager } from './input-manager.js';
 import { isMobile, RELAY_URL, SITE_URL, BIKE_MODEL_PATH, TUNE, applySteeringFeel, snapshotTuningBase } from './config.js';
 import { LEVELS } from './race-config.js';
 import { AuthManager } from './auth.js';
@@ -109,16 +110,25 @@ const HOLIDAY_BIKES = {
 };
 
 export class Lobby {
-  constructor({ onSolo, onMultiplayerReady, input }) {
+  constructor({ onSolo, onMultiplayerReady, onLocalReady, input }) {
     this.onSolo = onSolo;
     this.onMultiplayerReady = onMultiplayerReady;
+    this.onLocalReady = onLocalReady;
     this.input = input; // InputManager — needed for iOS motion permission
     this.net = null;
     this.selectedLevel = LEVELS.find(l => !l.isTutorial) || LEVELS[0]; // default to first non-tutorial level
     this._forceWizard = false;
     this.selectedPresetKey = 'default';
     this.selectedDifficulty = 'chill'; // 'chill' | 'adventurous' | 'daredevil'
-    this._pendingMode = null; // 'solo' or 'multiplayer', set during level selection
+    this._pendingMode = null; // 'solo' | 'multiplayer' | 'local', set during level selection
+
+    // Local multiplayer (JOIN RIDE on host page): second InputManager is created
+    // here when P2 presses JOIN RIDE, then handed off to the game via onLocalReady.
+    this._localP2InputManager = null;
+    this._localP2Type = null; // 'gamepad' | 'keyboard'
+    this._localJoinMonitorRAF = null;
+    this._localLastUnclaimedGp = null;  // last detected unclaimed gamepad index
+    this._localLastJoinState = null;    // cached state string for dirty-checking
 
     this.lobbyEl = document.getElementById('lobby');
     this.modeStep = document.getElementById('lobby-mode');
@@ -522,7 +532,15 @@ export class Lobby {
       .forEach(s => s.style.display = 'none');
     step.style.display = 'flex';
     this._clearFocusHighlight();
+    const prevStep = this._currentStep;
     this._currentStep = step;
+
+    // Local-MP JOIN RIDE monitor: run only while the captain host page is visible.
+    if (step === this.hostStep) {
+      this._startLocalJoinMonitor();
+    } else if (prevStep === this.hostStep) {
+      this._stopLocalJoinMonitor();
+    }
 
     // Room step: toggle grid layout on lobby-card
     const lobbyCardEl = document.querySelector('.lobby-card');
@@ -772,7 +790,7 @@ export class Lobby {
       this._showRoomLevelsStep();
     });
 
-    // Levels step: START RIDE button — works for both solo and multiplayer
+    // Levels step: START RIDE button — works for solo, multiplayer, and local co-op
     document.getElementById('btn-start-ride').addEventListener('click', () => {
       if (this._pendingMode === 'multiplayer') {
         if (this._roomRole !== 'captain') return;
@@ -784,12 +802,34 @@ export class Lobby {
         }
         this.net.sendProfile({ type: 'startRide' });
         this._transitionToGame();
+      } else if (this._pendingMode === 'local') {
+        // Local same-screen co-op: hand off the pre-constructed P2 InputManager
+        // to the game. onLocalReady handles mode setup + instructions screen.
+        this._hideLobby();
+        this.onLocalReady({
+          inputP2: this._localP2InputManager,
+          sourceType: this._localP2Type,
+        });
       } else {
         // Solo: start game directly
         this._hideLobby();
         this.onSolo();
       }
     });
+
+    // JOIN RIDE button on the host page: local same-screen co-op entry point.
+    // Clicking it transitions the in-flight online session into a local ride.
+    const btnLocalJoin = document.getElementById('btn-local-join-ride');
+    if (btnLocalJoin) {
+      btnLocalJoin.addEventListener('click', () => {
+        const state = this._detectLocalP2State();
+        if (!state.available) return;
+        // Prefer gamepad when both paths are available; the explicit 🎮/⌨️
+        // chooser is a Stage 4 polish item.
+        const sourceType = state.hasGamepad ? 'gamepad' : 'keyboard';
+        this._onLocalJoinClick(sourceType, state.gpIndex);
+      });
+    }
 
     document.getElementById('btn-back-room').addEventListener('click', () => {
       // Leave room — destroy connection, return to role step
@@ -3432,6 +3472,169 @@ export class Lobby {
     this._hideLobby();
     // Fire multiplayer ready
     this.onMultiplayerReady(this.net, this._roomRole);
+  }
+
+  // ============================================================
+  // LOCAL MULTIPLAYER — JOIN RIDE on host page (same-screen co-op)
+  // ============================================================
+
+  /**
+   * Start the RAF loop that watches for a second input source while the
+   * captain is on the host room-code page. Each frame we detect whether a
+   * P2 path exists (second gamepad, or keyboard when P1 is on a gamepad)
+   * and update the JOIN RIDE button visual state. Also polls the unclaimed
+   * gamepad's A button so P2 can "click" JOIN RIDE with their own controller.
+   */
+  _startLocalJoinMonitor() {
+    if (isMobile) return; // Local MP is desktop-only.
+    const btn = document.getElementById('btn-local-join-ride');
+    const icons = document.getElementById('btn-local-join-icons');
+    const hint = document.getElementById('host-local-hint');
+    if (!btn) return;
+    this._localP2APrev = false;
+
+    const tick = () => {
+      if (this._currentStep !== this.hostStep) {
+        this._localJoinMonitorRAF = null;
+        return;
+      }
+      const state = this._detectLocalP2State();
+
+      // Update button visuals only when state changes (avoids layout churn).
+      const stateKey = `${state.available}|${state.hasGamepad}|${state.hasKeyboard}|${state.gpIndex}`;
+      if (stateKey !== this._localLastJoinState) {
+        this._localLastJoinState = stateKey;
+        if (state.available) {
+          btn.style.display = '';
+          if (hint) hint.style.display = 'none';
+          if (icons) {
+            let html = '';
+            if (state.hasGamepad) html += '<span class="join-icon-gp">🎮</span>';
+            if (state.hasKeyboard) html += '<span class="join-icon-kb">⌨️</span>';
+            icons.innerHTML = html;
+          }
+        } else {
+          btn.style.display = 'none';
+          if (hint) hint.style.display = state.hintVisible ? '' : 'none';
+        }
+      }
+
+      // Poll the unclaimed gamepad's A button so P2 can fire JOIN RIDE with
+      // their own controller (not P1's — which is still driving menu nav).
+      if (state.hasGamepad && state.gpIndex !== null) {
+        const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+        const gp = pads[state.gpIndex];
+        const aPressed = !!(gp && gp.buttons[0] && gp.buttons[0].pressed);
+        if (aPressed && !this._localP2APrev) {
+          this._localP2APrev = true;
+          this._onLocalJoinClick('gamepad', state.gpIndex);
+          return;
+        }
+        if (!aPressed) this._localP2APrev = false;
+      }
+
+      this._localJoinMonitorRAF = requestAnimationFrame(tick);
+    };
+    this._localJoinMonitorRAF = requestAnimationFrame(tick);
+  }
+
+  _stopLocalJoinMonitor() {
+    if (this._localJoinMonitorRAF !== null) {
+      cancelAnimationFrame(this._localJoinMonitorRAF);
+      this._localJoinMonitorRAF = null;
+    }
+    this._localLastJoinState = null;
+    this._localP2APrev = false;
+  }
+
+  /**
+   * Determine whether a P2 input path exists right now.
+   * @returns {{available: boolean, hasGamepad: boolean, hasKeyboard: boolean, gpIndex: number|null, hintVisible?: boolean}}
+   */
+  _detectLocalP2State() {
+    const p1GpIndex = this.input.gamepadIndex;
+    const gamepads = (navigator.getGamepads ? navigator.getGamepads() : []) || [];
+    // Find the first attached gamepad that isn't P1's (note: the array can be
+    // sparse with holes at un-activated slots, so filter for truthy entries).
+    let unclaimedGpIndex = null;
+    for (let i = 0; i < gamepads.length; i++) {
+      if (gamepads[i] && i !== p1GpIndex) {
+        unclaimedGpIndex = i;
+        break;
+      }
+    }
+    const p1IsGamepad = p1GpIndex !== null;
+    // Keyboard is only a valid P2 input if P1 isn't using it (we block kb+kb
+    // because a single physical keyboard can't serve two players without key
+    // collisions on arrows / A / D).
+    const keyboardAvailable = p1IsGamepad;
+
+    if (unclaimedGpIndex !== null) {
+      return {
+        available: true,
+        hasGamepad: true,
+        hasKeyboard: keyboardAvailable,
+        gpIndex: unclaimedGpIndex,
+      };
+    }
+    if (keyboardAvailable) {
+      return {
+        available: true,
+        hasGamepad: false,
+        hasKeyboard: true,
+        gpIndex: null,
+      };
+    }
+    // P1 is on keyboard with no second gamepad → local MP blocked.
+    // Show a hint encouraging the captain to plug a controller in.
+    return {
+      available: false,
+      hasGamepad: false,
+      hasKeyboard: false,
+      gpIndex: null,
+      hintVisible: true,
+    };
+  }
+
+  /**
+   * Handle a JOIN RIDE click. Tears down any in-flight online MP session,
+   * constructs the P2 InputManager, and routes the captain directly to the
+   * level-select screen with _pendingMode='local'. The actual game-side
+   * setup happens on START RIDE via onLocalReady.
+   *
+   * @param {'gamepad'|'keyboard'} sourceType
+   * @param {number|null} gamepadSlot — gamepad index when sourceType is 'gamepad'
+   */
+  _onLocalJoinClick(sourceType, gamepadSlot) {
+    // Guard: if the monitor hasn't seen a P2 path, bail.
+    if (sourceType !== 'gamepad' && sourceType !== 'keyboard') return;
+    // Tear down the online MP attempt so the TNDM-XXXX room stops accepting
+    // remote stokers. Any in-flight online connection gets rejected.
+    if (this.net) {
+      try { this.net.destroy(); } catch (e) {}
+      this.net = null;
+    }
+    if (sourceType === 'gamepad') {
+      this._localP2InputManager = new InputManager({
+        gamepadSlot: gamepadSlot,
+        enableKeyboard: false,
+        enableMotion: false,
+        enableTouch: false,
+      });
+      this._localP2Type = 'gamepad';
+    } else {
+      // Keyboard P2: use a slot value that can never match a real gamepad.
+      this._localP2InputManager = new InputManager({
+        gamepadSlot: -1,
+        enableKeyboard: true,
+        enableMotion: false,
+        enableTouch: false,
+      });
+      this._localP2Type = 'keyboard';
+    }
+    this._pendingMode = 'local';
+    // Skip the room step; local co-op doesn't need social video prep.
+    this._showStep(this.levelStep);
   }
 
   _removePipLobbyMode() {

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -1609,7 +1609,11 @@ export class Lobby {
   }
 
   /** Auto-connect gyro in Electron/Steam — no user gesture needed since
-   *  WebHID permissions are granted via session handlers in main.js. */
+   *  WebHID permissions are granted via session handlers in main.js.
+   *  Passes a vendor/product filter so P1's gyro channel is pinned to
+   *  P1's actual physical controller instead of whichever gyro-capable
+   *  HID device happens to be approved first (critical when a second
+   *  controller is also attached for local co-op). */
   _autoConnectGyro() {
     if (this.motionActive || this._motionPermitted) return;
     const gamepads = navigator.getGamepads();
@@ -1617,8 +1621,9 @@ export class Lobby {
     const controllerInfo = gp ? ControllerRegistry.identifyFromGamepadId(gp.id) : null;
     if (!controllerInfo || !controllerInfo.hasGyro) return;
 
-    console.log('Auto-connecting gyro for', controllerInfo.driverName, 'in desktop mode...');
-    this.input.connectControllerGyro().then(() => {
+    const filter = gp ? ControllerRegistry.parseGamepadVendorProduct(gp.id) : null;
+    console.log('Auto-connecting gyro for', controllerInfo.driverName, 'in desktop mode...', filter);
+    this.input.connectControllerGyro(filter).then(() => {
       if (this.input.gyroConnected) {
         this._motionPermitted = true;
         this.motionActive = true;
@@ -1747,8 +1752,11 @@ export class Lobby {
         this._updateTutorialButton();
         return;
       }
-      // First time — request WebHID access
-      this.input.connectControllerGyro().then(() => {
+      // First time — request WebHID access, pinned to P1's physical gamepad
+      // so we don't grab a different controller that happens to be approved.
+      const gpForGyro = navigator.getGamepads()[this.input.gamepadIndex];
+      const filterForGyro = gpForGyro ? ControllerRegistry.parseGamepadVendorProduct(gpForGyro.id) : null;
+      this.input.connectControllerGyro(filterForGyro).then(() => {
         if (this.input.gyroConnected) {
           this._motionPermitted = true;
           this.motionActive = true;

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -3608,6 +3608,11 @@ export class Lobby {
   _onLocalJoinClick(sourceType, gamepadSlot) {
     // Guard: if the monitor hasn't seen a P2 path, bail.
     if (sourceType !== 'gamepad' && sourceType !== 'keyboard') return;
+    // Record that local JOIN RIDE won the race vs. any pending online stoker.
+    analytics.trackEvent('room_local_claimed', {
+      p2_source: sourceType,
+      had_net: !!this.net,
+    });
     // Tear down the online MP attempt so the TNDM-XXXX room stops accepting
     // remote stokers. Any in-flight online connection gets rejected.
     if (this.net) {

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -817,17 +817,23 @@ export class Lobby {
       }
     });
 
-    // JOIN RIDE button on the host page: local same-screen co-op entry point.
-    // Clicking it transitions the in-flight online session into a local ride.
-    const btnLocalJoin = document.getElementById('btn-local-join-ride');
-    if (btnLocalJoin) {
-      btnLocalJoin.addEventListener('click', () => {
+    // JOIN RIDE buttons on the host page: one per P2 path. Each button
+    // unambiguously commits to a specific device — no auto-picking when
+    // multiple options are present.
+    const btnJoinGp = document.getElementById('btn-local-join-gp');
+    if (btnJoinGp) {
+      btnJoinGp.addEventListener('click', () => {
         const state = this._detectLocalP2State();
-        if (!state.available) return;
-        // Prefer gamepad when both paths are available; the explicit 🎮/⌨️
-        // chooser is a Stage 4 polish item.
-        const sourceType = state.hasGamepad ? 'gamepad' : 'keyboard';
-        this._onLocalJoinClick(sourceType, state.gpIndex);
+        if (!state.hasGamepad || state.gpIndex === null) return;
+        this._onLocalJoinClick('gamepad', state.gpIndex);
+      });
+    }
+    const btnJoinKb = document.getElementById('btn-local-join-kb');
+    if (btnJoinKb) {
+      btnJoinKb.addEventListener('click', () => {
+        const state = this._detectLocalP2State();
+        if (!state.hasKeyboard) return;
+        this._onLocalJoinClick('keyboard', null);
       });
     }
 
@@ -3480,17 +3486,20 @@ export class Lobby {
 
   /**
    * Start the RAF loop that watches for a second input source while the
-   * captain is on the host room-code page. Each frame we detect whether a
-   * P2 path exists (second gamepad, or keyboard when P1 is on a gamepad)
-   * and update the JOIN RIDE button visual state. Also polls the unclaimed
-   * gamepad's A button so P2 can "click" JOIN RIDE with their own controller.
+   * captain is on the host room-code page. Each frame we detect whether
+   * a P2 path exists (second gamepad, or keyboard when P1 is on a gamepad)
+   * and show/hide the two JOIN RIDE buttons independently — one per P2
+   * device option, with the gamepad button labeled with the pad's name.
+   * Also polls the unclaimed gamepad's A button so P2 can fire JOIN RIDE
+   * with their own controller.
    */
   _startLocalJoinMonitor() {
     if (isMobile) return; // Local MP is desktop-only.
-    const btn = document.getElementById('btn-local-join-ride');
-    const icons = document.getElementById('btn-local-join-icons');
+    const btnGp = document.getElementById('btn-local-join-gp');
+    const btnKb = document.getElementById('btn-local-join-kb');
+    const gpNameEl = document.getElementById('btn-local-join-gp-name');
     const hint = document.getElementById('host-local-hint');
-    if (!btn) return;
+    if (!btnGp || !btnKb) return;
     this._localP2APrev = false;
 
     const tick = () => {
@@ -3500,27 +3509,27 @@ export class Lobby {
       }
       const state = this._detectLocalP2State();
 
-      // Update button visuals only when state changes (avoids layout churn).
-      const stateKey = `${state.available}|${state.hasGamepad}|${state.hasKeyboard}|${state.gpIndex}`;
+      // Dirty-check the visible state before touching the DOM (avoids layout
+      // churn every frame when nothing has changed).
+      const stateKey = `${state.hasGamepad}|${state.hasKeyboard}|${state.gpIndex}|${state.gpName}|${!!state.hintVisible}`;
       if (stateKey !== this._localLastJoinState) {
         this._localLastJoinState = stateKey;
-        if (state.available) {
-          btn.style.display = '';
-          if (hint) hint.style.display = 'none';
-          if (icons) {
-            let html = '';
-            if (state.hasGamepad) html += '<span class="join-icon-gp">🎮</span>';
-            if (state.hasKeyboard) html += '<span class="join-icon-kb">⌨️</span>';
-            icons.innerHTML = html;
-          }
-        } else {
-          btn.style.display = 'none';
-          if (hint) hint.style.display = state.hintVisible ? '' : 'none';
+        btnGp.style.display = state.hasGamepad ? '' : 'none';
+        btnKb.style.display = state.hasKeyboard ? '' : 'none';
+        if (state.hasGamepad && gpNameEl) {
+          gpNameEl.textContent = state.gpName || 'CONTROLLER';
+        }
+        if (hint) {
+          // Hint only appears when neither button is visible AND local MP
+          // is blocked (e.g. captain on keyboard, no gamepad attached).
+          hint.style.display = (!state.hasGamepad && !state.hasKeyboard && state.hintVisible) ? '' : 'none';
         }
       }
 
-      // Poll the unclaimed gamepad's A button so P2 can fire JOIN RIDE with
-      // their own controller (not P1's — which is still driving menu nav).
+      // Poll the unclaimed gamepad's A button so P2 can fire the 🎮 button
+      // with their own controller (not P1's — which is still driving menu
+      // navigation). No analogous poll for the ⌨️ button: browsers already
+      // fire click on Enter/Space when it's focused.
       if (state.hasGamepad && state.gpIndex !== null) {
         const pads = navigator.getGamepads ? navigator.getGamepads() : [];
         const gp = pads[state.gpIndex];
@@ -3548,8 +3557,9 @@ export class Lobby {
   }
 
   /**
-   * Determine whether a P2 input path exists right now.
-   * @returns {{available: boolean, hasGamepad: boolean, hasKeyboard: boolean, gpIndex: number|null, hintVisible?: boolean}}
+   * Determine whether a P2 input path exists right now, and what to label the
+   * gamepad button with when one is available.
+   * @returns {{available: boolean, hasGamepad: boolean, hasKeyboard: boolean, gpIndex: number|null, gpName: string|null, hintVisible?: boolean}}
    */
   _detectLocalP2State() {
     const p1GpIndex = this.input.gamepadIndex;
@@ -3557,9 +3567,11 @@ export class Lobby {
     // Find the first attached gamepad that isn't P1's (note: the array can be
     // sparse with holes at un-activated slots, so filter for truthy entries).
     let unclaimedGpIndex = null;
+    let unclaimedGpName = null;
     for (let i = 0; i < gamepads.length; i++) {
       if (gamepads[i] && i !== p1GpIndex) {
         unclaimedGpIndex = i;
+        unclaimedGpName = this._prettyGamepadName(gamepads[i].id);
         break;
       }
     }
@@ -3575,6 +3587,7 @@ export class Lobby {
         hasGamepad: true,
         hasKeyboard: keyboardAvailable,
         gpIndex: unclaimedGpIndex,
+        gpName: unclaimedGpName,
       };
     }
     if (keyboardAvailable) {
@@ -3583,6 +3596,7 @@ export class Lobby {
         hasGamepad: false,
         hasKeyboard: true,
         gpIndex: null,
+        gpName: null,
       };
     }
     // P1 is on keyboard with no second gamepad → local MP blocked.
@@ -3592,8 +3606,27 @@ export class Lobby {
       hasGamepad: false,
       hasKeyboard: false,
       gpIndex: null,
+      gpName: null,
       hintVisible: true,
     };
+  }
+
+  /**
+   * Resolve a raw `navigator.getGamepads()[i].id` string to a short display
+   * name for the JOIN RIDE button. Prefers the known-driver name from
+   * ControllerRegistry (e.g. "DualSense", "Switch Pro", "Xbox") and falls
+   * back to stripping the "(STANDARD GAMEPAD Vendor: xxxx Product: yyyy)"
+   * suffix browsers add to generic ids.
+   */
+  _prettyGamepadName(rawId) {
+    if (!rawId) return 'CONTROLLER';
+    const info = ControllerRegistry.identifyFromGamepadId(rawId);
+    if (info && info.driverName) return info.driverName.toUpperCase();
+    // Unknown device — strip the parenthetical suffix and uppercase.
+    let name = String(rawId).replace(/\s*\(.*\)\s*$/, '').trim();
+    if (!name) name = 'CONTROLLER';
+    if (name.length > 20) name = name.slice(0, 20) + '…';
+    return name.toUpperCase();
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds **same-screen local multiplayer** (local co-op) to Tandemonium. Two players on one machine share a single tandem bike via two independent `InputManager` instances feeding the existing `SharedPedalController`. No new physics, no changes to the network stack, no new lobby mode — the entry point is the existing RIDE TOGETHER → START A RIDE host room-code page.

Supported player pairings:

| P1 | P2 | Allowed? |
|---|---|---|
| Gamepad | 2nd gamepad | ✅ |
| Gamepad | Keyboard | ✅ |
| Keyboard | Gamepad | ✅ |
| Keyboard | Keyboard | ❌ (key collision on a single physical keyboard) |
| Mobile-only setup | — | ❌ (desktop only) |

Both players drive `SharedPedalController.receiveTap('captain'|'stoker', foot)` for the real offset-pedaling loop, and both players' lean is 50/50 averaged via the existing captain-path math — no game-mechanic asymmetry between online captain mode and local co-op.

## Commits (rebase-friendly, one logical chunk each)

1. **`6319019`** — `InputManager`: accept options for multi-instance support. New constructor options `{ gamepadSlot, enableKeyboard, enableTouch, enableMotion }`. Sticky claim on `gamepadconnected`. New `keyboardActive` flag so P1 can release its keyboard subscription when P2 is keyboard. Zero call-site changes for legacy modes.
2. **`6440505`** — `game`: add `'local'` mode + `_updateLocal(dt)` wrapper. P2 `BalanceController`, P2 pedal edge-detect feeding into `sharedPedal.receiveTap('stoker', …)`, then delegates to `_updateCaptain` for physics / race / HUD. Network sends no-op (`this.net === null` gates them). ContributionTracker accepts `'local'`.
3. **`4687eeb`** — `lobby`: JOIN RIDE button on host page for local co-op. `_startLocalJoinMonitor` RAF watches for a second P2 path and polls the unclaimed gamepad's A button so P2 can fire JOIN RIDE with their own pad. `_onLocalJoinClick` tears down any in-flight online session (`net.destroy()`) and jumps straight to level-select.
4. **`9327722`** — local MP: P1/P2 contribution bar recolor + `room_local_claimed` analytics. `body.mode-local` CSS class, coral-red P2 contribution bar.
5. **`3cc96a3`** — local MP: pause + disconnect overlay on mid-ride P2 pad loss. Reuses the existing `#disconnect-overlay`, freezes physics and race timer via `_reconnecting`, auto-resumes when the pad comes back.
6. **`d3b6e12`** — `lobby`: split JOIN RIDE into one button per P2 path. Fix for the "DualSense USB + forgotten Switch Pro Bluetooth" case where the monitor showed both 🎮 and ⌨️ icons on a single button and the click handler silently picked one. Now: separate 🎮 and ⌨️ buttons, 🎮 button labeled with the resolved controller name (`"DUALSENSE"`, `"SWITCH PRO"`, `"XBOX"`), no more auto-pick.
7. **`16ca43a`** — `lobby` + `hud`: stack JOIN RIDE button + fix phantom P1 pedal flash. Two-line button layout (label + icon on top, device name below in smaller type). HUD stoker self-flash gated on `leftHeld || rightHeld` so a stoker-side tap doesn't phantom-flash the captain's big pedal button (latent pre-existing bug, newly visible in local MP).
8. **`7198853`** — local MP: pin WebHID gyro to each player's physical controller. `ControllerRegistry.findApprovedDevice(capability, filter)` accepts vendor/product filter; new `parseGamepadVendorProduct(idString)` helper. `InputManager.connectControllerGyro(filter)` passes the filter to both `findApprovedDevice` and the `requestDevice` fallback. Lobby `_autoConnectGyro` and manual motion-toggle paths both pass P1's gamepad filter. New `Game._autoConnectP2Gyro` wires P2's gyro to its own physical device in local MP.
9. **`360c36c`** — local MP: show P1/P2 input per-player on the victory screen. "YOU BOTH MADE IT!" title, "P1 CAPTAIN" / "P2 STOKER" labels, per-player input-source row in each contribution column.
10. **`b17d355`** — controller hot-swap: recover gyro when active pad is replaced mid-lobby. `InputManager`'s `gamepaddisconnected` now tears down the gyro pipeline (so `gyroConnected` doesn't stay stuck on a dead HID device). New `Lobby._setupGamepadHotSwap` clears `_motionPermitted` / `motionActive` on disconnect and re-invokes `_checkGamepadGyro` on the next connect.
11. **`9d11872`** — `haptics`: target specific gamepads so rumble follows the actual player. New `setHapticSources(sources)` API — `_gamepadRumble` reads the current `gamepadIndex` from each source fresh (handles hot-swap for free) and rumbles each matching pad. In solo/online MP that's P1 only; in local MP it's `[P1, P2]` so shared events like crash and checkpoint rumble both pads simultaneously. Fixes a solo-mode regression where the Switch Pro was rumbling on DualSense crashes.
12. **`c929917`** — merge `main` into `feature/local-multiplayer`. Brings in **#194** (Switch Pro Bluetooth gyro driver fix ported from the controller-overlay) plus the two related overlay commits (**#190**, **#191**) that landed on main while this branch was in development. Auto-merge on `index.html` was trivial — different line regions — and no file touched by the feature branch collided with any of the merged-in work.

## What the branch explicitly does NOT do

- **No changes to the online MP network stack.** `NetworkManager` is untouched; PeerJS + Cloudflare relay still run exactly as before. Online MP's only interaction with this feature is that local JOIN RIDE on the host page tears down the in-flight online room (`net.destroy()`) so the online stoker gets a "room not found" error if they try to connect after local has claimed the room.
- **No DualSense Bluetooth full support.** Tracked separately — that port requires modifying `InputManager.pollGamepad` to fall through to HID-parsed state when Chromium's Gamepad API goes blind on BT DualSense (follow-up issue to come after this lands).
- **No DualSense rumble on macOS.** Tracked at petegordon/tandemonium#193.
- **No P2 role swap.** Current auto-detect picks "P1 = whoever already claimed a gamepad at lobby time, P2 = the other path." A captain who wants P1-keyboard + P2-gamepad with a single pad attached would need an explicit swap button — deferred as a Stage 4 polish item (noted in the spike plan at `docs/local-multiplayer-spike.md`).
- **No split-screen.** Tandemonium is a tandem bike. One camera, one bike, two players. This is correct.

## Design + decision log

Locked in during review (see `docs/local-multiplayer-spike.md` for the full record):

- **Captain/stoker asymmetry locally:** full equality, 50/50 lean average (same as online captain path).
- **Achievements:** local co-op counts as multiplayer for gating purposes.
- **Leaderboards:** local runs submit under P1's signed-in account with `mode: 'local'` in run metadata.
- **Entry point:** existing RIDE TOGETHER → START A RIDE host room-code page (no new mode card).
- **P2 color:** coral red `#ff4560`.
- **Kb + kb blocked:** single physical keyboard can't serve two players without colliding on arrow/A/D bindings.

## Scope of diff

```
 docs/ideal-customer-persona.md                  — already on main via #187
 docs/local-multiplayer-spike.md                 — already on main via #187
 index.html                                      | +105 −11
 js/contribution-tracker.js                      |   +1 −1
 js/controllers/controller-registry.js           |  +53 −4
 js/game.js                                      | +339 −6
 js/haptics.js                                   |  +47 −4
 js/hud.js                                       |  +12 −4
 js/input-manager.js                             |  +66 −22
 js/lobby.js                                     | +285 −11
```

~900 LoC net of the 12 commits above, spread across 8 files. No new dependencies, no new worker/backend changes, no new assets.

## Test plan

Manual hardware testing on the dev machine. Please check the following against your typical controller setup:

### Local multiplayer — base paths

- [ ] **Two gamepads, both USB** — P1 + P2 on separate pads. Both players can pedal and lean. Partner gauge shows P2's lean; purple arrows flash on P2 pedal input.
- [ ] **Two gamepads, one BT + one USB** — same as above. The 🎮 button on the host page should show the name of whichever pad isn't P1's (e.g. `"SWITCH PRO"` or `"DUALSENSE"`).
- [ ] **Two gamepads, both Bluetooth** — same as above. Note: Switch Pro BT gyro should work thanks to #194. DualSense BT gyro is a known limitation; it may need a separate PR.
- [ ] **Gamepad + keyboard (P2 keyboard)** — the ⌨️ button labeled `KEYBOARD` appears on the host page. Clicking it starts local co-op with P1 on the gamepad and P2 on the keyboard. P2 pedals with Arrow keys, leans with A/D. P1 keyboard is released (doesn't double-fire).
- [ ] **Single gamepad + keyboard** — only the ⌨️ button shows. Starting a ride works.
- [ ] **Zero gamepads** — ⌨️ button does NOT show (kb+kb blocked). Hint text appears on the host page.

### Local MP — gyro per player

- [ ] **Two USB gamepads, both gyro-capable** — P1 DualSense + P2 Switch Pro (or reversed). Tilting either pad steers only that player's contribution, not the other. No cross-wire.
- [ ] **Hot-swap mid-lobby** — plug in DualSense, enter host page, unplug, plug in Switch Pro. Gyro re-auto-connects to the new pad within ~1 second.
- [ ] **Switch Pro over Bluetooth gyro** — confirms #194 port works. Enable gyro on a BT-paired Switch Pro; lean works.

### Local MP — results screen

- [ ] **Finish a local ride.** Title reads `"YOU BOTH MADE IT!"`. Contribution bar labels are `"P1 CAPTAIN"` (green) and `"P2 STOKER"` (coral). Each column shows the player's input-source emoji and name (`🎮 gamepad-gyro`, `🕹️ gamepad`, `💻 keyboard`). Top grid does not duplicate the input-source row.

### Local MP — disconnect handling

- [ ] **Unplug P2's gamepad mid-ride.** Disconnect overlay appears, physics and race timer freeze. Replug the same pad: overlay disappears, ride resumes. Return to Lobby ends the ride cleanly, P1 solo mode is restored.

### Haptics

- [ ] **Solo ride with DualSense + Switch Pro both plugged in** (regression test for `9d11872`). Crash/tree hit/checkpoint/finish rumbles should fire on **whichever pad you're actually using as P1**, not "whichever pad Chromium lists first." (Note: DualSense may not rumble at all on macOS — tracked at petegordon/tandemonium#193, not a regression caused by this branch.)
- [ ] **Local MP with two gamepads, crash the bike.** **Both** pads should rumble simultaneously on shared events.

### Regression tests for existing modes

- [ ] **Solo keyboard** — pedal, lean, crash, finish. No change expected.
- [ ] **Solo gamepad** — pedal, lean, crash, finish. No change expected. Gyro path (`_autoConnectGyro`) still works thanks to the vendor/product filter fix.
- [ ] **Online captain** — create a room, remote stoker joins, complete a ride. No change expected. JOIN RIDE should not have fired (no local second gamepad).
- [ ] **Online stoker** — join a captain's room, ride. No change expected.
- [ ] **Tutorial (solo)** — runs through. No change expected.
- [ ] **Host room page shows JOIN RIDE buttons correctly on mobile**: they should **not** render (mobile is desktop-MP-only).

### Cross-platform

- [ ] **Electron macOS `npm start`** — full local-MP flow works, hot-swap works, BT Switch Pro gyro works.
- [ ] **Browser (Chrome/Edge)** — solo + online MP still works. Local MP doesn't need to work in browser for this PR (it's gated behind desktop), but nothing should regress.
- [ ] **Windows Electron build via `electron-forge make`** — smoke test that the main menu loads; in-depth local-MP testing on Windows can be a follow-up since local-MP was developed and tested on macOS first.

## Rollback plan

This is additive. Reverting the whole branch in one `git revert` would restore solo + online MP to exactly their pre-branch behavior. No migrations, no schema changes, no production infra touched.

## References

- **petegordon/tandemonium#187** — ICP persona + local multiplayer spike plan (design doc, already on main)
- **petegordon/tandemonium#188** — shared ride helpers refactor (already on main)
- **petegordon/tandemonium#194** — Switch Pro BT port (merged into main, now inherited by this branch)
- **petegordon/tandemonium#190**, **petegordon/tandemonium#191** — controller-overlay BT fixes that inspired #194
- **petegordon/tandemonium#192** — macOS Electron/Steam build (local MP needs to work there)
- **petegordon/tandemonium#193** — DualSense rumble on macOS (known limitation, not a regression)

https://claude.ai/code/session_01V3htCwRTeJvCosMgJCnXKf