### PR TITLE
Populate controller-overlay/src/shared/ during gh-pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Populate controller-overlay/src/shared/
+        # The overlay imports `../shared/...` relative to its src/js/ dir.
+        # The web-deployed overlay (served via iframe from
+        # /controller-overlay-web/) needs src/shared/ populated for those
+        # imports to resolve. copy-shared.js is pure node (no deps) so we
+        # can run it here without npm install.
+        run: node controller-overlay/scripts/copy-shared.js
+
       - name: Stage deploy files
         run: |
           mkdir -p _site


### PR DESCRIPTION
## Summary
Parallels #232 for the web-hosted overlay. Same root cause: the overlay imports \`../shared/...\` which resolves to \`controller-overlay/src/shared/\` — but that directory is gitignored (copy-shared.js populates it at build/dev time), so the web deploy on tandemonium.jimandi.love was 404'ing its shared module imports.

## Fix
Run \`node controller-overlay/scripts/copy-shared.js\` in \`deploy.yml\` before the rsync stage. Pure node fs ops, no npm install needed.

## Test plan
- [ ] Once merged, GHA runs and gh-pages re-deploys
- [ ] Visit https://tandemonium.jimandi.love/controller-overlay-web/ — iframe'd overlay loads without console errors
- [ ] DualSense gyro works in the web overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)