### PR TITLE
Fix TypeError in _submitScore for local MP (#229)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2212,15 +2212,27 @@ class Game {
     if (this.contributionTracker) {
       const contrib = this.contributionTracker.getSummary();
       const myServerId = auth.user ? auth.user.serverId : null;
-      if (contrib.mode === 'multiplayer') {
-        const myRole = this.mode; // 'captain' or 'stoker'
+      // Online MP: per-role server-ID split. Only applies when this.mode is
+      // 'captain' or 'stoker' (online roles). Local MP runs with
+      // this.mode === 'local' and has no server-side role distinction —
+      // attribute the contribution as if it were solo.
+      const isOnlineMp = contrib.mode === 'multiplayer'
+        && (this.mode === 'captain' || this.mode === 'stoker')
+        && contrib.captain && contrib.stoker;
+      if (isOnlineMp) {
+        const myRole = this.mode;
         const partnerRole = myRole === 'captain' ? 'stoker' : 'captain';
         contrib[myRole].userId = myServerId;
         contrib[partnerRole].userId = this._partnerServerId;
         data.contributions = { captain: contrib.captain, stoker: contrib.stoker };
       } else {
-        contrib.solo.userId = myServerId;
-        data.contributions = { solo: contrib.solo };
+        // Solo OR local MP — attribute to the local user. contribution-tracker
+        // returns a captain shape in local MP; treat it as solo for submission.
+        const contribToSubmit = contrib.solo || contrib.captain || contrib.stoker;
+        if (contribToSubmit) {
+          contribToSubmit.userId = myServerId;
+          data.contributions = { solo: contribToSubmit };
+        }
       }
     }
 


### PR DESCRIPTION
Closes #229.

## Cause
`contrib.mode === 'multiplayer'` is true for **both** online MP and local MP, but `this.mode` is `'local'` in local MP (not `'captain'` or `'stoker'`). The per-role split at line 2218 then tried to set `contrib['local'].userId`, which was undefined.

## Fix
Tighten the online-MP branch to also require `this.mode` to be a real online role. Local MP falls through to the else branch, which now also handles contrib without a `.solo` shape — contribution-tracker returns a `.captain` shape for local MP, so we use that as the solo submission payload.

## Test plan
- [x] Code-level guard prevents undefined access
- [ ] Reviewer: finish a local MP race (Electron without Steam), confirm no TypeError in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)