### PR TITLE
InputManager: self-heal stuck-zero IMU after BT hot-swap race

### DIFF
--- a/index.html
+++ b/index.html
@@ -4294,7 +4294,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.c2a9c36 | 04-11-2026 17:50</span></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.d37f085 | 04-11-2026 18:13</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -9,6 +9,11 @@ import { setHapticSources } from './haptics.js';
 
 const GYRO_CALIB_COUNT = 150;         // ~1.5s at 100Hz
 
+// Stuck-IMU self-heal thresholds (see #198 — BT Switch Pro hot-swap race
+// with macOS Game Controller framework).
+const IMU_ZERO_TIMEOUT_MS = 500;      // how long zero IMU has to persist before we act
+const MAX_IMU_REINIT = 2;             // cap on driver.init() re-runs per connect session
+
 export class InputManager {
   /**
    * @param {Object} [options]
@@ -81,6 +86,17 @@ export class InputManager {
     this._lastGyroTime = 0;
     this._gyroReportHandler = null;
     this._accelVerified = false;     // accel byte offsets validated
+
+    // Stuck-IMU self-heal (see #198). When hot-swapping from a BT DualSense
+    // to a BT Switch Pro on macOS, the Switch Pro's IMU-enable sub-command
+    // races with macOS Game Controller framework's parallel SPI probes and
+    // the IMU ends up disabled — 0x30 reports keep arriving but their IMU
+    // byte range is all zeros. Detect that state post-calibration and
+    // re-run driver.init() to re-send the enable-IMU sub-command. Capped
+    // so a genuinely-broken controller can't loop forever.
+    this._imuZeroSince = 0;          // ms timestamp when we first saw zero IMU, 0 = not currently zero
+    this._imuReinitAttempts = 0;     // bounded by MAX_IMU_REINIT
+    this._imuReinitInFlight = false; // guard against re-entering during the init await
 
     // Synthetic gamepad built from HID input reports. Required because
     // DualSense over Bluetooth, once switched into 0x31 full-report mode,
@@ -838,6 +854,12 @@ export class InputManager {
     this._lastGyroTime = 0;
     this._accelVerified = false;
     this._syntheticGamepad = null;
+    // Reset the stuck-IMU self-heal budget so the next controller gets
+    // a fresh set of retries. Without this, two successive hot-swaps
+    // that both need self-heal would exhaust the cap on the second one.
+    this._imuZeroSince = 0;
+    this._imuReinitAttempts = 0;
+    this._imuReinitInFlight = false;
     setHapticSources(null);
   }
 
@@ -883,6 +905,27 @@ export class InputManager {
     this._gyroRollAccum = 0;
     this._lastGyroTime = 0;
     this.motionOffset = null;
+  }
+
+  /**
+   * Stuck-IMU recovery path (#198). Re-run the current driver's init()
+   * to re-send its enable-IMU sub-command, then restart the bias
+   * calibration so the new (hopefully non-zero) samples aren't averaged
+   * against the stale (0,0,0) readings from before the reset.
+   */
+  async _reinitDriverAndCalibrate() {
+    if (!this._controllerDriver) {
+      this._imuReinitInFlight = false;
+      return;
+    }
+    try {
+      await this._controllerDriver.init();
+      this._startGyroCalibration();
+    } catch (err) {
+      console.warn('Driver re-init failed:', err.message);
+    } finally {
+      this._imuReinitInFlight = false;
+    }
   }
 
   _finishGyroCalibration() {
@@ -998,6 +1041,33 @@ export class InputManager {
       if (this._gyroCalibSamples.length >= GYRO_CALIB_COUNT) this._finishGyroCalibration();
       this._lastGyroTime = now;
       return;
+    }
+
+    // Stuck-IMU self-heal: detect the BT Switch Pro hot-swap race (#198)
+    // where macOS's Game Controller framework disables the IMU shortly
+    // after our init() completes. Real IMU data is never all-zero across
+    // six axes — noise alone produces small non-zero values — so all six
+    // reading as exactly 0 for 500ms+ is unambiguously a stuck-IMU signal.
+    // When we detect it, re-run driver.init() to re-send the enable-IMU
+    // sub-command and restart calibration. Capped to avoid looping on a
+    // genuinely broken controller.
+    const imuIsZero = rawGx === 0 && rawGy === 0 && rawGz === 0 &&
+                      rawAx === 0 && rawAy === 0 && rawAz === 0;
+    if (imuIsZero) {
+      if (this._imuZeroSince === 0) this._imuZeroSince = now;
+      if (!this._imuReinitInFlight &&
+          (now - this._imuZeroSince) >= IMU_ZERO_TIMEOUT_MS &&
+          this._imuReinitAttempts < MAX_IMU_REINIT) {
+        this._imuReinitAttempts++;
+        this._imuZeroSince = 0;
+        this._imuReinitInFlight = true;
+        console.warn('IMU stuck at zero for ' + IMU_ZERO_TIMEOUT_MS +
+          'ms — re-running driver init (' + this._imuReinitAttempts +
+          '/' + MAX_IMU_REINIT + ')');
+        this._reinitDriverAndCalibrate();
+      }
+    } else if (this._imuZeroSince !== 0) {
+      this._imuZeroSince = 0;
     }
 
     // Apply bias correction


### PR DESCRIPTION
## Summary

- Fixes #198 — the DualSense BT → Switch Pro BT hot-swap edge case where macOS's Game Controller framework probes the Switch Pro via SPI flash reads concurrently with our own ``driver.init()``, ending up with IMU disabled and 0x30 reports streaming with zeroed-out IMU frames.
- Adds a small self-heal loop in ``_handleGyroReport`` that detects all-six-axes-zero IMU data, re-runs ``driver.init()``, and restarts calibration. Capped retries so a genuinely-broken controller can't loop forever.

## Background

Bug is documented in #198 with full repro steps, hex-dump analysis showing IMU getting disabled shortly after our init completes, and three proposed fix approaches. This PR implements option 1 (self-heal in ``InputManager``) because:

- It's the most surgical — contained entirely to ``InputManager``, no changes to ``SwitchProDriver`` or ``DualSenseDriver``.
- It's generic — works for any controller whose ``driver.init()`` is idempotent (both DualSense and Switch Pro are).
- It's a safety net — the detection is gated on an unambiguous signal (all six IMU axes exactly zero) so healthy controllers never false-positive.

The race is **flaky**: sometimes macOS finishes its probe before our init lands (hot-swap appears to "just work"), sometimes it clobbers us afterward. Either way, the self-heal is correct — silent when macOS cooperates, recovers within ~2s when it doesn't.

## Changes — ``js/input-manager.js``

**Constants**

- ``IMU_ZERO_TIMEOUT_MS = 500`` — how long a stuck-zero streak has to persist before we act. Long enough to ride out transient glitches; short enough that user recovery is ~2s (500ms detection + 1.5s recalibration).
- ``MAX_IMU_REINIT = 2`` — per-connect retry budget. If two reinits don't recover, the controller is genuinely broken and we stop trying.

**Constructor state**

- ``_imuZeroSince`` — ms timestamp of when the current zero streak began, ``0`` means "not currently in a zero streak."
- ``_imuReinitAttempts`` — counter, reset in ``disconnectControllerGyro()``.
- ``_imuReinitInFlight`` — guard against re-entering ``_reinitDriverAndCalibrate()`` during its ``await driver.init()``.

**Detection in ``_handleGyroReport()``**

Between the calibration branch and the bias-correction path:

```js
const imuIsZero = rawGx === 0 && rawGy === 0 && rawGz === 0 &&
                  rawAx === 0 && rawAy === 0 && rawAz === 0;
if (imuIsZero) {
  if (this._imuZeroSince === 0) this._imuZeroSince = now;
  if (!this._imuReinitInFlight &&
      (now - this._imuZeroSince) >= IMU_ZERO_TIMEOUT_MS &&
      this._imuReinitAttempts < MAX_IMU_REINIT) {
    // ... fire recovery ...
  }
} else if (this._imuZeroSince !== 0) {
  this._imuZeroSince = 0;
}
```

The ``else`` branch resets the streak whenever we see any non-zero value, so transient zero glitches don't accumulate.

**Recovery — ``_reinitDriverAndCalibrate()``**

```js
async _reinitDriverAndCalibrate() {
  if (!this._controllerDriver) { this._imuReinitInFlight = false; return; }
  try {
    await this._controllerDriver.init();
    this._startGyroCalibration();
  } catch (err) {
    console.warn('Driver re-init failed:', err.message);
  } finally {
    this._imuReinitInFlight = false;
  }
}
```

Both the Switch Pro and DualSense drivers' ``init()`` methods are idempotent — re-running them on an already-connected device just re-sends their enable sub-commands (or re-reads feature 0x05 for DualSense), with no side effects if IMU was already enabled.

**Disconnect reset**

``disconnectControllerGyro()`` clears all three self-heal fields so a subsequent connect starts with a fresh retry budget.

## Test plan

Tested on real hardware (macOS, Electron 33):

- [x] **DualSense BT → Switch Pro BT hot-swap**: IMU data present from the first 0x30 report (this run, macOS didn't race us), accel verified at 4257 ~ 4096, gyro bias non-zero. Self-heal silent but ready as a safety net.
- [x] **Fresh Switch Pro BT**: unchanged, no self-heal log, gyro works.
- [x] **Fresh DualSense BT**: unchanged, no self-heal log, gyro works.
- [x] **USB DualSense**: unchanged.
- [x] **USB Switch Pro**: unchanged.

## What the diagnostics will show when the race bites

If a future hot-swap run hits the bad timing window, the console will show:

```
IMU stuck at zero for 500ms — re-running driver init (1/2)
Switch Pro: declared size for output 0x01 = 48
Switch Pro Controller: IMU enabled, full report mode set (attempt 1)
Gyro bias: {...}
Accel verified, magnitude: 4257 expected ~4096
```

And the bike will tilt normally after that recovery cycle.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)