### PR TITLE
Overlay: allow gyro shortcuts while settings open (closes #254)

### DIFF
--- a/controller-overlay/src/js/app.js
+++ b/controller-overlay/src/js/app.js
@@ -635,8 +635,11 @@ function loop() {
       navigateSettings(gamepad);
       checkCombo(gamepad, 'settings', toggleSettings);
     } else {
-      // Normal combo detection
       checkCombo(gamepad, 'settings', toggleSettings);
+    }
+
+    // Gyro shortcuts work regardless of settings panel state
+    if (!remapTarget && !exitConfirm.classList.contains('visible')) {
       checkCombo(gamepad, 'gyroToggle', toggleGyro);
       checkCombo(gamepad, 'calibrate', () => {
         if (gyroActive) {


### PR DESCRIPTION
## Summary
Gyro toggle (Select+R3) and calibrate (L3+R3) combos were trapped inside an else-if branch that only ran when settings was closed. Moved them outside so they fire regardless of panel state — only suppressed during remap capture and exit dialog.

Closes #254

## Test plan
- [ ] Open settings, press Select+R3 — gyro toggles on/off
- [ ] Open settings, press L3+R3 — calibration starts
- [ ] Remap capture and exit dialog still suppress all combos

🤖 Generated with [Claude Code](https://claude.com/claude-code)