### PR TITLE
Overlay: add DualSense mic/mute button (closes #248)

### DIFF
--- a/controller-overlay/src/js/app.js
+++ b/controller-overlay/src/js/app.js
@@ -357,7 +357,7 @@ async function bootstrapFromHID() {
       id: d.productName || drv.driverName,
       index: -1,
       axes: [0, 0, 0, 0],
-      buttons: Array.from({ length: 17 }, () => ({ pressed: false, value: 0 })),
+      buttons: Array.from({ length: 18 }, () => ({ pressed: false, value: 0 })),
     };
     await switchController(stub);
     // switchController() calls disconnectGyro() which nulls syntheticGamepad,
@@ -967,7 +967,7 @@ function createSyntheticGamepad(id) {
     id: id || 'HID Controller',
     index: -1,
     axes: [0, 0, 0, 0],
-    buttons: Array.from({ length: 17 }, () => ({ pressed: false, value: 0 })),
+    buttons: Array.from({ length: 18 }, () => ({ pressed: false, value: 0 })),
     _synthetic: true,
   };
 }
@@ -1012,6 +1012,7 @@ function updateSyntheticFromParsed(parsed) {
     set(14, b.dpadLeft);
     set(15, b.dpadRight);
     set(16, b.ps);
+    set(17, b.mic);
   }
 }
 

--- a/controller-overlay/src/js/controller-overlay.js
+++ b/controller-overlay/src/js/controller-overlay.js
@@ -291,6 +291,50 @@ export class ControllerOverlay {
       }
     }
 
+    // DualSense: procedurally add the mic/mute button (not in the GLB).
+    // Small capsule/pill below the PS button, between the sticks.
+    if (this.controllerType === 'dualsense' && meshByName['button_ps']) {
+      const psMesh = meshByName['button_ps'];
+      psMesh.geometry.computeBoundingBox();
+      const psBB = psMesh.geometry.boundingBox;
+      const psSize = new THREE.Vector3();
+      psBB.getSize(psSize);
+      const psCenter = new THREE.Vector3();
+      psBB.getCenter(psCenter);
+
+      // Pill shape — slightly wider than PS button, very shallow
+      const micW = psSize.x * 1.8;
+      const micH = psSize.y * 0.9;
+      const micD = psSize.z * 0.9;
+      const micGeo = new THREE.CapsuleGeometry(micH * 0.5, Math.max(0.001, micW - micH), 6, 12);
+      // CapsuleGeometry's length is along Y by default — rotate to lie flat (X-long)
+      micGeo.rotateZ(Math.PI / 2);
+
+      const micMat = new THREE.MeshStandardMaterial({
+        color: 0x1a1a1e, metalness: 0.3, roughness: 0.55,
+      });
+      const micMesh = new THREE.Mesh(micGeo, micMat);
+      micMesh.name = 'button_mic';
+
+      // Position in the same local space as PS button:
+      // same X (centered), same Y (top face), offset +Z (toward front/bottom
+      // of controller face) by ~1.6x the PS button's Z size.
+      const micLocalX = psMesh.position.x + psCenter.x;
+      const micLocalY = psMesh.position.y + psBB.max.y; // sit on the face
+      const micLocalZ = psMesh.position.z + psCenter.z + psSize.z * 1.6;
+      micMesh.position.set(micLocalX, micLocalY, micLocalZ);
+
+      psMesh.parent.add(micMesh);
+      this.meshes['button_mic'] = micMesh;
+      this.originals['button_mic'] = {
+        posX: micMesh.position.x,
+        posY: micMesh.position.y,
+        posZ: micMesh.position.z,
+        rotX: micMesh.rotation.x,
+        rotZ: micMesh.rotation.z,
+      };
+    }
+
     // Fix meshes that should be body-colored but are dark in the GLB
     for (const name of ['touchpad', 'button_create', 'button_options']) {
       const m = meshByName[name];

--- a/controller-overlay/src/js/controller-overlay.js
+++ b/controller-overlay/src/js/controller-overlay.js
@@ -303,7 +303,7 @@ export class ControllerOverlay {
       psBB.getCenter(psCenter);
 
       // Pill shape — slightly wider than PS button, very shallow
-      const micW = psSize.x * 1.8;
+      const micW = psSize.x * 0.9;
       const micH = psSize.y * 0.9;
       const micD = psSize.z * 0.9;
       const micGeo = new THREE.CapsuleGeometry(micH * 0.5, Math.max(0.001, micW - micH), 6, 12);

--- a/controller-overlay/src/js/controller-profiles.js
+++ b/controller-overlay/src/js/controller-profiles.js
@@ -36,6 +36,7 @@ export const PROFILES = {
       14: 'dpad_left',
       15: 'dpad_right',
       16: 'button_ps',        // PS button
+      17: 'button_mic',       // Mic / mute (procedurally added — not in GLB)
     },
 
     // Analog triggers (button index → mesh, animated by value 0-1)
@@ -73,7 +74,7 @@ export const PROFILES = {
     ],
     accentColorMeshes: [
       'body_bottom', 'body_extra', 'bumper_l1', 'bumper_r1',
-      'trigger_l2', 'trigger_r2', 'button_ps',
+      'trigger_l2', 'trigger_r2', 'button_ps', 'button_mic',
     ],
     defaultBodyColor: '#e8e8ec',
     defaultAccentColor: '#1a1a1e',

--- a/shared/controllers/dualsense-driver.js
+++ b/shared/controllers/dualsense-driver.js
@@ -104,6 +104,7 @@ export class DualSenseDriver extends ControllerDriver {
       l3:       !!(optByte & 0x40),
       r3:       !!(optByte & 0x80),
       ps:       !!(psByte  & 0x01),
+      mic:      !!(psByte  & 0x04),
       dpadUp:    dpadDir === 7 || dpadDir === 0 || dpadDir === 1,
       dpadRight: dpadDir === 1 || dpadDir === 2 || dpadDir === 3,
       dpadDown:  dpadDir === 3 || dpadDir === 4 || dpadDir === 5,


### PR DESCRIPTION
## Summary
The DualSense GLB has no mic button, so add a small procedural pill mesh just in front of the PS button. Wires the HID mic bit (psByte 0x04) through the synthetic gamepad as button 17, with the standard yellow press highlight.

Closes #248

## Test plan
- [ ] Connect a DualSense, verify the pill mesh appears below the PS button
- [ ] Press the mic/mute button — it should depress slightly and glow yellow

🤖 Generated with [Claude Code](https://claude.com/claude-code)