### PR TITLE
Local MP: gate rumble on held controllers + stoker assist parity (#216)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -3299,9 +3299,17 @@ class Game {
 
     // Compute P2's lean via their own balance controller. The captain path
     // will average (captainLean + this.remoteLean) * 0.5, so stashing P2's
-    // lean into this.remoteLean makes the existing math Just Work.
-    const balanceResultP2 = this.balanceCtrlP2.update(this.bike, 0, null, null);
-    this.remoteLean = balanceResultP2.leanInput;
+    // lean into this.remoteLean makes the existing math Just Work. Pass the
+    // same assist + item managers as the captain path so stoker gets
+    // identical auto-steer when assist is engaged — without this, the back
+    // seat felt "looser" than the front seat because DDA assist only
+    // corrected captain's half of the merge.
+    const balanceResultP2 = this.balanceCtrlP2.update(this.bike, this._assistWeight, this.collectibleManager, this.obstacleManager);
+    // One-human local MP: if P2's controller is idle on the desk, its gyro
+    // drifts (and gets rumble-shaken) and dragging that into the 50/50 lean
+    // merge makes steering feel loose. Zero the contribution until the
+    // player actually picks P2 up.
+    this.remoteLean = this.inputP2.isActive() ? balanceResultP2.leanInput : 0;
 
     // Edge-detect P2 pedals → feed as the 'stoker' source into the shared
     // pedal controller. The captain path does the same for its own ('captain')

--- a/js/haptics.js
+++ b/js/haptics.js
@@ -76,6 +76,18 @@ function _gamepadRumble(strong, weak, duration) {
       for (const src of _hapticSources) {
         if (!src) continue;
 
+        // Skip controllers sitting idle on the desk during one-human local
+        // MP — rumbling a resting controller shakes its gyro and pollutes
+        // the steering merge. `isActive()` returns true by default on
+        // sources that haven't opted into held-detection.
+        if (typeof src.isActive === 'function' && !src.isActive()) continue;
+
+        // Let the source suppress its in-motion bias calibration during
+        // the rumble window so vibration doesn't corrupt gyro bias.
+        if (typeof src.onRumbleWillFire === 'function') {
+          src.onRumbleWillFire(duration);
+        }
+
         // Prefer the driver-level rumble path when the source has a
         // controller driver that implements setRumble — e.g. DualSense on
         // macOS, where Chromium's Gamepad API vibrationActuator sometimes

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -96,6 +96,13 @@ export class InputManager {
     // DOM badge updates and haptic source registration.
     this._lastGamepadConnected = false;
     this._lastHidBound = false;
+
+    // Held-detection: timestamp of the last user action on this controller
+    // (button press, trigger, stick past deadzone, or keyboard). Used by
+    // haptics + local-MP lean merge to identify a controller sitting idle
+    // on the desk during one-human local multiplayer. Seeded to "now" so
+    // controllers default to active before any input arrives.
+    this._lastActivityMs = performance.now();
     // Edge-detect flag for "calibration just finished" auto-arm of
     // motionEnabled. Set while fusion.calibrating, cleared after arm.
     this._wasFusionCalibrating = false;
@@ -184,6 +191,11 @@ export class InputManager {
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
       if (['ArrowLeft','ArrowRight','KeyA','KeyD'].includes(e.code)) e.preventDefault();
       this.keys[e.code] = true;
+      // Only count keyboard activity when this InputManager actually owns
+      // the keyboard (in local MP, P1's keyboard is released to P2 by
+      // setting keyboardActive=false — without this gate, P2's typing
+      // would falsely mark P1 as held).
+      if (this.keyboardActive) this._markActive();
     });
     window.addEventListener('keyup', (e) => {
       const tag = document.activeElement && document.activeElement.tagName;
@@ -214,6 +226,7 @@ export class InputManager {
         this.touchRight = true;
         this._rightTapped = true;
       }
+      this._markActive();
     };
 
     pedalBar.addEventListener('touchstart', (e) => {
@@ -535,6 +548,14 @@ export class InputManager {
       this._gpTriggerRightVal = gp.buttons[7] ? gp.buttons[7].value : 0;
       this._gpTriggerLeftPressed = this._gpLB || this._gpTriggerLeftVal >= THRESHOLD;
       this._gpTriggerRightPressed = this._gpRB || this._gpTriggerRightVal >= THRESHOLD;
+
+      // Held-detection: stick/trigger/shoulder activity = human is touching
+      // this controller. Gyro motion is intentionally NOT used here — rumble
+      // shakes a resting controller's gyro and would falsely mark it held.
+      if (Math.abs(rawX) >= 0.08 ||
+          this._gpTriggerLeftPressed || this._gpTriggerRightPressed) {
+        this._markActive();
+      }
     }
 
     // Orientation → tilt projection. The slot's HidEntry ingests gyro at
@@ -645,5 +666,34 @@ export class InputManager {
 
   getMotionLean() {
     return this.motionEnabled ? this.motionLean : 0;
+  }
+
+  /** Stamp this controller as "in use right now". */
+  _markActive() {
+    this._lastActivityMs = performance.now();
+  }
+
+  /**
+   * True if this controller has had user input within the last `timeoutMs`.
+   * Sources: keyboard, touch, gamepad stick (past deadzone), triggers,
+   * shoulder buttons. Gyro motion is deliberately excluded so rumble
+   * vibrations on a resting controller don't keep it falsely flagged as
+   * held. The default 10s window easily spans normal pedaling cadence
+   * (tandem MP requires constant pedal taps).
+   */
+  isActive(timeoutMs = 10000) {
+    return (performance.now() - this._lastActivityMs) < timeoutMs;
+  }
+
+  /**
+   * Called by the haptics module just before rumble fires on this
+   * controller. Suppresses the in-motion sensor-fusion bias-refinement
+   * calibration for the rumble duration plus a short settle margin, so
+   * rumble-induced accel noise can't corrupt the bias estimate. The
+   * initial one-shot and continuous stillness calibrations are
+   * naturally gated by their own thresholds.
+   */
+  onRumbleWillFire(durationMs) {
+    this._slot?.fusion?.suppressCalibrationFor(durationMs + 200);
   }
 }

--- a/shared/sensor-fusion.js
+++ b/shared/sensor-fusion.js
@@ -110,6 +110,13 @@ export class SensorFusion {
     this._sfTimeSteady = 0;
     this._sfSkippedTime = 0;
 
+    // performance.now() until which the in-motion bias-refinement
+    // pipeline is suppressed. Set by suppressCalibrationFor() when
+    // rumble fires so vibration-induced accel noise can't pollute the
+    // gyro/accel cross-check. The stillness calibration auto-gates on
+    // its own thresholds and is not affected.
+    this._suppressCalibUntilMs = 0;
+
     // Timekeeping: set to performance.now() on first ingest().
     this._lastGyroTime = 0;
 
@@ -144,6 +151,18 @@ export class SensorFusion {
   cancelCalibration() {
     this._calibrating = false;
     this._calibSamples = [];
+  }
+
+  /**
+   * Suppress the in-motion sensor-fusion calibration pipeline for the
+   * next `ms` milliseconds. Called by the haptics module when rumble
+   * fires — rumble vibration produces high-frequency accel noise that
+   * aliases below the normal threshold gate and would otherwise pollute
+   * the gyro-vs-accel bias cross-check.
+   */
+  suppressCalibrationFor(ms) {
+    const until = performance.now() + ms;
+    if (until > this._suppressCalibUntilMs) this._suppressCalibUntilMs = until;
   }
 
   /**
@@ -366,8 +385,10 @@ export class SensorFusion {
       this._updateStillnessCalibration(rawGx, rawGy, rawGz, hasAccel ? rawAx : 0, hasAccel ? rawAy : 0, hasAccel ? rawAz : 0, accelScale, dt, nowMs);
     }
 
-    // 5. Sensor-fusion calibration (runs when accel is changing)
-    if (!this._calibrating && hasAccel) {
+    // 5. Sensor-fusion calibration (runs when accel is changing). Skipped
+    // while rumble is suppressing calibration — vibration noise would
+    // otherwise contaminate the gyro-vs-accel bias cross-check.
+    if (!this._calibrating && hasAccel && nowMs >= this._suppressCalibUntilMs) {
       this._updateSensorFusionCalibration(rawGx, rawGy, rawGz, gyroScale, rawAx, rawAy, rawAz, dt);
     }
   }


### PR DESCRIPTION
## Summary
Fixes three compounding issues observed in one-human local multiplayer on DualSense BT (two controllers, one held, one on the desk):

- **Rumble shook the desk controller's gyro.** Haptics fired on both P1 and P2 regardless of which was held. The desk controller's accelerometer picked up the vibration, sensor fusion's "shaky mode" trusted the gyro more in response, and the noise got integrated as real roll — then averaged into bike steering at 50%, destabilizing the held controller's input.
- **Stoker felt looser than captain.** Captain's balance controller received \`_assistWeight\` + item managers; stoker's was hardcoded to \`0, null, null\`. With DDA or assist-button engaged, captain's half of the merge got auto-steer correction while stoker's half stayed raw.
- **Rumble vibration can leak through the in-motion fusion bias calibration.** The existing angular-accel threshold doesn't fully reject aliased high-frequency accel noise, so the cross-check could refine bias toward a corrupted value.

## Changes

**Held-detection (InputManager)**
- \`_lastActivityMs\` timestamp updated on button/trigger/stick/keyboard/touch input. Gyro motion is deliberately **excluded** so rumble vibration on a resting controller can't self-perpetuate the "held" signal.
- Keyboard activity only counts when \`this.keyboardActive\` (P1 releases keyboard to P2 in local MP — without this gate, P2's typing would falsely mark P1 held).
- \`isActive(timeoutMs = 10000)\` — 10s window covers normal tandem pedaling cadence.
- \`onRumbleWillFire(durationMs)\` — informs the fusion to suppress calib during rumble.

**Rumble gate (haptics.js)**
- \`_gamepadRumble\` skips sources where \`isActive()\` is false.
- Calls \`onRumbleWillFire(duration)\` on active sources before firing rumble.

**Stoker assist parity (game.js \`_updateLocal\`)**
- \`balanceCtrlP2.update(bike, this._assistWeight, this.collectibleManager, this.obstacleManager)\` — matches captain path.
- \`this.remoteLean = this.inputP2.isActive() ? ... : 0\` — desk controller no longer drags drift into the lean merge.

**Fusion calib gate (shared/sensor-fusion.js)**
- New \`suppressCalibrationFor(ms)\` method — extends a suppression window.
- Step 5 (\`_updateSensorFusionCalibration\`) in \`ingest()\` now skipped when \`now < _suppressCalibUntilMs\`.
- Stillness calibration (step 4) and initial one-shot calibration are unchanged — they auto-gate on their own thresholds.

## Test plan
- [ ] One-human local MP, DualSense BT x2: hold P1 only → bike steers crisply from P1, P2 on desk contributes 0 to merge
- [ ] Swap: hold P2 only → same crisp response from P2, P1 on desk contributes 0
- [ ] Observe: rumble events (off-road, tree hits, checkpoints) only vibrate the held controller
- [ ] Two-human local MP with both controllers actively used: both feel rumble, both contribute to merge (regression check)
- [ ] Engage assist button mid-ride → stoker's half of the merge now feels equally "magnetic" to road center as captain's
- [ ] Extended ride with rumble-heavy gameplay (tree hits) → no visible bias drift on held controller after rumble subsides
- [ ] Idle the held controller for 10+ seconds without input → becomes inactive, next input wakes it back up

## Related
- Closes observations in #216 (Multiplayer gyro calibration and testing improvements)
- Builds on the BT calibration tuning from #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)