### PR TITLE
Web controller robustness: ghost-pad detection + gyro-capable toggle

### DIFF
--- a/js/lobby.js
+++ b/js/lobby.js
@@ -326,10 +326,7 @@ export class Lobby {
         // otherwise the user has to power-cycle the controller on
         // every app restart to force it back into Chromium-visible
         // compat mode.
-        const isDesktopRelaunch = window.steam ||
-          navigator.userAgent.includes('Electron') ||
-          navigator.userAgent.includes('electron');
-        if (isDesktopRelaunch) {
+        if (!isMobile) {
           this._runDesktopGamepadDetection();
         }
       } else {
@@ -355,11 +352,11 @@ export class Lobby {
     this._tapOverlay = null;
     localStorage.setItem('tandemonium_started', '1');
 
-    const isDesktop = window.steam || navigator.userAgent.includes('Electron') || navigator.userAgent.includes('electron');
-
-    if (isDesktop) {
-      // Desktop: the button press that dismissed the overlay also activated the gamepad.
-      // Poll briefly to let Chromium register it, then show toggles + auto-connect gyro.
+    // Any non-mobile platform (Electron, Chrome desktop, Edge desktop) uses
+    // the gamepad-detection poll. The old isDesktop check excluded regular
+    // browsers, which meant the web-deployed game never auto-claimed P1 —
+    // menu-nav stayed keyboard-only and the gyro toggle never appeared.
+    if (!isMobile) {
       console.log('Desktop: overlay dismissed, activating gamepad...');
       this._runDesktopGamepadDetection();
     } else {
@@ -418,12 +415,26 @@ export class Lobby {
           this._setToggleActive('joystick', this.joystickActive);
           if (this.onMusicChanged) this.onMusicChanged(true);
         }
+        // Motion-toggle visibility: the claimed pad's id tells us whether
+        // the controller has gyro, BEFORE HID is attached. Show the toggle
+        // (in OFF state) so the user has a clickable affordance to grant
+        // WebHID permission; _toggleMotion's first-click path calls
+        // manager.connectHidForSlot('P1') which in Electron auto-approves
+        // invisibly and in a browser shows the HID picker.
+        const info = slot.controllerLabel
+          ? ControllerRegistry.identifyFromGamepadId(slot.controllerLabel)
+          : null;
+        if (info?.hasGyro) {
+          this._showMotionToggle();
+          // Reflect HID state in the active class: green when bound, off
+          // (greyed) otherwise so the user knows it needs a click.
+          this._setToggleActive('motion', !!slot._hidEntry);
+        }
         // If HID was attached synchronously (pool hit), arm motion now.
         if (slot._hidEntry && !this._motionPermitted) {
           this._motionPermitted = true;
           this.motionActive = true;
           if (this.input) this.input.motionEnabled = true;
-          this._showMotionToggle();
           this._setToggleActive('motion', true);
         }
       } else if (reason === 'hid-bound' && !this._motionPermitted) {

--- a/shared/controller-manager.js
+++ b/shared/controller-manager.js
@@ -105,6 +105,36 @@ export function gamepadHasActivity(gp, axisThreshold = DEFAULTS.axisActivityThre
   return false;
 }
 
+/**
+ * Stricter activity check for claim-time only: button presses count
+ * unconditionally, but axes have to *move* between frames (not just be
+ * pinned at a non-center value). Chrome persists BT-reconnect ghost
+ * pads with stuck stick axes that gamepadHasActivity would falsely
+ * treat as active input; this check needs prevAxes from the last frame
+ * to distinguish. Call with the output of `prevAxesByIndex.get(gp.index)`.
+ */
+export function gamepadHasFreshActivity(gp, prevAxes, axisThreshold = DEFAULTS.axisActivityThreshold) {
+  if (!gp) return false;
+  // Buttons: any press is fresh activity.
+  for (const b of gp.buttons) {
+    if (b && (b.pressed || (typeof b.value === 'number' && b.value > 0.5))) return true;
+  }
+  // Axes: require motion (delta > 0.1) vs last-frame values. If we have
+  // no prev data yet, axes must be near center (<= threshold) to count —
+  // otherwise they're probably a stuck ghost we've never seen move.
+  if (!prevAxes) {
+    for (const a of gp.axes) {
+      if (Math.abs(a) > axisThreshold) return false; // suspect ghost
+    }
+    return false; // no motion, no buttons, nothing fresh
+  }
+  for (let i = 0; i < gp.axes.length; i++) {
+    const prev = prevAxes[i] != null ? prevAxes[i] : 0;
+    if (Math.abs(gp.axes[i] - prev) > 0.1) return true;
+  }
+  return false;
+}
+
 // ── HidEntry ──
 //
 // One per paired WebHID device. Lives in ControllerManager._hidPool
@@ -366,6 +396,10 @@ export class ControllerManager {
     this._hidPool = new Map(); // HIDDevice -> HidEntry
     this._recentlyReleasedByIndex = new Map();
     this._recentlyReleasedBySlot = new Map();
+    // Prev-frame axes per gamepad index — lets ingestFrame's claim path
+    // require axis motion (not just pinned position) to treat a pad as
+    // active. Counters Chrome BT-reconnect ghost pads with stuck axes.
+    this._prevAxesByIndex = new Map();
     this._hidConnectHandler = null;
     this._hidDisconnectHandler = null;
   }
@@ -387,19 +421,45 @@ export class ControllerManager {
     const claimedIndices = new Set(
       this.slots.filter((s) => s.gamepadIndex != null).map((s) => s.gamepadIndex)
     );
+    // Boot-claim is a convenience for "controller plugged in before page
+    // loaded" — we don't want the user forced to press a button to start
+    // nav. BUT Chrome persists ghost slots from past BT reconnects that
+    // are indistinguishable from live pads with centered sticks. Without
+    // a button press or stick motion we can't tell them apart.
+    //
+    // Heuristics:
+    //  - Skip pads with stuck stick axes (>0.5 at rest — definitely ghost)
+    //  - If exactly one clean candidate remains, claim it. That's the
+    //    single-controller-plugged-in case.
+    //  - If multiple clean candidates remain, DEFER. Activity-based claim
+    //    in ingestFrame handles the multi-pad case via button press.
+    const candidates = [];
     for (const gp of pads) {
       if (!gp) continue;
       if (claimedIndices.has(gp.index)) continue;
-      const info = ControllerRegistry.identifyFromGamepadId(gp.id);
-      slot.claim(gp, {
-        controllerTypeHint: info?.driverName?.toLowerCase().replace(' ', '-') || null,
-        silent: true,
-      });
-      this._attachMatchingPoolEntry(slot);
-      slot._emit('claimed');
-      return gp;
+      const stickMag = Math.max(
+        Math.abs(gp.axes[0] || 0),
+        Math.abs(gp.axes[1] || 0),
+        Math.abs(gp.axes[2] || 0),
+        Math.abs(gp.axes[3] || 0),
+      );
+      if (stickMag > 0.5) continue; // definitely ghost
+      candidates.push(gp);
     }
-    return null;
+    if (candidates.length === 0) return null;
+    if (candidates.length > 1) {
+      console.log(`[manager] deferring boot-claim: ${candidates.length} candidate pads — waiting for user input to disambiguate`);
+      return null;
+    }
+    const gp = candidates[0];
+    const info = ControllerRegistry.identifyFromGamepadId(gp.id);
+    slot.claim(gp, {
+      controllerTypeHint: info?.driverName?.toLowerCase().replace(' ', '-') || null,
+      silent: true,
+    });
+    this._attachMatchingPoolEntry(slot);
+    slot._emit('claimed');
+    return gp;
   }
 
   _isDeviceInPoolOrSlot(device) {
@@ -504,6 +564,8 @@ export class ControllerManager {
     const releasedThisFrame = [];
 
     // Orphan check (Gamepad-API-backed claims only)
+    // Note: _prevAxesByIndex is updated at the END of the frame so the
+    // claim path sees "previous frame" axes vs this-frame's.
     for (const s of this.slots) {
       if (s.state !== 'claimed') continue;
       if (s.gamepadIndex == null) continue;
@@ -520,7 +582,9 @@ export class ControllerManager {
       if (!gpActive && !synthActive) s._awaitingSilence = false;
     }
 
-    // Claim via Gamepad API activity.
+    // Claim via Gamepad API activity. Uses gamepadHasFreshActivity
+    // (not gamepadHasActivity) so pinned-stick ghost pads don't get
+    // claimed — only real button presses or stick motion count.
     const claimedIndices = new Set(
       this.slots.filter((s) => s.gamepadIndex != null).map((s) => s.gamepadIndex)
     );
@@ -529,7 +593,8 @@ export class ControllerManager {
       if (claimedIndices.has(gp.index)) continue;
       const releasedAt = this._recentlyReleasedByIndex.get(gp.index);
       if (releasedAt != null && (now - releasedAt) < this.opts.reclaimCooldownMs) continue;
-      if (!gamepadHasActivity(gp)) continue;
+      const prevAxes = this._prevAxesByIndex.get(gp.index);
+      if (!gamepadHasFreshActivity(gp, prevAxes)) continue;
       const empty = this.slots.find((s) => s.state === 'empty' && !s._awaitingSilence);
       if (!empty) break;
       const info = ControllerRegistry.identifyFromGamepadId(gp.id);
@@ -585,6 +650,12 @@ export class ControllerManager {
         this._recentlyReleasedBySlot.set(s.id, now);
         releasedThisFrame.push(s.id);
       }
+    }
+
+    // Snapshot axes for next frame's fresh-activity check.
+    for (const gp of pads) {
+      if (!gp) continue;
+      this._prevAxesByIndex.set(gp.index, [...gp.axes]);
     }
 
     return { claimed: claimedThisFrame, released: releasedThisFrame };


### PR DESCRIPTION
Fixes the DualSense/Switch Pro controller flow on the web-deployed game (localhost testing + tandemonium.jimandi.love). Three issues surfaced:

## 1. Desktop gamepad detection limited to Electron
`_runDesktopGamepadDetection` gated on `navigator.userAgent.includes('Electron')` — regular Chrome/Edge never ran the boot-time claim poll. Switched to `!isMobile`.

## 2. Chrome BT-reconnect ghost pads
Chrome persists stale slots after BT reconnect cycles. These 'ghost' pads have stuck stick axes (stick frozen at -0.80 forever) or centered idle state that looks identical to a live pad. Three heuristics:
- `claimFirstAvailable` filters pads with stickMag > 0.5 (clearly-stuck). If >1 clean candidate remains, DEFER — wait for user to press a button to disambiguate.
- New `gamepadHasFreshActivity(gp, prevAxes)` — axes must MOVE between frames to count as activity (not just be non-centered). Buttons still trigger instantly.
- `_prevAxesByIndex` Map in ControllerManager tracks per-pad axes history across frames.

## 3. Gyro toggle hidden until HID bound
Motion toggle was gated on `slot._hidEntry`. On the web the HID pool is empty at boot (per-origin permissions), so the toggle never appeared and users had no way to request HID access. Now: show the toggle as soon as the claimed pad is gyro-capable per `ControllerRegistry.identifyFromGamepadId`. Click triggers `connectHidForSlot` → `requestDevice` which auto-approves in Electron and prompts in browsers. Once HID binds, toggle flips green.

Same code works in both environments.

## Test plan
- [x] localhost:8080 Chrome, USB DualSense: auto-claim after button press, gyro toggle appears grey, click prompts HID picker, select device → toggle green
- [x] localhost:8080 Chrome, BT DualSense after power-cycle: same flow works
- [x] Electron desktop: gyro toggle appears green immediately at claim (HID auto-approved at boot)
- [ ] Reviewer: tandemonium.jimandi.love web deployment — verify gyro UX end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)