### PR TITLE
Include shared/ in controller-overlay package (#231)

### DIFF
--- a/.github/workflows/build-controller-overlay.yml
+++ b/.github/workflows/build-controller-overlay.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'controller-overlay/**'
+      - 'shared/**'
       - '.github/workflows/build-controller-overlay.yml'
   workflow_dispatch:
 

--- a/controller-overlay/.gitignore
+++ b/controller-overlay/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 src/lib/
+src/shared/
 out/
 .webpack/
 *.dmg

--- a/controller-overlay/package.json
+++ b/controller-overlay/package.json
@@ -4,8 +4,11 @@
   "description": "3D controller overlay for streamers — real-time button, stick, trigger, and gyro visualization",
   "main": "electron/main.js",
   "scripts": {
-    "postinstall": "node scripts/copy-three.js",
-    "prestart": "node scripts/copy-three.js",
+    "postinstall": "node scripts/copy-three.js && node scripts/copy-shared.js",
+    "prestart": "node scripts/copy-three.js && node scripts/copy-shared.js",
+    "prestart:multi": "node scripts/copy-three.js && node scripts/copy-shared.js",
+    "prepackage": "node scripts/copy-three.js && node scripts/copy-shared.js",
+    "premake": "node scripts/copy-three.js && node scripts/copy-shared.js",
     "start": "electron .",
     "start:multi": "electron . --multi",
     "make": "electron-forge make",

--- a/controller-overlay/scripts/copy-shared.js
+++ b/controller-overlay/scripts/copy-shared.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Copies repo-root shared/ modules into controller-overlay/src/shared/ so
+// the Electron Forge packager picks them up. Without this the packaged
+// overlay fails at runtime with module-not-found for ../../../shared/*
+// (the relative import works in dev where Electron reads arbitrary paths,
+// but breaks once the overlay is asar-packaged).
+//
+// Run as prestart (dev) AND prepackage (build). Mirrors the existing
+// copy-three.js pattern.
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const srcDir = path.join(repoRoot, 'shared');
+const destDir = path.join(__dirname, '..', 'src', 'shared');
+
+if (!fs.existsSync(srcDir)) {
+  console.error(`ERROR: Could not find shared/ at ${srcDir}`);
+  process.exit(1);
+}
+
+function copyRecursive(src, dest) {
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      copyRecursive(path.join(src, entry), path.join(dest, entry));
+    }
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
+
+// Wipe destination first so renamed/deleted files don't linger.
+if (fs.existsSync(destDir)) {
+  fs.rmSync(destDir, { recursive: true, force: true });
+}
+copyRecursive(srcDir, destDir);
+console.log(`Copied shared/ → ${path.relative(repoRoot, destDir)}`);

--- a/controller-overlay/src/js/app.js
+++ b/controller-overlay/src/js/app.js
@@ -13,8 +13,8 @@
 import * as THREE from 'three';
 import { ControllerOverlay } from './controller-overlay.js';
 import { detectControllerType, PROFILES } from './controller-profiles.js';
-import { ControllerRegistry } from '../../../shared/controllers/controller-registry.js';
-import { SensorFusion } from '../../../shared/sensor-fusion.js';
+import { ControllerRegistry } from '../shared/controllers/controller-registry.js';
+import { SensorFusion } from '../shared/sensor-fusion.js';
 
 // ── DOM refs ──
 const canvas = document.getElementById('canvas');

--- a/controller-overlay/src/js/multi-app.js
+++ b/controller-overlay/src/js/multi-app.js
@@ -16,8 +16,8 @@
 
 import { ControllerOverlay } from './controller-overlay.js';
 import { detectControllerType } from './controller-profiles.js';
-import { ControllerRegistry } from '../../../shared/controllers/controller-registry.js';
-import { ControllerManager, gamepadHasActivity } from '../../../shared/controller-manager.js';
+import { ControllerRegistry } from '../shared/controllers/controller-registry.js';
+import { ControllerManager, gamepadHasActivity } from '../shared/controller-manager.js';
 
 const SLOT_IDS = ['P1', 'P2'];
 


### PR DESCRIPTION
## Summary
The overlay's Electron Forge config packages \`controller-overlay/\` only, but the #224 consolidation moved common code to repo-root \`shared/\`. Packaged builds of the overlay would fail at runtime with module-not-found on \`../../../shared/*\` imports (dev worked because Electron reads arbitrary paths off disk).

## Fix
- New \`scripts/copy-shared.js\` mirrors \`shared/\` → \`controller-overlay/src/shared/\` (gitignored). Runs as postinstall / prestart / prestart:multi / prepackage / premake hook.
- Overlay imports rewritten from \`../../../shared/...\` to \`../shared/...\` — resolves identically in dev and packaged builds.
- GHA \`build-controller-overlay.yml\` path filter now includes \`shared/**\` so changes there retrigger the overlay build.

## Rejected alternatives
- \`extraResource\`: exposes files at \`process.resourcesPath\` but fights ES modules.
- Symlink: unreliable on Windows.
- npm workspaces: correct long-term, out of scope for a bug fix.

## Test plan
- [x] Syntax checks pass on modified files
- [x] \`node scripts/copy-shared.js\` runs clean locally, src/shared/ populated
- [ ] Reviewer: once merged, GHA triggers — confirm overlay Windows .exe installer starts + DualSense gyro works in the packaged build
- [ ] Reviewer: confirm the \"test 3d overlay\" download page on tandemonium.jimandi.love serves the new build

Closes: packaging risk flagged in #224 and #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)