### PR TITLE
Overwrite stale controller-overlay/.gitignore on gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,12 +34,16 @@ jobs:
           # deploy.yml iteration.
           mkdir -p _site/controller-overlay/src/shared
           cp -r shared/* _site/controller-overlay/src/shared/
-          # Strip dev-only .gitignore entries that would make git (inside
-          # peaceiris/actions-gh-pages) refuse to stage src/shared/. Without
-          # this, the files get cp'd into _site but never committed to
-          # gh-pages (silent skip — no visible error), leaving the
-          # web-deployed overlay's imports 404'd at runtime.
-          rm -f _site/controller-overlay/.gitignore
+          # Overwrite dev-only .gitignore with an empty file. peaceiris
+          # uses rsync (not delete-and-replace) to copy _site over the
+          # gh-pages checkout, so an existing stale .gitignore on gh-pages
+          # (from a previous deploy that committed it) stays active at
+          # `git add -A` time and silently filters src/shared/ out. Writing
+          # an empty file at the same path ensures the gh-pages copy gets
+          # overwritten with no ignore rules, letting the shared files
+          # commit properly. Delete-from-_site alone isn't enough — that
+          # leaves the stale gh-pages version in place.
+          : > _site/controller-overlay/.gitignore
           echo "Overlay shared/ contents in _site:"
           ls -R _site/controller-overlay/src/shared
 


### PR DESCRIPTION
Follow-up to #236. My `rm -f` from `_site` only affected the staged tree but didn't remove the file already on gh-pages (from a pre-consolidation deploy). peaceiris/actions-gh-pages uses additive rsync — stale files persist. The gh-pages copy of `controller-overlay/.gitignore` was still active at `git add -A` time, silently filtering src/shared/ out.

Verified via gh api: decoded .gitignore on gh-pages has `node_modules/\nsrc/lib/\nsrc/shared/\nout/...` — that `src/shared/` line was blocking everything.

## Fix
Write an empty file at the same path (`: > ...`). rsync overwrites gh-pages' copy, git sees no ignore rules, shared/ files commit.

## Verify after merge
- [ ] gh-pages contains an empty controller-overlay/.gitignore
- [ ] `curl -sI /controller-overlay/src/shared/controllers/controller-registry.js` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)