### PR TITLE
Online MP: stoker victory screen uses local steer source

### DIFF
--- a/index.html
+++ b/index.html
@@ -4294,7 +4294,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.d37f085 | 04-11-2026 18:13</span></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.3da51ea | 04-11-2026 18:17</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/js/game.js
+++ b/js/game.js
@@ -1921,6 +1921,16 @@ class Game {
     if (fromRemote && this._remoteFinishStats) {
       summary = this._remoteFinishStats.raceSummary;
       contribData = this._remoteFinishStats.contribSummary;
+      // Per-side fix: the captain's raceSummary carries the captain's own
+      // inputSource, which the stoker would otherwise display as if it were
+      // theirs (#196). Steering source is strictly local — it's never sent
+      // over the wire because BalanceController.getSteerSource() only sees
+      // the frames accumulated on this side. Overwrite with the stoker's
+      // own value here so the victory screen's input-source row matches
+      // what this player actually used.
+      if (this.mode === 'stoker' && this.balanceCtrl) {
+        summary = { ...summary, inputSource: this.balanceCtrl.getSteerSource() };
+      }
     } else if (this.raceManager) {
       this.raceManager.inputSource = this.balanceCtrl.getSteerSource();
       summary = this.raceManager.getSummary(this.bike.distanceTraveled);


### PR DESCRIPTION
## Summary

Fixes #196 — cosmetic bug where the stoker's victory screen in online multiplayer showed the captain's input source (🎮 gamepad-gyro) instead of the stoker's own (📱 motion).

## Root cause

\`js/game.js:_showVictory()\` copies \`summary\` from \`this._remoteFinishStats.raceSummary\` on the stoker side — but that summary is built from the captain's \`RaceManager\`, which holds the captain's own \`BalanceController.getSteerSource()\` value. Steering source is strictly local: \`BalanceController\` only sees the frames accumulated on this side and the value is never serialized across the wire. So the stoker displays the captain's mode as if it were their own.

## Fix

In the \`fromRemote\` branch of \`_showVictory\`, after copying the captain's authoritative race summary, overwrite \`inputSource\` with the stoker's own \`this.balanceCtrl.getSteerSource()\` value:

```js
if (fromRemote && this._remoteFinishStats) {
  summary = this._remoteFinishStats.raceSummary;
  contribData = this._remoteFinishStats.contribSummary;
  // Per-side fix: inputSource is strictly local and never sent over
  // the wire; the captain's value would otherwise appear on the
  // stoker's victory screen.
  if (this.mode === 'stoker' && this.balanceCtrl) {
    summary = { ...summary, inputSource: this.balanceCtrl.getSteerSource() };
  }
}
```

All other authoritative race stats (time, distance, crashes, checkpoints, collectibles) remain the captain's values — only this single per-side field is overwritten.

## Scope

- **Change size**: ~10 lines including comment. One branch of one function.
- **Affects**: online MP stoker victory screen only.
- **Unchanged**: captain victory (takes the \`else if\` branch and always computed locally), solo victory (same), local MP victory (\`this.mode === 'local'\`, skips the single-input row entirely — the contribution breakdown already shows per-player sources), tutorial.

## Test plan

- [ ] Online captain on desktop with gamepad + gyro. Online stoker on phone with device motion. Complete a level. Stoker's victory screen should show 📱 \`motion\`, not 🎮 \`gamepad-gyro\`.
- [ ] Regression: captain victory still shows captain's input source correctly.
- [ ] Regression: solo ride victory unchanged.
- [ ] Regression: local MP victory unchanged (top-grid input row is skipped; contribution breakdown shows both players).

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)