### PR TITLE
Overlay: 3D gyro gimbal + axis readout (closes #247)

### DIFF
--- a/controller-overlay/src/index.html
+++ b/controller-overlay/src/index.html
@@ -213,6 +213,7 @@
   body:not(.show-title) #status-bar { opacity: 0; pointer-events: none; }
   body:not(.show-gyro) #gyro-toggle { opacity: 0; pointer-events: none; }
   body:not(.show-gear) #settings-toggle { opacity: 0; pointer-events: none; }
+  body.hide-roll-hud #gyro-hud { display: none !important; }
 
   .camera-presets {
     display: flex;
@@ -256,6 +257,25 @@
     white-space: nowrap;
   }
   .status-badge.connected { color: #4f4; background: rgba(0,80,0,0.5); }
+
+  #axis-readout {
+    position: fixed;
+    top: 40px; right: 42px;
+    display: none;
+    gap: 14px;
+    font-family: monospace;
+    font-size: 30px;
+    font-weight: 600;
+    z-index: 110;
+    background: rgba(0,0,0,0.35);
+    padding: 4px 12px;
+    border-radius: 14px;
+    pointer-events: none;
+  }
+  body.show-axis-readout #axis-readout { display: flex; }
+  #axis-readout .ax-pitch { color: #44dd66; }
+  #axis-readout .ax-roll { color: #ee4455; }
+  #axis-readout .ax-yaw { color: #4488ff; }
 
   /* ── Gyro toggle button (emoji) ── */
   #gyro-toggle {
@@ -363,6 +383,20 @@
   }
   #calib-hint.hidden { opacity: 0; }
 
+  /* ── 3D gyro gimbal widget (above controller) ── */
+  #gimbal-canvas {
+    position: fixed;
+    top: 4%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(36vw, 220px);
+    height: min(36vw, 220px);
+    pointer-events: none;
+    z-index: 45;
+    display: none;
+  }
+  body.show-gimbal #gimbal-canvas { display: block; }
+
   /* ── Click-through indicator ── */
   #click-through-indicator {
     position: fixed;
@@ -469,6 +503,22 @@
     <label>Show Gear Icon</label>
     <input type="checkbox" id="show-gear">
   </div>
+  <div class="setting-row">
+    <label>Show Roll HUD</label>
+    <input type="checkbox" id="show-roll-hud" checked>
+  </div>
+  <div class="setting-row">
+    <label>Show Axis Values</label>
+    <input type="checkbox" id="show-axis-readout">
+  </div>
+  <div class="setting-row">
+    <label>Show 3D Gyro</label>
+    <input type="checkbox" id="show-gimbal">
+  </div>
+  <div class="setting-row">
+    <label>Gimbal: full orientation</label>
+    <input type="checkbox" id="gimbal-full-mode">
+  </div>
 
   <hr class="settings-divider">
   <h3>Shortcuts</h3>
@@ -513,6 +563,13 @@
   <span class="status-badge" id="gamepad-status">No gamepad</span>
 </div>
 
+<!-- Live axis readout (pitch/yaw/roll in degrees) -->
+<div id="axis-readout">
+  <span class="ax-pitch">P <span id="ax-pitch-val">0°</span></span>
+  <span class="ax-roll">R <span id="ax-roll-val">0°</span></span>
+  <span class="ax-yaw">Y <span id="ax-yaw-val">0°</span></span>
+</div>
+
 <!-- Gyro HUD -->
 <div id="gyro-hud">
   <svg id="arc-svg" viewBox="-120 -105 240 115">
@@ -542,6 +599,9 @@
     </svg>
   </div>
 </div>
+
+<!-- 3D gyro gimbal widget canvas -->
+<canvas id="gimbal-canvas"></canvas>
 
 <!-- Click-through mode indicator -->
 <div id="click-through-indicator"></div>

--- a/controller-overlay/src/js/app.js
+++ b/controller-overlay/src/js/app.js
@@ -15,6 +15,7 @@ import { ControllerOverlay } from './controller-overlay.js';
 import { detectControllerType, PROFILES } from './controller-profiles.js';
 import { ControllerRegistry } from '../shared/controllers/controller-registry.js';
 import { SensorFusion } from '../shared/sensor-fusion.js';
