### PR TITLE
Strip overlay .gitignore from deploy staging (fixes shared/ 404)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,12 @@ jobs:
           # deploy.yml iteration.
           mkdir -p _site/controller-overlay/src/shared
           cp -r shared/* _site/controller-overlay/src/shared/
+          # Strip dev-only .gitignore entries that would make git (inside
+          # peaceiris/actions-gh-pages) refuse to stage src/shared/. Without
+          # this, the files get cp'd into _site but never committed to
+          # gh-pages (silent skip — no visible error), leaving the
+          # web-deployed overlay's imports 404'd at runtime.
+          rm -f _site/controller-overlay/.gitignore
           echo "Overlay shared/ contents in _site:"
           ls -R _site/controller-overlay/src/shared
 


### PR DESCRIPTION
Root cause of controller-overlay/src/shared/ never reaching gh-pages: the .gitignore in controller-overlay/ has 'src/shared/' (legit — it's dev-side copy output). peaceiris/actions-gh-pages uses 'git add -A' inside publish_dir when committing to gh-pages; git respects the .gitignore that got rsync'd alongside and silently skips those files. No error, no visible symptom in logs.

Fix: rm the overlay's .gitignore from the staged _site tree before peaceiris runs. It's a dev-only concern, useless on the deployed static-asset tree.

## Verify
- [x] Pinpointed via gh api check on gh-pages showing no 'create mode' entries for shared/ despite ls -R staging them
- [ ] After merge, curl confirms 200 on the shared/ URLs
- [ ] Web overlay recognizes DualSense

🤖 Generated with [Claude Code](https://claude.com/claude-code)