### PR TITLE
Fix DualSense BT gyro drift between games (#213)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1492,6 +1492,10 @@ class Game {
     if (this.input.gyroConnected) {
       this.input.recenterGyro();
     }
+    // Local multiplayer: recenter P2's gyro too
+    if (this.inputP2 && this.inputP2.gyroConnected) {
+      this.inputP2.recenterGyro();
+    }
     // Mobile tilt calibration (10 samples, ~167ms)
     if (this.input.motionEnabled) {
       this.input.startTiltCalibration();

--- a/js/game.js
+++ b/js/game.js
@@ -1483,8 +1483,16 @@ class Game {
 
     this.chaseCamera.initialized = false;
 
-    // Only tilt calibration (10 samples, ~167ms) — NOT gyro calibration
-    // (150 samples, ~1.5s) which would conflict with the 3s countdown.
+    // Recenter gyro to absorb any orientation drift from the previous game.
+    // Without this, quaternion integration errors (especially over BT where
+    // report timing is jittery) accumulate across games and cause a persistent
+    // pull to one side. Full re-calibration (150 samples, ~1.5s) would
+    // conflict with the 3s countdown — recenter is instant and the continuous
+    // stillness calibration keeps the bias fresh in the background.
+    if (this.input.gyroConnected) {
+      this.input.recenterGyro();
+    }
+    // Mobile tilt calibration (10 samples, ~167ms)
     if (this.input.motionEnabled) {
       this.input.startTiltCalibration();
     }

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -950,6 +950,10 @@ export class InputManager {
     if (this._accelVerified && this._accelRoll != null) {
       this.motionOffset = -this._accelRoll;
     }
+    console.log('Gyro recentered: rollAccum=' + this._gyroRollAccum.toFixed(1) +
+      ' accelRoll=' + (this._accelRoll != null ? this._accelRoll.toFixed(1) : 'null') +
+      ' offset=' + (this.motionOffset != null ? this.motionOffset.toFixed(1) : 'null') +
+      ' conn=' + (this._gyroConnType || 'unknown'));
     this._gyroRollAccum = 0;
     this._resetSensorFusionState();
     // Don't reset _smoothedLean/motionLean — they're shared with mobile


### PR DESCRIPTION
## Summary
- Recenter gyro in `_resetGame()` so orientation quaternion drift doesn't carry across play-throughs
- Fixes persistent pull to one side observed on second game with DualSense over Bluetooth on Windows
- Added diagnostic logging to `recenterGyro()` for BT testing (visible in DevTools console)

## What changed
- `js/game.js`: Added `recenterGyro()` call in `_resetGame()` before countdown starts
- `js/input-manager.js`: Added console.log in `recenterGyro()` showing rollAccum, accelRoll, offset, and connection type

## Test plan
- [ ] Connect DualSense via Bluetooth on Windows with Steam running
- [ ] Play solo ride to completion (Grandma level, chill difficulty)
- [ ] On victory screen, check DevTools console — no freeze expected (also fixed in main via #212)
- [ ] Hit "Play Again" — check console for "Gyro recentered" log with sane values
- [ ] Second game should not pull left or right at start
- [ ] Verify USB DualSense still works normally (no regression)
- [ ] Verify recenter-on-L3-press still works during gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)