### PR TITLE
Overlay: flip trigger rotation so pulls press into body (closes #246)

### DIFF
--- a/controller-overlay/src/js/controller-overlay.js
+++ b/controller-overlay/src/js/controller-overlay.js
@@ -465,7 +465,7 @@ export class ControllerOverlay {
         const orig = this.originals[meshName];
         if (!mesh || !orig) continue;
 
-        const targetAngle = orig.rotX + btn.value * profile.triggerMaxAngle;
+        const targetAngle = orig.rotX - btn.value * profile.triggerMaxAngle;
         mesh.rotation.x = THREE.MathUtils.lerp(mesh.rotation.x, targetAngle, LERP_SPEED);
 
         // Yellow emissive glow scaling with trigger pull depth


### PR DESCRIPTION
## Summary
One-line sign flip in the trigger animation — triggers now rotate inward (hinge pressing into the controller body) when pulled, matching the physical motion.

Closes #246

## Test plan
- [ ] Connect a controller, pull L2/R2 — trigger should rotate into the body, not away from it

🤖 Generated with [Claude Code](https://claude.com/claude-code)