+import { GyroGimbal } from './gyro-gimbal.js';
 
 // ── DOM refs ──
 const canvas = document.getElementById('canvas');
@@ -648,6 +649,25 @@ function loop() {
 
   overlay.update(gamepad, gyroActive ? gyroFusion.orientation : null);
 
+  // Drive the 3D gimbal widget when visible
+  if (gimbal && document.body.classList.contains('show-gimbal')) {
+    gimbal.update(gyroActive ? gyroFusion.orientation : null);
+  }
+
+  // Live axis readout (pitch/yaw/roll in degrees, swing-twist per axis)
+  if (document.body.classList.contains('show-axis-readout')) {
+    const q = gyroActive ? gyroFusion.orientation : null;
+    const toDeg = 180 / Math.PI;
+    const twist = (ax, ay, az) => {
+      if (!q) return 0;
+      const d = q.x * ax + q.y * ay + q.z * az;
+      return 2 * Math.atan2(d, q.w) * toDeg;
+    };
+    axPitchVal.textContent = Math.round(twist(1, 0, 0)) + '\u00B0';
+    axRollVal.textContent = Math.round(twist(0, 0, 1)) + '\u00B0';
+    axYawVal.textContent = Math.round(twist(0, 1, 0)) + '\u00B0';
+  }
+
   // Update gyro HUD
   if (gyroActive) {
     _hudEuler.setFromQuaternion(gyroFusion.orientation, 'XYZ');
@@ -699,6 +719,24 @@ async function toggleGyro() {
 let settingsFocusIndex = 0;
 const navPrevState = { up: false, down: false, left: false, right: false, a: false, b: false };
 
+// Auto-repeat for held directions: fire on press, then wait INITIAL_DELAY,
+// then repeat every REPEAT_INTERVAL while held.
+const NAV_INITIAL_DELAY = 400;
+const NAV_REPEAT_INTERVAL = 90;
+const navRepeatNext = { up: 0, down: 0, left: 0, right: 0 };
+function navTrigger(dir, pressed) {
+  const now = performance.now();
+  if (pressed && !navPrevState[dir]) {
+    navRepeatNext[dir] = now + NAV_INITIAL_DELAY;
+    return true;
+  }
+  if (pressed && now >= navRepeatNext[dir]) {
+    navRepeatNext[dir] = now + NAV_REPEAT_INTERVAL;
+    return true;
+  }
+  return false;
+}
+
 function getSettingRows() {
   return Array.from(settingsPanel.querySelectorAll('.setting-row, .camera-presets'));
 }
@@ -714,12 +752,16 @@ function navigateSettings(gamepad) {
   const a = gamepad.buttons[0]?.pressed;
   const b = gamepad.buttons[1]?.pressed;
 
-  // Edge-triggered navigation
-  if (up && !navPrevState.up) {
+  const upFire = navTrigger('up', up);
+  const downFire = navTrigger('down', down);
+  const leftFire = navTrigger('left', left);
+  const rightFire = navTrigger('right', right);
+
+  if (upFire) {
     settingsFocusIndex = Math.max(0, settingsFocusIndex - 1);
     updateSettingsFocus();
   }
-  if (down && !navPrevState.down) {
+  if (downFire) {
     settingsFocusIndex = Math.min(rows.length - 1, settingsFocusIndex + 1);
     updateSettingsFocus();
   }
@@ -733,11 +775,11 @@ function navigateSettings(gamepad) {
       let hoverIdx = btns.findIndex(b => b.classList.contains('nav-hover'));
       if (hoverIdx === -1) hoverIdx = btns.findIndex(b => b.classList.contains('selected'));
 
-      if (left && !navPrevState.left) {
+      if (leftFire) {
         hoverIdx = Math.max(0, (hoverIdx === -1 ? btns.length : hoverIdx) - 1);
         highlightPresetBtn(btns, hoverIdx);
       }
-      if (right && !navPrevState.right) {
+      if (rightFire) {
         hoverIdx = Math.min(btns.length - 1, (hoverIdx === -1 ? -1 : hoverIdx) + 1);
         highlightPresetBtn(btns, hoverIdx);
       }
@@ -751,11 +793,11 @@ function navigateSettings(gamepad) {
       const slider = row.querySelector('input[type="range"]');
       const button = row.querySelector('button');
 
-      if (left && !navPrevState.left) {
+      if (leftFire) {
         if (select) { select.selectedIndex = Math.max(0, select.selectedIndex - 1); select.dispatchEvent(new Event('change')); }
         if (slider) { slider.value = Math.max(+slider.min, +slider.value - 5); slider.dispatchEvent(new Event('input')); }
       }
-      if (right && !navPrevState.right) {
+      if (rightFire) {
         if (select) { select.selectedIndex = Math.min(select.options.length - 1, select.selectedIndex + 1); select.dispatchEvent(new Event('change')); }
         if (slider) { slider.value = Math.min(+slider.max, +slider.value + 5); slider.dispatchEvent(new Event('input')); }
       }
@@ -1188,16 +1230,58 @@ selectCameraPreset('player');
 const showTitleCheck = document.getElementById('show-title');
 const showGyroCheck = document.getElementById('show-gyro');
 const showGearCheck = document.getElementById('show-gear');
+const showGimbalCheck = document.getElementById('show-gimbal');
+const gimbalFullCheck = document.getElementById('gimbal-full-mode');
+const showRollHudCheck = document.getElementById('show-roll-hud');
+const showAxisReadoutCheck = document.getElementById('show-axis-readout');
+const axPitchVal = document.getElementById('ax-pitch-val');
+const axRollVal = document.getElementById('ax-roll-val');
+const axYawVal = document.getElementById('ax-yaw-val');
+
+const DISPLAY_PREFS_KEY = 'overlay-display-prefs';
+try {
+  const saved = JSON.parse(localStorage.getItem(DISPLAY_PREFS_KEY) || '{}');
+  if (typeof saved.gimbal === 'boolean') showGimbalCheck.checked = saved.gimbal;
+  if (typeof saved.gimbalFull === 'boolean') gimbalFullCheck.checked = saved.gimbalFull;
+  if (typeof saved.rollHud === 'boolean') showRollHudCheck.checked = saved.rollHud;
+  if (typeof saved.axisReadout === 'boolean') showAxisReadoutCheck.checked = saved.axisReadout;
+} catch (e) { /* ignore */ }
 
 function applyDisplayToggles() {
   document.body.classList.toggle('show-title', showTitleCheck.checked);
   document.body.classList.toggle('show-gyro', showGyroCheck.checked);
   document.body.classList.toggle('show-gear', showGearCheck.checked);
+  document.body.classList.toggle('show-gimbal', showGimbalCheck.checked);
+  document.body.classList.toggle('hide-roll-hud', !showRollHudCheck.checked);
+  document.body.classList.toggle('show-axis-readout', showAxisReadoutCheck.checked);
+  if (showGimbalCheck.checked) ensureGimbal();
+  if (gimbal) gimbal.fullMode = gimbalFullCheck.checked;
+  try {
+    localStorage.setItem(DISPLAY_PREFS_KEY, JSON.stringify({
+      gimbal: showGimbalCheck.checked,
+      gimbalFull: gimbalFullCheck.checked,
+      rollHud: showRollHudCheck.checked,
+      axisReadout: showAxisReadoutCheck.checked,
+    }));
+  } catch (e) { /* ignore */ }
+}
+
+let gimbal = null;
+function ensureGimbal() {
+  if (gimbal) return;
+  const gimbalCanvas = document.getElementById('gimbal-canvas');
+  if (!gimbalCanvas) return;
+  gimbal = new GyroGimbal(gimbalCanvas);
+  new ResizeObserver(() => gimbal.resize()).observe(gimbalCanvas);
 }
 
 showTitleCheck.addEventListener('change', applyDisplayToggles);
 showGyroCheck.addEventListener('change', applyDisplayToggles);
 showGearCheck.addEventListener('change', applyDisplayToggles);
+showGimbalCheck.addEventListener('change', applyDisplayToggles);
+gimbalFullCheck.addEventListener('change', applyDisplayToggles);
+showRollHudCheck.addEventListener('change', applyDisplayToggles);
+showAxisReadoutCheck.addEventListener('change', applyDisplayToggles);
 applyDisplayToggles(); // apply defaults (all unchecked = all hidden)
 
 // Right-click opens settings (needed when gear icon is hidden)

--- a/controller-overlay/src/js/gyro-gimbal.js
+++ b/controller-overlay/src/js/gyro-gimbal.js
@@ -1,0 +1,170 @@
+// ============================================================
+// GYRO-GIMBAL — 3D nested-ring gyroscope visualization
+// ============================================================
+// Three colored torus rings (X/Y/Z) nested inside each other. Each
+// ring rotates with one component of the controller's orientation,
+// giving the classic gimbal look. Driven by gyroFusion.orientation.
+// ============================================================
+
+import * as THREE from 'three';
+
+// Swing-twist decomposition: signed angle of the "twist" component of a
+// quaternion around a unit axis (ax,ay,az). Isolates rotation-around-this-axis
+// from the swing component, so the three returned angles don't cross-couple
+// the way euler angles do.
+function twistAngle(q, ax, ay, az) {
+  const d = q.x * ax + q.y * ay + q.z * az;
+  // Twist quaternion is (d*ax, d*ay, d*az, q.w), before normalization.
+  // Signed angle = 2 * atan2(d, q.w), with sign carried by d.
+  return 2 * Math.atan2(d, q.w);
+}
+
+export class GyroGimbal {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.disposed = false;
+
+    this.renderer = new THREE.WebGLRenderer({
+      canvas,
+      alpha: true,
+      antialias: true,
+      premultipliedAlpha: false,
+    });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.setClearColor(0x000000, 0);
+
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.PerspectiveCamera(40, 1, 0.1, 50);
+    this.camera.position.set(0, 1.6, 4.2);
+    this.camera.lookAt(0, 0, 0);
+
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.7));
+    const key = new THREE.DirectionalLight(0xffffff, 0.9);
+    key.position.set(2, 3, 4);
+    this.scene.add(key);
+    const fill = new THREE.DirectionalLight(0x88aaff, 0.4);
+    fill.position.set(-3, -1, -2);
+    this.scene.add(fill);
+
+    // Three rings as siblings — each shows only its own axis.
+    this.outer = new THREE.Group();  // Y / yaw
+    this.middle = new THREE.Group(); // X / pitch
+    this.inner = new THREE.Group();  // Z / roll
+    // Center indicator (bars + arrow) — always carries the full orientation
+    // so it reads like a physical pointer independent of ring decoupling.
+    this.indicator = new THREE.Group();
+
+    const ringGeo = (radius) => new THREE.TorusGeometry(radius, 0.04, 16, 96);
+    const mat = (hex) => new THREE.MeshStandardMaterial({
+      color: hex, metalness: 0.5, roughness: 0.35,
+      emissive: hex, emissiveIntensity: 0.25,
+    });
+
+    // Outer ring (Y/yaw) — green, lying flat (rotated around X by 90°)
+    const ringY = new THREE.Mesh(ringGeo(1.4), mat(0x44dd66));
+    ringY.rotation.x = Math.PI / 2;
+    this.outer.add(ringY);
+
+    // Middle ring (X/pitch) — red, vertical front-facing
+    const ringX = new THREE.Mesh(ringGeo(1.15), mat(0xee4455));
+    ringX.rotation.y = Math.PI / 2;
+    this.middle.add(ringX);
+
+    // Inner ring (Z/roll) — blue, vertical side-facing
+    const ringZ = new THREE.Mesh(ringGeo(0.9), mat(0x4488ff));
+    this.inner.add(ringZ);
+
+    // Center indicator: a small arrow pointing forward so orientation is readable
+    // Silver center indicator — three axis bars with an arrow on the Z bar
+    // pointing away from the viewer (toward the front of the controller).
+    const silverMat = new THREE.MeshStandardMaterial({
+      color: 0xcfd4dc, metalness: 0.7, roughness: 0.3,
+    });
+
+    const arrowBody = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.04, 0.04, 0.7, 12),
+      silverMat
+    );
+    arrowBody.rotation.x = Math.PI / 2;
+    arrowBody.position.z = 0.0;
+    this.indicator.add(arrowBody);
+
+    const arrowHead = new THREE.Mesh(
+      new THREE.ConeGeometry(0.12, 0.25, 16),
+      silverMat
+    );
+    arrowHead.rotation.x = -Math.PI / 2; // point -Z (into the screen)
+    arrowHead.position.z = -0.45;
+    this.indicator.add(arrowHead);
+
+    const barGeo = new THREE.CylinderGeometry(0.04, 0.04, 1.5, 12);
+    const barX = new THREE.Mesh(barGeo, silverMat);
+    barX.rotation.z = Math.PI / 2; // align along X
+    this.indicator.add(barX);
+    const barY = new THREE.Mesh(barGeo, silverMat); // along Y
+    this.indicator.add(barY);
+
+    // Center sphere
+    const hub = new THREE.Mesh(
+      new THREE.SphereGeometry(0.08, 16, 16),
+      new THREE.MeshStandardMaterial({ color: 0xdddddd, metalness: 0.6, roughness: 0.3 })
+    );
+    this.indicator.add(hub);
+
+    // Siblings, not nested — so yaw doesn't drag red/blue, pitch doesn't
+    // drag green/blue, roll doesn't drag green/red. Each ring shows only
+    // its own axis (unless fullMode is on, where each also gets the full
+    // orientation). The center indicator always gets the full orientation.
+    this.scene.add(this.outer);
+    this.scene.add(this.middle);
+    this.scene.add(this.inner);
+    this.scene.add(this.indicator);
+
+    this._euler = new THREE.Euler();
+    this._q = new THREE.Quaternion();
+    this.fullMode = false; // false = mechanical nested gimbal, true = all rings share full orientation
+
+    this.resize();
+  }
+
+  resize() {
+    const w = this.canvas.clientWidth || 200;
+    const h = this.canvas.clientHeight || 200;
+    this.renderer.setSize(w, h, false);
+    this.camera.aspect = w / h;
+    this.camera.updateProjectionMatrix();
+  }
+
+  // Drive rotation from a controller-orientation quaternion.
+  // When null, slowly returns to identity.
+  update(q) {
+    if (q) {
+      this._q.copy(q);
+    } else {
+      this._q.slerp(new THREE.Quaternion(), 0.08);
+    }
+    if (this.fullMode) {
+      this.outer.quaternion.copy(this._q);
+      this.middle.quaternion.copy(this._q);
+      this.inner.quaternion.copy(this._q);
+    } else {
+      // Swing-twist: extract the pure rotation around each world axis from _q.
+      // Independent of the other axes — unlike euler decomposition, a physical
+      // pitch won't bleed into yaw/roll angles regardless of current pose.
+      const pitch = twistAngle(this._q, 1, 0, 0); // around X
+      const yaw   = twistAngle(this._q, 0, 1, 0); // around Y
+      const roll  = twistAngle(this._q, 0, 0, 1); // around Z
+      this.outer.rotation.set(pitch, 0, 0);   // green / pitch
+      this.middle.rotation.set(0, 0, roll);   // red / roll
+      this.inner.rotation.set(0, yaw, 0);     // blue / yaw
+    }
+    // Center indicator always follows full orientation
+    this.indicator.quaternion.copy(this._q);
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  dispose() {
+    this.disposed = true;
+    this.renderer.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a 3D nested/decoupled gimbal widget (green=pitch, red=roll, blue=yaw) to the single-controller overlay, driven by swing-twist decomposition of the gyro orientation
- New settings: Show 3D Gyro, Gimbal full orientation, Show Roll HUD, Show Axis Values — all persisted in localStorage
- Live P/R/Y degree readout (colored per ring) in the status area
- Auto-repeat on settings stick/dpad navigation (400ms delay, 90ms repeat)

Closes #247

## Test plan
- [ ] Connect a gyro-capable controller, enable "Show 3D Gyro", verify rings rotate independently on each axis
- [ ] Toggle "Gimbal: full orientation" — all rings should share the full orientation
- [ ] Toggle "Show Roll HUD" — arc/needle indicator hides/shows
- [ ] Toggle "Show Axis Values" — large P/R/Y degrees appear below controller badge
- [ ] Hold dpad/stick down in settings — selection auto-repeats down the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)