### PR TITLE
Fix gyro roll runaway on DualSense Bluetooth (closes #256)

### DIFF
--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -557,10 +557,13 @@ export class InputManager {
     if (!this.motionEnabled) return;
     this._tmpEuler.setFromQuaternion(fusion.orientation, 'XYZ');
     const leanDeg = -this._tmpEuler.z * (180 / Math.PI);
-    const clampedLean = Math.max(-90, Math.min(90, leanDeg));
-    this._gyroRollAccum = -clampedLean;
-    this._accelRoll = clampedLean;
-    this._applyTilt(clampedLean, true);
+    // Do NOT clamp before passing to _applyTilt — clamping the fusion input
+    // prevents gravity correction from tracking through extreme angles,
+    // causing the "gyro goes wild" feedback loop on noisy BT connections.
+    // _applyTilt's sensitivity/response-curve naturally bounds steering output.
+    this._gyroRollAccum = -leanDeg;
+    this._accelRoll = leanDeg;
+    this._applyTilt(leanDeg, true);
   }
 
   /**

--- a/shared/controller-manager.js
+++ b/shared/controller-manager.js
@@ -161,7 +161,7 @@ class HidEntry {
     this.device = device;
     this.driver = driver;
     this.fusion = new SensorFusion();
-    this.fusion.startCalibration();
+    this.fusion.startCalibration(driver?.connectionType);
     this.synthetic = makeSyntheticGamepad(device);
     this.hasButtons = false;
     this.hidActiveSince = 0;
@@ -265,7 +265,7 @@ class HidEntry {
     }
     try {
       await this.driver.init();
-      this.fusion.startCalibration();
+      this.fusion.startCalibration(this.driver?.connectionType);
     } catch (err) {
       console.warn('Driver re-init failed:', err.message);
     } finally {
@@ -367,7 +367,7 @@ export class Slot {
 
   startGyroCalibration() {
     if (!this.fusion) return;
-    this.fusion.startCalibration();
+    this.fusion.startCalibration(this.driver?.connectionType);
     this._wasCalibrating = true;
     this._emit('calibration-start');
   }

--- a/shared/sensor-fusion.js
+++ b/shared/sensor-fusion.js
@@ -22,7 +22,12 @@
 import * as THREE from 'three';
 
 // ── Initial one-shot bias calibration ──
-export const FUSION_CALIB_COUNT = 150; // ~1.5s at 100Hz
+// Bluetooth captures are noisier (lower effective sample rate + packet
+// jitter) than USB, so BT gets a longer window and a slightly relaxed
+// ideal-stddev bar to avoid repeated retries on a connection that simply
+// cannot produce a tighter window. USB stays at the original tuning.
+export const FUSION_CALIB_COUNT = 150;    // ~1.5s at 100Hz — USB default
+export const FUSION_CALIB_COUNT_BT = 250; // ~2.5s — BT needs more samples
 // Variance thresholds for bias calibration.
 //  - IDEAL: commit immediately when any axis's per-sample stddev is under
 //    this. A still DualSense typically produces stddev 5–15 raw units.
@@ -32,6 +37,7 @@ export const FUSION_CALIB_COUNT = 150; // ~1.5s at 100Hz
 //    (previous value, zero on first pass) and let the continuous stillness
 //    calibration refine it in the background once the user settles.
 const FUSION_CALIB_IDEAL_STDDEV = 150;
+const FUSION_CALIB_IDEAL_STDDEV_BT = 200; // BT packet jitter raises the floor
 const FUSION_CALIB_ABORT_STDDEV = 1500;
 const FUSION_CALIB_MAX_RETRIES = 5;
 
@@ -118,12 +124,20 @@ export class SensorFusion {
   /** Whether the initial one-shot bias calibration is still collecting. */
   get calibrating() { return this._calibrating; }
 
-  /** Begin initial bias calibration. Clears any prior samples. */
-  startCalibration() {
+  /**
+   * Begin initial one-shot bias calibration. Clears any prior samples.
+   * @param {string} [connectionType] — 'bluetooth' or 'usb'. BT gets a
+   *   longer capture window and relaxed ideal-stddev threshold to match
+   *   the noisier transport. Defaults to USB tuning when unspecified.
+   */
+  startCalibration(connectionType) {
     this._calibrating = true;
     this._calibSamples = [];
     this._calibRetries = 0;
     this._calibBest = null;
+    const isBT = connectionType === 'bluetooth';
+    this._calibCount = isBT ? FUSION_CALIB_COUNT_BT : FUSION_CALIB_COUNT;
+    this._calibIdealStddev = isBT ? FUSION_CALIB_IDEAL_STDDEV_BT : FUSION_CALIB_IDEAL_STDDEV;
   }
 
   /** Abort calibration without touching bias. */
@@ -187,7 +201,8 @@ export class SensorFusion {
     // Initial one-shot bias capture with best-of-N retry selection.
     if (this._calibrating) {
       this._calibSamples.push({ x: rawGx, y: rawGy, z: rawGz });
-      if (this._calibSamples.length >= FUSION_CALIB_COUNT) {
+      const calibCount = this._calibCount || FUSION_CALIB_COUNT;
+      if (this._calibSamples.length >= calibCount) {
         const n = this._calibSamples.length;
         let sx = 0, sy = 0, sz = 0;
         for (const s of this._calibSamples) { sx += s.x; sy += s.y; sz += s.z; }
@@ -208,7 +223,8 @@ export class SensorFusion {
         if (!this._calibBest || maxStd < this._calibBest.stddev) {
           this._calibBest = { meanX, meanY, meanZ, stddev: maxStd };
         }
-        if (maxStd <= FUSION_CALIB_IDEAL_STDDEV) {
+        const idealStddev = this._calibIdealStddev || FUSION_CALIB_IDEAL_STDDEV;
+        if (maxStd <= idealStddev) {
           // Great sample — commit immediately.
           this.bias.x = meanX;
           this.bias.y = meanY;


### PR DESCRIPTION
## Summary
Two compounding issues caused the gyro roll to peg hard left/right during Solo Ride, then snap back (observed twice in a single ride on DualSense BT):

- **Clamp fighting fusion.** `input-manager.js` clamped the Euler-extracted roll to ±90° before passing it to `_applyTilt` and writing it back into the state-tracking fields. When drift pushed the quaternion toward the boundary, the clamped readback prevented the gravity-correction pipeline from tracking through it — the roll stayed pegged until correction slowly pulled it past, then overshot to the other side. `_applyTilt`'s sensitivity / response curve already bounds steering output, so the clamp was redundant and actively harmful. Removed.
- **USB-tuned calibration on a BT transport.** Initial bias calibration used 150 samples / stddev≤150 ideal threshold for all transports. Bluetooth has more packet jitter and a lower effective sample rate, making clean windows hard to capture (observed stddev=233 in the field). Added BT-specific tuning: 250 samples (~2.5s) and ideal stddev 200. `SensorFusion.startCalibration(connectionType)` picks the right thresholds; `HidEntry` / `Slot.startGyroCalibration` pass `driver.connectionType` through.

USB tuning is unchanged.

## Test plan
- [ ] Solo Ride with DualSense over Bluetooth, ≥3 minutes of aggressive lean — confirm no hard-left/hard-right runaway
- [ ] Solo Ride with DualSense over USB — confirm steering feel unchanged
- [ ] Local MP (P1 + P2 DualSense BT) — confirm both players' gyro calibrates cleanly through countdown
- [ ] L3 recenter mid-ride still works
- [ ] Check console for `Fusion calib retry` frequency on BT — should be rarer with the wider window
- [ ] Confirm `Gyro recentered:` log no longer shows `rollAccum=±90.0` values after drift events

## Related
- #230 — Gyro drift indicator + auto-recenter (separate symptom, still open)
- #216 — Multiplayer gyro calibration improvements (BT tuning here helps the noisy-first-calibration observation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)