### PR TITLE
Local MP: fix P1/P2 slot race + captain/P2 controller visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -4324,7 +4324,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.e6c31ad | 04-11-2026 22:29</span></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.635d4b0 | 04-11-2026 22:34</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/index.html
+++ b/index.html
@@ -4324,7 +4324,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.635d4b0 | 04-11-2026 22:34</span></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.616e5c8 | 04-11-2026 22:39</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/index.html
+++ b/index.html
@@ -4324,7 +4324,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.48dd24d | 04-11-2026 22:11</span></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.e6c31ad | 04-11-2026 22:29</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/index.html
+++ b/index.html
@@ -1921,6 +1921,33 @@
     letter-spacing: 0.12em;
     font-weight: 600;
   }
+  /* Captain controller label — shows which physical controller is
+     currently assigned to P1 so the user can confirm before starting
+     local MP. Rendered above the JOIN RIDE buttons. */
+  .local-join-captain-label {
+    margin: calc(0.4 * var(--ls)) 0;
+    font-size: 0.75em;
+    color: var(--tandem-player1, #ffffff);
+    opacity: 0.85;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+  .local-join-captain-label span {
+    font-weight: 700;
+    letter-spacing: 0.12em;
+  }
+  /* Brief flash applied to btn-local-join-gp when P2 presses any button
+     on the unclaimed gamepad — gives the second player visible
+     confirmation that their controller is recognized as P2 without
+     having to commit to starting the ride. */
+  @keyframes btn-local-join-flash {
+    0%   { box-shadow: 0 0 0 0 rgba(255, 69, 96, 0.7); }
+    60%  { box-shadow: 0 0 0 calc(0.8 * var(--ls)) rgba(255, 69, 96, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(255, 69, 96, 0); }
+  }
+  .lobby-btn-p2-gp.p2-flash {
+    animation: btn-local-join-flash 450ms ease-out;
+  }
   .lobby-layout {
     display: flex;
     align-items: center;
@@ -4092,6 +4119,9 @@ ON</button>
                The monitor (lobby._startLocalJoinMonitor) shows/hides each
                button based on connected devices. Each button commits to a
                specific P2 device — no auto-picking. -->
+          <p id="local-join-captain-label" class="local-join-captain-label" style="display:none;">
+            Captain: <span id="local-join-captain-name">—</span>
+          </p>
           <button class="lobby-btn lobby-btn-p2-gp" id="btn-local-join-gp" style="display:none;">
             <span class="btn-local-join-main">JOIN RIDE <span class="btn-local-join-icon">&#127918;</span></span>
             <span class="btn-local-join-padname" id="btn-local-join-gp-name">CONTROLLER</span>
@@ -4294,7 +4324,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.91bff3f | 04-11-2026 21:48</span></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.48dd24d | 04-11-2026 22:11</span></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/js/arch-indicator.js
+++ b/js/arch-indicator.js
@@ -275,9 +275,9 @@ export class ArchIndicator {
     this._clearNeedles();
     this._mode = mode;
 
-    const isMultiplayer = (mode === 'captain' || mode === 'stoker');
-    const playerRole = mode === 'captain' ? 'YOU CAPTAIN' : mode === 'stoker' ? 'YOU STOKER' : 'YOU';
-    const partnerRole = mode === 'captain' ? 'STOKER' : 'CAPTAIN';
+    const isMultiplayer = (mode === 'captain' || mode === 'stoker' || mode === 'local');
+    const playerRole = mode === 'captain' ? 'YOU CAPTAIN' : mode === 'stoker' ? 'YOU STOKER' : mode === 'local' ? 'CAPTAIN' : 'YOU';
+    const partnerRole = mode === 'captain' ? 'STOKER' : mode === 'local' ? 'STOKER' : 'CAPTAIN';
 
     // Player needle — label on inner (bottom) edge of arch
     this._playerNeedle = this._buildNeedle(playerColor, 0.75, playerRole, ARCH_INNER - 0.35);

--- a/js/controllers/controller-registry.js
+++ b/js/controllers/controller-registry.js
@@ -75,12 +75,18 @@ export class ControllerRegistry {
    *   device rather than "any approved gyro device" (critical for local
    *   multiplayer where two controllers are attached and each player
    *   needs their own gyro pipeline wired to the correct physical pad).
+   * @param {HIDDevice[]} [excludeDevices] — HID devices to skip (already
+   *   claimed by another player). When two identical controllers are
+   *   connected, vendorId/productId can't distinguish them; this
+   *   exclude list is the only way to ensure P2 lands on a different
+   *   physical device than P1.
    * @returns {Promise<HIDDevice|null>}
    */
-  static async findApprovedDevice(capability, filter = null) {
+  static async findApprovedDevice(capability, filter = null, excludeDevices = []) {
     if (!navigator.hid) return null;
     const devices = await navigator.hid.getDevices();
     for (const device of devices) {
+      if (excludeDevices.length > 0 && excludeDevices.includes(device)) continue;
       const D = ControllerRegistry.getDriver(device.vendorId, device.productId);
       if (!D || !D.capabilities[capability]) continue;
       if (filter) {

--- a/js/game.js
+++ b/js/game.js
@@ -950,8 +950,14 @@ class Game {
     if (!info || !info.hasGyro) return;
     const filter = ControllerRegistry.parseGamepadVendorProduct(gp.id);
     if (!filter) return;
+    // Exclude P1's already-claimed HID device so P2 lands on a DIFFERENT
+    // physical device. When both players are on the same controller model
+    // (e.g., two DualSenses), vendorId/productId alone can't disambiguate
+    // — the exclude list is the only way to prevent both InputManagers
+    // from opening the same HID device and cross-wiring gyro/sticks.
+    const excludeDevices = this.input.gyroDevice ? [this.input.gyroDevice] : [];
     console.log('Auto-connecting P2 gyro for', info.driverName, filter);
-    this.inputP2.connectControllerGyro(filter).then(() => {
+    this.inputP2.connectControllerGyro(filter, excludeDevices).then(() => {
       if (this.inputP2 && this.inputP2.gyroConnected) {
         // Ensure P2's motion pipeline is armed so balanceCtrlP2 reads lean.
         this.inputP2.motionEnabled = true;

--- a/js/haptics.js
+++ b/js/haptics.js
@@ -41,6 +41,31 @@ export function setHapticSources(sources) {
   _hapticSources = sources && sources.length > 0 ? sources : null;
 }
 
+/**
+ * Add a single input source to the haptic target list without
+ * replacing existing sources. Used by connectControllerGyro so each
+ * InputManager independently registers itself — the previous
+ * setHapticSources([this]) call was replacing the whole array and
+ * dropping other players' sources in local MP.
+ * @param {{gamepadIndex: number|null}} src
+ */
+export function addHapticSource(src) {
+  if (!src) return;
+  if (!_hapticSources) _hapticSources = [];
+  if (!_hapticSources.includes(src)) _hapticSources.push(src);
+}
+
+/**
+ * Remove a single input source from the haptic target list.
+ * @param {{gamepadIndex: number|null}} src
+ */
+export function removeHapticSource(src) {
+  if (!_hapticSources || !src) return;
+  const idx = _hapticSources.indexOf(src);
+  if (idx >= 0) _hapticSources.splice(idx, 1);
+  if (_hapticSources.length === 0) _hapticSources = null;
+}
+
 function _gamepadRumble(strong, weak, duration) {
   try {
     const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import { isMobile, TUNE } from './config.js';
 import { ControllerRegistry } from './controllers/controller-registry.js';
 import * as analytics from './analytics.js';
-import { setHapticSources } from './haptics.js';
+import { setHapticSources, addHapticSource, removeHapticSource } from './haptics.js';
 
 const GYRO_CALIB_COUNT = 150;         // ~1.5s at 100Hz
 
@@ -821,8 +821,11 @@ export class InputManager {
     // Register this InputManager as a haptic target so js/haptics.js can
     // route rumble to our claimed gamepad (and, for DualSense, our driver's
     // WebHID rumble path as a fallback around Chromium's broken macOS
-    // vibrationActuator).
-    setHapticSources([this]);
+    // vibrationActuator). Use addHapticSource (not setHapticSources) so we
+    // don't clobber another player's registration in local MP — the old
+    // setHapticSources([this]) call replaced the whole array, dropping P1
+    // when P2 connected and vice versa.
+    addHapticSource(this);
 
     this.gyroConnected = true;
     this._startGyroCalibration();
@@ -930,7 +933,7 @@ export class InputManager {
     // Clear sensor fusion state too so the next controller starts with
     // a clean quaternion/gravity vector instead of the last one's pose.
     this._resetSensorFusionState();
-    setHapticSources(null);
+    removeHapticSource(this);
   }
 
   calibrateGyro() {

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -737,7 +737,7 @@ export class InputManager {
    *   the first approved gyro device wins, which in a two-controller
    *   session is non-deterministic.
    */
-  async connectControllerGyro(filter = null) {
+  async connectControllerGyro(filter = null, excludeDevices = []) {
     if (this.gyroConnected || !navigator.hid) return;
     // Concurrent-call guard: the lobby has two gamepadconnected listeners
     // (main + hot-swap) that both schedule _autoConnectGyro with different
@@ -769,7 +769,7 @@ export class InputManager {
       // then fall back to requestDevice() which triggers the auto-select handler.
       const isDesktop = window.steam || navigator.userAgent.includes('Electron');
       if (isDesktop) {
-        device = await ControllerRegistry.findApprovedDevice('gyro', filter);
+        device = await ControllerRegistry.findApprovedDevice('gyro', filter, excludeDevices);
         if (!device) {
           const devices = await navigator.hid.requestDevice({ filters: hidFilters });
           device = devices && devices[0];

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -3625,9 +3625,28 @@ export class Lobby {
     const btnGp = document.getElementById('btn-local-join-gp');
     const btnKb = document.getElementById('btn-local-join-kb');
     const gpNameEl = document.getElementById('btn-local-join-gp-name');
+    const capLabel = document.getElementById('local-join-captain-label');
+    const capNameEl = document.getElementById('local-join-captain-name');
     const hint = document.getElementById('host-local-hint');
     if (!btnGp || !btnKb) return;
     this._localP2APrev = false;
+    this._localP2AnyPrev = false;
+    this._localP2FlashTimer = null;
+
+    // Briefly flash btnGp's border so the second player gets visual
+    // confirmation that the system sees their button press. Covers the
+    // "which controller is P2?" UX ask from #204.
+    const flashP2Button = () => {
+      btnGp.classList.remove('p2-flash');
+      // Force a reflow so the animation re-runs if it was already playing.
+      void btnGp.offsetWidth;
+      btnGp.classList.add('p2-flash');
+      if (this._localP2FlashTimer) clearTimeout(this._localP2FlashTimer);
+      this._localP2FlashTimer = setTimeout(() => {
+        btnGp.classList.remove('p2-flash');
+        this._localP2FlashTimer = null;
+      }, 500);
+    };
 
     const tick = () => {
       if (this._currentStep !== this.hostStep) {
@@ -3638,13 +3657,24 @@ export class Lobby {
 
       // Dirty-check the visible state before touching the DOM (avoids layout
       // churn every frame when nothing has changed).
-      const stateKey = `${state.hasGamepad}|${state.hasKeyboard}|${state.gpIndex}|${state.gpName}|${!!state.hintVisible}`;
+      const stateKey = `${state.hasGamepad}|${state.hasKeyboard}|${state.gpIndex}|${state.gpName}|${state.p1GpName}|${!!state.hintVisible}`;
       if (stateKey !== this._localLastJoinState) {
         this._localLastJoinState = stateKey;
         btnGp.style.display = state.hasGamepad ? '' : 'none';
         btnKb.style.display = state.hasKeyboard ? '' : 'none';
         if (state.hasGamepad && gpNameEl) {
           gpNameEl.textContent = state.gpName || 'CONTROLLER';
+        }
+        // Captain label: show whenever at least one P2 path is available,
+        // so the user can verify which physical controller is captain vs
+        // which one will be P2.
+        if (capLabel && capNameEl) {
+          if (state.available && (state.p1GpName || state.hasKeyboard)) {
+            capNameEl.textContent = state.p1GpName || 'KEYBOARD';
+            capLabel.style.display = '';
+          } else {
+            capLabel.style.display = 'none';
+          }
         }
         if (hint) {
           // Hint only appears when neither button is visible AND local MP
@@ -3653,20 +3683,42 @@ export class Lobby {
         }
       }
 
-      // Poll the unclaimed gamepad's A button so P2 can fire the 🎮 button
+      // Poll the unclaimed gamepad's buttons so P2 can fire the 🎮 button
       // with their own controller (not P1's — which is still driving menu
       // navigation). No analogous poll for the ⌨️ button: browsers already
       // fire click on Enter/Space when it's focused.
+      //
+      // Two separate checks on the unclaimed pad:
+      //   1. A button (index 0) → commits to JOIN RIDE
+      //   2. Any button at all → triggers a brief visual flash on btnGp
+      //      so the second player gets confirmation their controller is
+      //      seen as P2 before they commit
       if (state.hasGamepad && state.gpIndex !== null) {
         const pads = navigator.getGamepads ? navigator.getGamepads() : [];
         const gp = pads[state.gpIndex];
-        const aPressed = !!(gp && gp.buttons[0] && gp.buttons[0].pressed);
-        if (aPressed && !this._localP2APrev) {
-          this._localP2APrev = true;
-          this._onLocalJoinClick('gamepad', state.gpIndex);
-          return;
+        if (gp) {
+          // Any-button flash (includes A, so flashing fires before the
+          // commit action but that's fine — commit still happens).
+          let anyPressed = false;
+          if (gp.buttons) {
+            for (let i = 0; i < gp.buttons.length; i++) {
+              if (gp.buttons[i] && gp.buttons[i].pressed) { anyPressed = true; break; }
+            }
+          }
+          if (anyPressed && !this._localP2AnyPrev) {
+            flashP2Button();
+          }
+          this._localP2AnyPrev = anyPressed;
+
+          // A-button commit
+          const aPressed = !!(gp.buttons[0] && gp.buttons[0].pressed);
+          if (aPressed && !this._localP2APrev) {
+            this._localP2APrev = true;
+            this._onLocalJoinClick('gamepad', state.gpIndex);
+            return;
+          }
+          if (!aPressed) this._localP2APrev = false;
         }
-        if (!aPressed) this._localP2APrev = false;
       }
 
       this._localJoinMonitorRAF = requestAnimationFrame(tick);
@@ -3679,16 +3731,37 @@ export class Lobby {
       cancelAnimationFrame(this._localJoinMonitorRAF);
       this._localJoinMonitorRAF = null;
     }
+    if (this._localP2FlashTimer) {
+      clearTimeout(this._localP2FlashTimer);
+      this._localP2FlashTimer = null;
+    }
+    const btnGp = document.getElementById('btn-local-join-gp');
+    if (btnGp) btnGp.classList.remove('p2-flash');
     this._localLastJoinState = null;
     this._localP2APrev = false;
+    this._localP2AnyPrev = false;
   }
 
   /**
    * Determine whether a P2 input path exists right now, and what to label the
    * gamepad button with when one is available.
-   * @returns {{available: boolean, hasGamepad: boolean, hasKeyboard: boolean, gpIndex: number|null, gpName: string|null, hintVisible?: boolean}}
+   * @returns {{available: boolean, hasGamepad: boolean, hasKeyboard: boolean, gpIndex: number|null, gpName: string|null, p1GpName?: string|null, hintVisible?: boolean}}
    */
   _detectLocalP2State() {
+    // Force P1 to claim a gamepad slot if it hasn't already, before we
+    // compute what's "unclaimed" for P2. Without this, if two gamepads
+    // were plugged in before launch (so neither triggered a
+    // gamepadconnected event) and the user clicks JOIN RIDE inside the
+    // ~1 second desktop gamepad poll window, this.input.gamepadIndex is
+    // still null — and the "first unclaimed" loop below picks slot 0 as
+    // P2. Then P1's pollGamepad later claims slot 0 too, and both
+    // InputManagers read the same physical controller while the second
+    // gamepad is completely ignored. Calling pollGamepad() synchronously
+    // runs P1's "first available" fallback so p1GpIndex is populated
+    // before the comparison. See #204 for the full repro.
+    if (this.input && this.input.gamepadIndex === null) {
+      this.input.pollGamepad();
+    }
     const p1GpIndex = this.input.gamepadIndex;
     const gamepads = (navigator.getGamepads ? navigator.getGamepads() : []) || [];
     // Find the first attached gamepad that isn't P1's (note: the array can be
@@ -3708,6 +3781,14 @@ export class Lobby {
     // collisions on arrows / A / D).
     const keyboardAvailable = p1IsGamepad;
 
+    // Captain's controller name for the UI label. If P1 is on a real
+    // gamepad, read the pretty name from this.input._gpName; otherwise
+    // it'll render as "Keyboard" (or just stay hidden if neither side
+    // has any input at all).
+    const p1GpName = (p1IsGamepad && this.input && this.input._gpName)
+      ? this._prettyGamepadName(this.input._gpName)
+      : null;
+
     if (unclaimedGpIndex !== null) {
       return {
         available: true,
@@ -3715,6 +3796,7 @@ export class Lobby {
         hasKeyboard: keyboardAvailable,
         gpIndex: unclaimedGpIndex,
         gpName: unclaimedGpName,
+        p1GpName,
       };
     }
     if (keyboardAvailable) {
@@ -3724,6 +3806,7 @@ export class Lobby {
         hasKeyboard: true,
         gpIndex: null,
         gpName: null,
+        p1GpName,
       };
     }
     // P1 is on keyboard with no second gamepad → local MP blocked.
@@ -3734,6 +3817,7 @@ export class Lobby {
       hasKeyboard: false,
       gpIndex: null,
       gpName: null,
+      p1GpName,
       hintVisible: true,
     };
   }


### PR DESCRIPTION
## Summary

Fixes #204 — three issues in the local-MP JOIN RIDE flow, all in one commit:

1. **Slot-assignment race fix**: P2 could steal P1's gamepad slot if both controllers were connected at launch and the user clicked JOIN RIDE within the first ~1 second before the desktop gamepad poll fired. Fixed by forcing ``this.input.pollGamepad()`` at the top of ``_detectLocalP2State()`` to claim P1's slot synchronously.

2. **Captain controller label**: new ``#local-join-captain-label`` element above the JOIN RIDE buttons showing "Captain: DualSense" (or "Captain: KEYBOARD") so the user can confirm which physical controller is captain before entering the ride.

3. **P2 button-press flash**: any button press on the unclaimed P2 gamepad now triggers a brief coral-red border-flash animation on the gamepad JOIN RIDE button, giving the second player visual confirmation that their controller is recognized as P2 without committing to start the ride. Previously only the A button was polled (and only for the commit action).

## Test plan

- [ ] Two DualSense controllers plugged in before launch → click JOIN RIDE quickly → both controllers get distinct slots, ride starts with independent input for each player
- [ ] Captain label shows correct controller name (or "KEYBOARD" if captain is keyboard)
- [ ] P2 label on the JOIN RIDE button shows correct controller name
- [ ] Pressing any button on the P2 controller produces a visible flash on the JOIN RIDE button
- [ ] A button on P2 controller commits to JOIN RIDE (unchanged behavior)
- [ ] Local MP ride: both players have independent pedaling + gyro
- [ ] Keyboard-as-P2 path still works (button shows "KEYBOARD", no flash behavior)
- [ ] Solo ride regression: no impact (local-join monitor only runs on the host step)

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)