### PR TITLE
Multi-controller overlay: 4 dynamic slots + HID pool dedupe

### DIFF
--- a/controller-overlay/src/js/multi-app.js
+++ b/controller-overlay/src/js/multi-app.js
@@ -19,7 +19,7 @@ import { detectControllerType } from './controller-profiles.js';
 import { ControllerRegistry } from '../shared/controllers/controller-registry.js';
 import { ControllerManager, gamepadHasActivity } from '../shared/controller-manager.js';
 
-const SLOT_IDS = ['P1', 'P2'];
+const SLOT_IDS = ['P1', 'P2', 'P3', 'P4'];
 
 const manager = new ControllerManager({ slotIds: SLOT_IDS });
 // Expose for DevTools debugging.
@@ -47,6 +47,11 @@ class SlotView {
 
     root.classList.toggle('p1', slot.id === 'P1');
     root.classList.toggle('p2', slot.id === 'P2');
+    root.classList.toggle('p3', slot.id === 'P3');
+    root.classList.toggle('p4', slot.id === 'P4');
+    root.setAttribute('data-slot', slot.id);
+    const titleEl = root.querySelector('.slot-title');
+    if (titleEl) titleEl.textContent = `Player ${slot.id.slice(1)}`;
 
     if (this.connectBtn) {
       this.connectBtn.addEventListener('click', () => {
@@ -305,8 +310,13 @@ function renderDebugStrip(pads, views) {
 
 // ── Wiring ──
 
+const slotsContainer = document.getElementById('slots');
+const slotTemplate = document.getElementById('slot-template');
+
 const views = manager.slots.map((slot) => {
-  const root = document.querySelector(`.slot[data-slot="${slot.id}"]`);
+  const fragment = slotTemplate.content.cloneNode(true);
+  const root = fragment.querySelector('.slot');
+  slotsContainer.appendChild(fragment);
   return new SlotView(slot, root);
 });
 

--- a/controller-overlay/src/multi.html
+++ b/controller-overlay/src/multi.html
@@ -38,13 +38,16 @@
   #slots {
     position: absolute;
     top: 36px; left: 0; right: 0; bottom: 0;
-    display: flex;
+    display: grid;
+    /* 2 slots → 1 row; 3–4 → 2×2; 5–6 → 2×3. Wraps automatically. */
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-auto-rows: 1fr;
     gap: 12px;
     padding: 16px;
+    align-content: stretch;
   }
 
   .slot {
-    flex: 1 1 0;
     position: relative;
     background: linear-gradient(180deg, rgba(30,34,44,0.65) 0%, rgba(18,21,28,0.65) 100%);
     border: 1px solid rgba(255,255,255,0.06);
@@ -52,6 +55,7 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    min-height: 260px;
     transition: border-color 0.25s, box-shadow 0.25s, opacity 0.25s;
   }
   .slot.claimed.p1 {
@@ -62,7 +66,21 @@
     border-color: rgba(255,90,90,0.45);
     box-shadow: 0 0 30px rgba(220,60,60,0.18) inset;
   }
+  .slot.claimed.p3 {
+    border-color: rgba(90,220,120,0.45);
+    box-shadow: 0 0 30px rgba(40,190,90,0.18) inset;
+  }
+  .slot.claimed.p4 {
+    border-color: rgba(200,120,255,0.45);
+    box-shadow: 0 0 30px rgba(160,80,240,0.18) inset;
+  }
   .slot.empty { opacity: 0.75; }
+
+  /* Title-color accents mirror the border/lightbar per player */
+  .slot.claimed.p1 .slot-title { color: #6ea8ff; }
+  .slot.claimed.p2 .slot-title { color: #ff7a7a; }
+  .slot.claimed.p3 .slot-title { color: #7ae09a; }
+  .slot.claimed.p4 .slot-title { color: #c79dff; }
 
   .slot-header {
     display: flex;
@@ -77,9 +95,6 @@
     color: #7d8aa0;
     text-transform: uppercase;
   }
-  .slot.claimed.p1 .slot-title { color: #6ea8ff; }
-  .slot.claimed.p2 .slot-title { color: #ff7a7a; }
-
   .slot-sub {
     font-size: 9px;
     color: #4e5564;
@@ -94,7 +109,9 @@
   }
 
   .slot-canvas-wrap {
-    flex: 1;
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: 55%;
     position: relative;
     display: flex;
     align-items: center;
@@ -111,9 +128,12 @@
     padding: 10px 18px 16px 18px;
     text-align: center;
     min-height: 46px;
+    max-height: 50%;
+    overflow-y: auto;
     display: flex;
     align-items: center;
     justify-content: center;
+    flex: 0 0 auto;
   }
   .slot-prompt {
     font-size: 13px;
@@ -253,10 +273,12 @@
 <div id="drag-bar"></div>
 <div id="app-title">Tandemonium · Multi-Controller Prototype</div>
 
-<div id="slots">
-  <div class="slot empty" data-slot="P1">
+<div id="slots"></div>
+
+<template id="slot-template">
+  <div class="slot empty">
     <div class="slot-header">
-      <div class="slot-title">Player 1</div>
+      <div class="slot-title"></div>
       <div class="slot-sub" data-role="sub"></div>
     </div>
     <div class="slot-canvas-wrap">
@@ -277,33 +299,9 @@
       </div>
     </div>
   </div>
+</template>
 
-  <div class="slot empty" data-slot="P2">
-    <div class="slot-header">
-      <div class="slot-title">Player 2</div>
-      <div class="slot-sub" data-role="sub"></div>
-    </div>
-    <div class="slot-canvas-wrap">
-      <canvas data-role="canvas"></canvas>
-      <div class="release-ring" data-role="ring"></div>
-      <div class="release-label">Release</div>
-    </div>
-    <div class="slot-footer">
-      <div>
-        <div class="slot-prompt" data-role="prompt"><span class="pulse">Press any button to join</span></div>
-        <div class="slot-hint" data-role="hint"></div>
-        <div class="slot-actions">
-          <button class="slot-btn" data-role="connect-hid">Connect Gyro (WebHID)</button>
-          <button class="slot-btn" data-role="calibrate" style="display:none;">Recalibrate Gyro</button>
-          <button class="slot-btn" data-role="diag-toggle">Diagnostics</button>
-        </div>
-        <div class="slot-diag" data-role="diag" hidden></div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id="status-line">Hold PS/Home 2s to release a slot · First input claims P1, second distinct device claims P2</div>
+<div id="status-line">Hold PS/Home 2s to release a slot · First input claims next empty slot</div>
 
 <button id="debug-toggle" title="Toggle debug readout">&#x25BE; Debug</button>
 <div id="debug-readout" class="hidden"></div>

--- a/shared/controller-manager.js
+++ b/shared/controller-manager.js
@@ -177,6 +177,35 @@ class HidEntry {
     // — if a new driver's parseReport is wrong, mag would be off by 10×+
     // and gravity correction would be garbage. Logged once per entry.
     this._accelVerified = false;
+    // Snapshot of buttons reported as pressed on the first report. Used
+    // to gate pool-to-slot auto-claim: a "fresh press" is a button that
+    // wasn't stuck-pressed from the start. Some drivers mis-parse foreign
+    // HID layouts (e.g. DualSense driver reading a GameSir-as-DS4 report)
+    // and report phantom stuck buttons that would otherwise auto-claim a
+    // slot with no user input.
+    this._initialPressedMask = null;
+  }
+
+  /** True if any button not in the initial-stuck set is currently pressed. */
+  hasFreshButtonPress() {
+    if (!this.synthetic) return false;
+    const buttons = this.synthetic.buttons;
+    if (this._initialPressedMask == null) {
+      // Snapshot on first query — by now the first HID report has landed.
+      if (!this.hasButtons) return false;
+      this._initialPressedMask = new Set();
+      for (let i = 0; i < buttons.length; i++) {
+        if (buttons[i] && buttons[i].pressed) this._initialPressedMask.add(i);
+      }
+      return false; // first frame never counts as fresh
+    }
+    for (let i = 0; i < buttons.length; i++) {
+      const b = buttons[i];
+      if (!b) continue;
+      const pressed = b.pressed || (typeof b.value === 'number' && b.value > 0.5);
+      if (pressed && !this._initialPressedMask.has(i)) return true;
+    }
+    return false;
   }
 
   _onReport(ev) {
@@ -630,7 +659,42 @@ export class ControllerManager {
     // iterate the HID pool, not slots. Any pool entry showing activity
     // promotes into an empty slot.
     for (const entry of this._hidPool.values()) {
-      if (!gamepadHasActivity(entry.synthetic)) continue;
+      // Require a *fresh* button press to claim via HID pool (ignoring
+      // buttons that were stuck-pressed from the first HID report).
+      // GameSir-as-DS4 gets mis-parsed by the DualSense driver, producing
+      // phantom stuck buttons (e.g. button 12) that would otherwise
+      // auto-claim a slot with no user input. BT-silent DualSense still
+      // claims normally because the user's PS press is a fresh transition.
+      if (!entry.hasFreshButtonPress()) continue;
+      // Dedupe: if this physical controller is already claimed via the
+      // Gamepad API path (same vid:pid), attach the HID entry to that slot
+      // for gyro/touchpad rather than spawning a second slot. Fixes pads
+      // that expose both Gamepad API and WebHID interfaces (e.g. GameSir
+      // Super Nova presenting as DS4 + raw HID).
+      const existing = this.slots.find((s) => {
+        if (s.state !== 'claimed' || s._hidEntry) return false;
+        const vp = ControllerRegistry.parseGamepadVendorProduct(s.controllerLabel);
+        if (vp && vp.vendorId === entry.device.vendorId && vp.productId === entry.device.productId) return true;
+        const name = (entry.device.productName || '').trim().toLowerCase();
+        if (name && s.controllerLabel && s.controllerLabel.toLowerCase().includes(name)) return true;
+        return false;
+      });
+      if (existing) {
+        this._attachEntryToSlot(existing, entry);
+        continue;
+      }
+      // Also skip spawning a new slot if any unclaimed live Gamepad API pad
+      // shares this HID device's productName — the Gamepad API claim path
+      // will pick it up on its own button press, and we don't want to beat
+      // it to a second slot. Covers multi-interface pads like GameSir Super
+      // Nova where Gamepad API and WebHID report different vid:pid for the
+      // same physical device.
+      const claimedIdx = new Set(this.slots.filter((s) => s.gamepadIndex != null).map((s) => s.gamepadIndex));
+      const hidName = (entry.device.productName || '').trim().toLowerCase();
+      if (hidName) {
+        const dupeUnclaimed = pads.some((gp) => gp && !claimedIdx.has(gp.index) && gp.id.toLowerCase().includes(hidName));
+        if (dupeUnclaimed) continue;
+      }
       const empty = this.slots.find((s) => s.state === 'empty' && !s._awaitingSilence);
       if (!empty) break;
       const releasedAt = this._recentlyReleasedBySlot.get(empty.id);


### PR DESCRIPTION
Closes #244

## Summary
- 4-slot dynamic overlay using CSS grid + `<template>` cloning (P1-P4 color accents)
- Canvas height cap so footer/diagnostics buttons stay reachable in shorter slot heights
- HID pool dedupe: attach to existing slot on vid:pid or productName match instead of spawning a second slot (handles multi-interface pads)
- Fresh-button-press gate (\`HidEntry.hasFreshButtonPress()\`) on HID pool auto-claim — blocks phantom stuck-button presses from mis-parsed foreign HID layouts (e.g. GameSir-as-DS4 read by DualSense driver)

## Test plan
- [x] 2 DualSense + 1 Switch Pro claim P1/P2/P3 correctly via Gamepad API
- [x] GameSir Super Nova in Switch Pro mode works (buttons + gyro)
- [x] GameSir Super Nova in PS mode no longer silently auto-claims a slot
- [x] Electron game boot-claim path (\`claimFirstAvailable\`) unaffected
- [ ] Test 4th slot when a 4th controller is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)