### PR TITLE
Move Cyclone A/B-swap quirk into SwitchProDriver (#224 step 4)

### DIFF
--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -503,9 +503,9 @@ export class InputManager {
       this.gamepadIndex = e.gamepad.index;
       this.gamepadConnected = true;
       this._gpName = e.gamepad.id;
-      // GameSir Cyclone reports as "Gamepad" with Switch Pro vendor/product (057e:2009)
-      // but has rotated face button mapping — swap A/B to fix confirm/back
-      this._gpSwapAB = /^Gamepad/i.test(e.gamepad.id) && /057e/i.test(e.gamepad.id);
+      // Per-device quirks (e.g. GameSir Cyclone's swapped A/B) live on the
+      // driver — registry dispatches by gamepad.id.
+      this._gpSwapAB = !!ControllerRegistry.getGamepadQuirks(e.gamepad.id).swapAB;
       console.log('Gamepad connected:', e.gamepad.id, this._gpSwapAB ? '(A/B swapped)' : '');
       const info = ControllerRegistry.identifyFromGamepadId(e.gamepad.id);
       analytics.setController(info ? info.driverName : e.gamepad.id, 'standard');

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -399,9 +399,7 @@ export class Lobby {
           this.input.gamepadIndex = i;
           this.input.gamepadConnected = true;
           this.input._gpName = gamepads[i].id;
-          // GameSir Cyclone reports as "Gamepad" with Switch Pro IDs but has
-          // swapped A/B buttons (Nintendo layout). Detect and store swap flag.
-          this.input._gpSwapAB = /^Gamepad/i.test(gamepads[i].id) && /057e/i.test(gamepads[i].id);
+          this.input._gpSwapAB = !!ControllerRegistry.getGamepadQuirks(gamepads[i].id).swapAB;
           console.log('Desktop: gamepad activated:', gamepads[i].id, this.input._gpSwapAB ? '(A/B swapped)' : '');
         }
         // Show joystick toggle
@@ -2719,7 +2717,7 @@ export class Lobby {
             this.input.gamepadIndex = i;
             this.input.gamepadConnected = true;
             this.input._gpName = gamepads[i].id;
-            this.input._gpSwapAB = /^Gamepad/i.test(gamepads[i].id) && /057e/i.test(gamepads[i].id);
+            this.input._gpSwapAB = !!ControllerRegistry.getGamepadQuirks(gamepads[i].id).swapAB;
             console.log('Desktop: auto-detected gamepad:', gamepads[i].id);
           }
           // Show joystick toggle

--- a/shared/controllers/base-driver.js
+++ b/shared/controllers/base-driver.js
@@ -26,6 +26,17 @@ export class ControllerDriver {
   /** @returns {RegExp} Pattern to match Gamepad API id string */
   static get gamepadIdPattern() { return /^$/; }
 
+  /**
+   * Per-id quirk flags. Override in subclasses that need to flag device
+   * variants enumerating with the same vid:pid as the base controller but
+   * with different runtime behavior (e.g. GameSir Cyclone enumerates as
+   * Switch Pro but uses Nintendo A/B button ordering).
+   *
+   * @param {string} idString — gamepad.id from the Gamepad API
+   * @returns {{ swapAB?: boolean }} quirks — empty object when none apply
+   */
+  static getGamepadQuirks(_idString) { return {}; }
+
   // ── Capabilities (override in subclass) ──
 
   static get capabilities() {

--- a/shared/controllers/controller-registry.js
+++ b/shared/controllers/controller-registry.js
@@ -58,6 +58,25 @@ export class ControllerRegistry {
   }
 
   /**
+   * Return per-id quirk flags by dispatching to each registered driver's
+   * `getGamepadQuirks(idString)`. Used so callers that care about
+   * device variants (GameSir Cyclone's swapped A/B, future quirks)
+   * don't have to re-implement the id pattern checks themselves.
+   *
+   * @param {string} idString — gamepad.id from the Gamepad API
+   * @returns {{ swapAB?: boolean }} merged quirks — `{}` when none apply
+   */
+  static getGamepadQuirks(idString) {
+    if (!idString) return {};
+    const out = {};
+    for (const D of DRIVERS) {
+      const q = D.getGamepadQuirks(idString);
+      if (q) Object.assign(out, q);
+    }
+    return out;
+  }
+
+  /**
    * Check if a given HID device matches any registered driver with WebHID capabilities.
    * @param {HIDDevice} device
    * @returns {boolean}

--- a/shared/controllers/switch-pro-driver.js
+++ b/shared/controllers/switch-pro-driver.js
@@ -11,6 +11,22 @@ export class SwitchProDriver extends ControllerDriver {
   static get driverName() { return 'Switch Pro'; }
   static get gamepadIdPattern() { return /pro controller|057e.*2009|nintendo/i; }
 
+  /**
+   * GameSir Cyclone enumerates with Switch Pro vid:pid (057e:2009) but its
+   * gamepad.id starts with "Gamepad" (rather than "Pro Controller") and it
+   * uses Nintendo-style physical face-button ordering — the positions of A
+   * and B are swapped relative to the Xbox-standard Gamepad API mapping.
+   * Callers that show on-screen prompts or apply confirm/back actions
+   * should swap buttons 0 and 1 when this quirk is set.
+   */
+  static getGamepadQuirks(idString) {
+    if (!idString) return {};
+    if (this.gamepadIdPattern.test(idString) && /^Gamepad/i.test(idString)) {
+      return { swapAB: true };
+    }
+    return {};
+  }
+
   static get capabilities() {
     return { gyro: true, accel: true, touchpad: false };
   }


### PR DESCRIPTION
## Summary
- Step 4 of #224: controller-specific quirks live inside drivers now.
- Adds \`ControllerDriver.getGamepadQuirks(idString)\` and \`ControllerRegistry.getGamepadQuirks()\` dispatcher.
- Deletes 3 identical inline regex detections of the GameSir Cyclone A/B-swap across \`js/input-manager.js\` and \`js/lobby.js\`.

## Why
The same \`/^Gamepad/i.test(id) && /057e/i.test(id)\` regex lived in three files. Any future driver-variant quirk (Super Nova, etc.) would've forced a fourth — and drift between them would break silently. Quirks should be a first-class driver concern.

## What moved
| Before | After |
|---|---|
| \`js/input-manager.js\` — inline regex → \`this._gpSwapAB = ...\` | \`ControllerRegistry.getGamepadQuirks(id).swapAB\` |
| \`js/lobby.js\` (desktop activation) — same regex | Same call |
| \`js/lobby.js\` (auto-detect fallback) — same regex | Same call |
| (nothing) | \`SwitchProDriver.getGamepadQuirks()\` returns \`{ swapAB: true }\` for Cyclone |

Downstream consumers (\`game.js\`, \`game-recorder.js\`, \`lobby.js\` rendering) keep reading \`this.input._gpSwapAB\` — the flag is canonical, only the detection site moved.

## Test plan
- [x] DualSense — solo ride end-to-end, no regression
- [x] GameSir Cyclone (BT) — A/B swap still applied correctly; buttons work
- [ ] Reviewer: any lobby navigation with a confirm/back controller, verify nothing feels inverted

## Known residual
Cyclone gyro is still unsupported (HID protocol quirks not fully decoded for clones). Same family as #225 — pre-existed this PR; not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)