### PR TITLE
Overlay: fix janky Windows startup (Squirrel + transparent flash)

### DIFF
--- a/controller-overlay/electron/main.js
+++ b/controller-overlay/electron/main.js
@@ -1,6 +1,15 @@
 const { app, BrowserWindow, globalShortcut, Tray, Menu, ipcMain } = require('electron');
 const path = require('path');
 
+// Handle Squirrel.Windows install/update/uninstall events. When the Squirrel
+// installer launches the app with --squirrel-install / --squirrel-updated /
+// --squirrel-uninstall / --squirrel-obsolete, this quits immediately so the
+// user doesn't see a flash of the UI followed by a relaunch on first run.
+if (require('electron-squirrel-startup')) {
+  app.quit();
+  return;
+}
+
 let mainWindow = null;
 let tray = null;
 let clickThrough = false;
@@ -16,6 +25,11 @@ function createWindow() {
     resizable: true,
     hasShadow: false,
     skipTaskbar: false,
+    // Don't show the window until the renderer has painted — otherwise the
+    // transparent window flashes the default chrome color (green/white on
+    // Windows) for a few hundred ms before the HTML appears.
+    show: false,
+    backgroundColor: '#00000000',
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
@@ -25,6 +39,10 @@ function createWindow() {
 
   const entry = useMulti ? 'multi.html' : 'index.html';
   mainWindow.loadFile(path.join(__dirname, '..', 'src', entry));
+
+  mainWindow.once('ready-to-show', () => {
+    mainWindow.show();
+  });
 
   // DevTools: Cmd+Shift+I to open manually (auto-open triggers Autofill errors)
 

--- a/controller-overlay/package-lock.json
+++ b/controller-overlay/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "electron-squirrel-startup": "^1.0.1",
         "three": "0.161.0"
       },
       "devDependencies": {
@@ -2533,6 +2534,30 @@
       "optionalDependencies": {
         "appdmg": "^0.6.4"
       }
+    },
+    "node_modules/electron-squirrel-startup": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.1.tgz",
+      "integrity": "sha512-sTfFIHGku+7PsHLJ7v0dRcZNkALrV+YEozINTW8X1nM//e5O3L+rfYuvSW00lmGHnYmUjARZulD8F2V8ISI9RA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.2.0"
+      }
+    },
+    "node_modules/electron-squirrel-startup/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/electron-squirrel-startup/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",

--- a/controller-overlay/package.json
+++ b/controller-overlay/package.json
@@ -16,6 +16,7 @@
     "package": "electron-forge package"
   },
   "dependencies": {
+    "electron-squirrel-startup": "^1.0.1",
     "three": "0.161.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Fixes the "green window → controller briefly appears → window disappears → reloads" experience on the packaged Windows build. Two separate root causes, both addressed.

### 1. Squirrel install/update bookkeeping launches (Setup.exe users)

`@electron-forge/maker-squirrel` builds `3D-Controller-Overlay-Setup.exe` (what users actually download from the GitHub Pages site at `controller-overlay-web/index.html:269`). Squirrel invokes the app with `--squirrel-install` / `--squirrel-updated` / `--squirrel-obsolete` / `--squirrel-uninstall` for install/upgrade bookkeeping and expects the app to quit immediately. Without the standard `electron-squirrel-startup` handler the full overlay UI boots for those invocations, then Squirrel kills it and relaunches — producing the visible exit/reload cycle on first install and every upgrade.

Added `electron-squirrel-startup` and a top-of-file guard in `controller-overlay/electron/main.js` that quits early on Squirrel events.

### 2. Transparent window chrome flash (all launches, every platform)

The `BrowserWindow` was created visible with `transparent: true` and no `backgroundColor`, so Electron painted the default window chrome (green/white on Windows) for a few hundred ms before the renderer's first paint. Created the window hidden with `backgroundColor: '#00000000'` and reveal it on `ready-to-show`.

### Upgrade behavior

- **New installs** from GitHub Pages → clean from the first run.
- **Existing users** upgrading from the current (unpatched) build → one last brief flicker during the Squirrel `--squirrel-obsolete` call on the *old* on-disk exe (can't retroactively patch a binary that's already installed), then every future upgrade is smooth.
- **Patched → patched upgrades** → fully invisible, as both the outgoing and incoming binaries know how to quit cleanly on the Squirrel hooks.

### Follow-up

Filed a separate feature issue for adding Electron's `autoUpdater` so users don't have to manually re-download `Setup.exe` each release.

## Test plan

- [ ] `cd controller-overlay && npm ci && npm start` — local dev still launches cleanly
- [ ] Run `npm run make` on Windows, install the produced `3D-Controller-Overlay-Setup.exe` on a clean VM — no UI flash, no exit/relaunch cycle
- [ ] Install the produced Setup.exe *over* the currently-shipped release on a machine that already has it — confirm the single upgrade-time flicker (expected, one-time), then subsequent launches are clean
- [ ] Run the raw `3d-controller-overlay.exe` from `out/3D Controller Overlay-win32-x64/` — confirm no green/white flash before the controller appears

https://claude.ai/code/session_014Z1beU9ThxFW8VGP1qRS5a