### PR TITLE
Audio: shared engine, bike motion loop, richer SFX (Phase 1 of #267)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4452,7 +4452,14 @@ ON</button>
       </p>
       <p class="help-attribution">
         Thanks to <a href="https://thecogg.com" target="_blank" rel="noopener"><strong>The Central Ohio GameDev Group</strong></a>
-        — for inspiration, friendship, and fun.
+        &mdash; for inspiration, friendship, and fun.
+      </p>
+      <p class="help-attribution">
+        Immersive audio design based on the taxonomy in
+        <em>&ldquo;A Taxonomy for Immersive Audio Techniques in Video Game Sound Design&rdquo;</em>
+        by <a href="https://music.osu.edu/people/sallade.5" target="_blank" rel="noopener"><strong>Alex Sallade</strong></a>
+        (<a href="mailto:sallade.5@osu.edu">sallade.5@osu.edu</a>,
+        Ph.D. dissertation, The Ohio State University, 2024).
       </p>
     </div>
 

--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -1,0 +1,336 @@
+// Shared Web Audio engine for Tandemonium.
+//
+// Design goals:
+//   - One AudioContext, lazily created on first user gesture (iOS-safe).
+//   - Three buses off a single master: music, sfx, bike. Lets us duck music
+//     during gameplay without touching individual volumes (St2).
+//   - Procedural bike motion sound (wind + tire hiss + chain) driven by
+//     speed (Sp3), so the bike is never silent while rolling.
+//   - Richer SFX timbres (bell-like chime with inharmonic partials, noise-
+//     based crash) instead of bare square/sine oscillators (Ti1).
+//   - Linear crossfades on music start/stop/duck changes (St3).
+//   - Recorder tap: connecting a MediaStreamDestination on the master bus
+//     keeps music + SFX + bike audio in exported clips automatically.
+//
+// The engine never disconnects the <audio> MediaElementSource after creating
+// it. Muting is handled by ramping the music bus gain to zero and pausing
+// the element — this avoids the iOS looping-artifact bug the old code
+// worked around with disconnect/reconnect.
+
+// Shared motif for the Tandemonium audio signature (Re4). C major triad
+// inherited from the original finish chime; reused in checkpoint & victory.
+export const MOTIF = {
+  C5: 523.25,
+  E5: 659.25,
+  G5: 783.99,
+};
+
+export class AudioEngine {
+  constructor() {
+    this.ctx = null;
+    this.master = null;
+    this.musicBus = null;
+    this.sfxBus = null;
+    this.bikeBus = null;
+    this._musicDuck = null;
+    this._musicSrc = null;
+    this._recorderDest = null;
+    this._noiseBuf = null;
+    this._bike = null;
+    this._duckTarget = 1.0;
+  }
+
+  // Create the AudioContext and bus graph. Safe to call multiple times.
+  // Returns the context (or null if Web Audio is unavailable).
+  ensureContext() {
+    if (this.ctx) return this.ctx;
+    const Ctor = window.AudioContext || window.webkitAudioContext;
+    if (!Ctor) return null;
+    const ctx = new Ctor();
+    this.ctx = ctx;
+
+    this.master = ctx.createGain();
+    this.master.gain.value = 1.0;
+    this.master.connect(ctx.destination);
+
+    this.musicBus = ctx.createGain();
+    this.musicBus.gain.value = 1.0;
+    this._musicDuck = ctx.createGain();
+    this._musicDuck.gain.value = 1.0;
+    this.musicBus.connect(this._musicDuck).connect(this.master);
+
+    this.sfxBus = ctx.createGain();
+    this.sfxBus.gain.value = 1.0;
+    this.sfxBus.connect(this.master);
+
+    this.bikeBus = ctx.createGain();
+    this.bikeBus.gain.value = 0.0;
+    this.bikeBus.connect(this.master);
+
+    return ctx;
+  }
+
+  resume() {
+    if (this.ctx && this.ctx.state === 'suspended') {
+      this.ctx.resume();
+    }
+  }
+
+  // Silent warmup buffer primes the iOS audio session so the first real
+  // sound isn't delayed 2-3 seconds.
+  warmup() {
+    if (!this.ctx) return;
+    try {
+      const buf = this.ctx.createBuffer(1, 1, this.ctx.sampleRate);
+      const src = this.ctx.createBufferSource();
+      src.buffer = buf;
+      src.connect(this.ctx.destination);
+      src.start();
+    } catch (e) {}
+  }
+
+  // Tap the full mix into a MediaStreamDestination (for GameRecorder).
+  attachRecorderDestination(dest) {
+    if (!this.ctx || !this.master || !dest) return;
+    this._recorderDest = dest;
+    try { this.master.connect(dest); } catch (e) {}
+  }
+
+  detachRecorderDestination() {
+    if (this._recorderDest && this.master) {
+      try { this.master.disconnect(this._recorderDest); } catch (e) {}
+    }
+    this._recorderDest = null;
+  }
+
+  // Route a background-music <audio> element through the music bus.
+  connectMusicElement(el) {
+    if (!this.ctx || !el || this._musicSrc) return;
+    try {
+      this._musicSrc = this.ctx.createMediaElementSource(el);
+      this._musicSrc.connect(this.musicBus);
+    } catch (e) {}
+  }
+
+  // St2 — ramp the music duck gain to target (typically 1.0 idle, 0.55 play).
+  duckMusic(target, duration = 0.6) {
+    if (!this._musicDuck || !this.ctx) return;
+    this._duckTarget = target;
+    const now = this.ctx.currentTime;
+    const g = this._musicDuck.gain;
+    g.cancelScheduledValues(now);
+    g.setValueAtTime(g.value, now);
+    g.linearRampToValueAtTime(target, now + duration);
+  }
+
+  // St3 — linear crossfade helper for any GainNode.
+  crossfade(gainNode, target, duration = 0.3) {
+    if (!gainNode || !this.ctx) return;
+    const now = this.ctx.currentTime;
+    gainNode.gain.cancelScheduledValues(now);
+    gainNode.gain.setValueAtTime(gainNode.gain.value, now);
+    gainNode.gain.linearRampToValueAtTime(target, now + duration);
+  }
+
+  // Instant mute of the entire mix (honoured by the existing M shortcut).
+  setMuted(muted) {
+    if (!this.master) return;
+    this.master.gain.value = muted ? 0 : 1;
+  }
+
+  // ── SFX (Ti1) ────────────────────────────────────────────────────────────
+
+  // Short tone with attack/decay envelope. Used as the general-purpose beep.
+  // `type` defaults to 'triangle' — warmer than the old 'square' without
+  // losing the arcade-y feel.
+  tone(freq, duration, opts = {}) {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    this.resume();
+    const { type = 'triangle', gain = 0.14, attack = 0.006 } = opts;
+    const now = ctx.currentTime;
+    const osc = ctx.createOscillator();
+    const g = ctx.createGain();
+    osc.type = type;
+    osc.frequency.value = freq;
+    g.gain.setValueAtTime(0.0001, now);
+    g.gain.exponentialRampToValueAtTime(gain, now + attack);
+    g.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+    osc.connect(g).connect(this.sfxBus);
+    osc.start(now);
+    osc.stop(now + duration + 0.02);
+  }
+
+  // Bell-like chime: fundamental + a few inharmonic partials. Far less
+  // "test-tone" sounding than a plain sine oscillator.
+  chime(freq, duration, gain = 0.28) {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    this.resume();
+    const now = ctx.currentTime;
+    const partials = [
+      { mult: 1.0,  amp: 1.0  },
+      { mult: 2.0,  amp: 0.45 },
+      { mult: 3.01, amp: 0.22 },
+      { mult: 4.07, amp: 0.10 }, // slight inharmonicity for bell character
+    ];
+    const env = ctx.createGain();
+    env.gain.setValueAtTime(0.0001, now);
+    env.gain.exponentialRampToValueAtTime(gain, now + 0.005);
+    env.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+    env.connect(this.sfxBus);
+    for (const p of partials) {
+      const osc = ctx.createOscillator();
+      osc.type = 'sine';
+      osc.frequency.value = freq * p.mult;
+      const pg = ctx.createGain();
+      pg.gain.value = p.amp;
+      osc.connect(pg).connect(env);
+      osc.start(now);
+      osc.stop(now + duration + 0.02);
+    }
+  }
+
+  // Noise-based crash impact with a low-frequency thump. Replaces the old
+  // double-beep crash cue with something that actually reads as an impact.
+  crash(intensity = 1) {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    this.resume();
+    const now = ctx.currentTime;
+    const duration = 0.45;
+
+    // Bandpassed white noise — the "clatter"
+    const src = ctx.createBufferSource();
+    src.buffer = this._getNoiseBuffer();
+    const bp = ctx.createBiquadFilter();
+    bp.type = 'bandpass';
+    bp.frequency.value = 900;
+    bp.Q.value = 0.6;
+    const ng = ctx.createGain();
+    ng.gain.setValueAtTime(0.35 * intensity, now);
+    ng.gain.exponentialRampToValueAtTime(0.001, now + duration);
+    src.connect(bp).connect(ng).connect(this.sfxBus);
+    src.start(now);
+    src.stop(now + duration);
+
+    // Pitch-falling sine — the "thump"
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(140, now);
+    osc.frequency.exponentialRampToValueAtTime(55, now + 0.22);
+    const og = ctx.createGain();
+    og.gain.setValueAtTime(0.45 * intensity, now);
+    og.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+    osc.connect(og).connect(this.sfxBus);
+    osc.start(now);
+    osc.stop(now + 0.32);
+  }
+
+  _getNoiseBuffer() {
+    if (this._noiseBuf) return this._noiseBuf;
+    const sr = this.ctx.sampleRate;
+    const buf = this.ctx.createBuffer(1, Math.floor(sr * 2), sr);
+    const d = buf.getChannelData(0);
+    for (let i = 0; i < d.length; i++) d[i] = Math.random() * 2 - 1;
+    this._noiseBuf = buf;
+    return buf;
+  }
+
+  // ── Bike motion loop (Sp3) ───────────────────────────────────────────────
+
+  startBike() {
+    const ctx = this.ctx;
+    if (!ctx || this._bike) return;
+
+    // Wind: lowpassed pink-ish noise
+    const windSrc = ctx.createBufferSource();
+    windSrc.buffer = this._getNoiseBuffer();
+    windSrc.loop = true;
+    const windFilt = ctx.createBiquadFilter();
+    windFilt.type = 'lowpass';
+    windFilt.frequency.value = 420;
+    windFilt.Q.value = 0.5;
+    const windGain = ctx.createGain();
+    windGain.gain.value = 0;
+    windSrc.connect(windFilt).connect(windGain).connect(this.bikeBus);
+
+    // Tires: bandpassed noise around 1200 Hz
+    const tireSrc = ctx.createBufferSource();
+    tireSrc.buffer = this._getNoiseBuffer();
+    tireSrc.loop = true;
+    const tireFilt = ctx.createBiquadFilter();
+    tireFilt.type = 'bandpass';
+    tireFilt.frequency.value = 1200;
+    tireFilt.Q.value = 1.0;
+    const tireGain = ctx.createGain();
+    tireGain.gain.value = 0;
+    tireSrc.connect(tireFilt).connect(tireGain).connect(this.bikeBus);
+
+    // Drivetrain: low filtered saw whose pitch tracks cadence
+    const chainOsc = ctx.createOscillator();
+    chainOsc.type = 'sawtooth';
+    chainOsc.frequency.value = 60;
+    const chainFilt = ctx.createBiquadFilter();
+    chainFilt.type = 'lowpass';
+    chainFilt.frequency.value = 240;
+    chainFilt.Q.value = 2;
+    const chainGain = ctx.createGain();
+    chainGain.gain.value = 0;
+    chainOsc.connect(chainFilt).connect(chainGain).connect(this.bikeBus);
+
+    windSrc.start();
+    tireSrc.start();
+    chainOsc.start();
+
+    this._bike = { windSrc, tireSrc, chainOsc, windGain, tireGain, chainGain };
+
+    // Fade the bus in; individual sources stay at 0 until speed rises.
+    const now = ctx.currentTime;
+    this.bikeBus.gain.cancelScheduledValues(now);
+    this.bikeBus.gain.setValueAtTime(this.bikeBus.gain.value, now);
+    this.bikeBus.gain.linearRampToValueAtTime(1.0, now + 0.2);
+  }
+
+  stopBike() {
+    if (!this.ctx || !this._bike) return;
+    const ctx = this.ctx;
+    const now = ctx.currentTime;
+    this.bikeBus.gain.cancelScheduledValues(now);
+    this.bikeBus.gain.setValueAtTime(this.bikeBus.gain.value, now);
+    this.bikeBus.gain.linearRampToValueAtTime(0, now + 0.3);
+    const b = this._bike;
+    this._bike = null;
+    setTimeout(() => {
+      try { b.windSrc.stop(); } catch (e) {}
+      try { b.tireSrc.stop(); } catch (e) {}
+      try { b.chainOsc.stop(); } catch (e) {}
+    }, 400);
+  }
+
+  // Called each frame while playing. `speed` in the bike's units,
+  // `maxSpeed` the configured cap, `offRoad` 0-1 surface roughness.
+  updateBike(speed, maxSpeed, offRoad = 0, fallen = false) {
+    if (!this.ctx || !this._bike) return;
+    const ctx = this.ctx;
+    const norm = Math.max(0, Math.min(1, speed / (maxSpeed || 19)));
+    const ramp = 0.12;
+    const now = ctx.currentTime;
+
+    const wind  = fallen ? 0 : norm * norm * 0.22;
+    const tire  = fallen ? 0 : norm * 0.16 + offRoad * 0.28;
+    const chain = fallen ? 0 : norm * 0.09;
+    const chainHz = 58 + norm * 112;
+
+    const { windGain, tireGain, chainGain, chainOsc } = this._bike;
+    [windGain.gain, tireGain.gain, chainGain.gain].forEach((g, i) => {
+      const t = [wind, tire, chain][i];
+      g.cancelScheduledValues(now);
+      g.setValueAtTime(g.value, now);
+      g.linearRampToValueAtTime(t, now + ramp);
+    });
+    chainOsc.frequency.cancelScheduledValues(now);
+    chainOsc.frequency.setValueAtTime(chainOsc.frequency.value, now);
+    chainOsc.frequency.linearRampToValueAtTime(chainHz, now + ramp);
+  }
+}

--- a/js/game-recorder.js
+++ b/js/game-recorder.js
@@ -629,7 +629,7 @@ export class GameRecorder {
   // Chunks accumulate in _chunks[]; we keep only the last bufferDuration
   // seconds worth. On save: stop recorder, assemble kept chunks into one blob.
 
-  async startBuffer(audioCtx, micEnabled = false) {
+  async startBuffer(audioCtx, micEnabled = false, audioEngine = null) {
     // Wait for GPU readback probe to finish before deciding whether to buffer
     await this._gpuProbe;
     if (!this.supported || this.buffering) return;
@@ -671,10 +671,15 @@ export class GameRecorder {
     this._mimeType = this._getMimeType();
     if (!this._mimeType) return;
 
-    // Set up audio mixing destination using the game's AudioContext
+    // Set up audio mixing destination using the game's AudioContext. If an
+    // AudioEngine was provided, tap its master bus so music + SFX + bike audio
+    // all land in the recording without per-node wiring.
     if (audioCtx) {
       this._audioCtx = audioCtx;
       this._audioDestination = audioCtx.createMediaStreamDestination();
+      if (audioEngine && typeof audioEngine.attachRecorderDestination === 'function') {
+        audioEngine.attachRecorderDestination(this._audioDestination);
+      }
       // Add the mixed audio track to the recording stream
       for (const track of this._audioDestination.stream.getAudioTracks()) {
         this._stream.addTrack(track);

--- a/js/game.js
+++ b/js/game.js
@@ -23,6 +23,7 @@ import { GrassParticles } from './grass-particles.js';
 import { Lobby } from './lobby.js';
 import { GameRecorder } from './game-recorder.js';
 import { ArchIndicator } from './arch-indicator.js';
+import { AudioEngine, MOTIF } from './audio-engine.js';
 import { hapticCrash, hapticTreeHit, hapticCheckpoint, hapticFinish, hapticOffRoad, setHapticSources } from './haptics.js';
 import { DDAManager } from './dda-manager.js';
 import * as analytics from './analytics.js';
@@ -479,7 +480,8 @@ class Game {
     this.countdownTimer = 0;
     this._lastCountNum = 3;
     this.instructionsEl = document.getElementById('instructions');
-    this.audioCtx = null;
+    this.audioEngine = new AudioEngine();
+    this.audioCtx = null; // mirrors audioEngine.ctx once created (recorder API)
 
     // Lobby
     this.lobby = new Lobby({
@@ -494,8 +496,6 @@ class Game {
     this._musicEl = new Audio('assets/Krampus Workshop.mp3');
     this._musicEl.loop = true;
     this._musicEl.volume = this.lobby.musicVolume;
-    this._musicSourceNode = null; // created once via createMediaElementSource
-
     // In-game music mute button
     this._musicBtn = document.getElementById('music-btn');
     this._updateMusicBtnIcon();
@@ -511,20 +511,16 @@ class Game {
 
     this.lobby.onMusicChanged = (on) => {
       if (on) {
-        // Reconnect source node to AudioContext destination before playing
-        if (this._musicSourceNode && this.audioCtx) {
-          try { this._musicSourceNode.connect(this.audioCtx.destination); } catch (e) {}
-          // Also reconnect to recording destination if actively recording
-          if (this.recorder && this.recorder._audioDestination) {
-            try { this._musicSourceNode.connect(this.recorder._audioDestination); } catch (e) {}
-          }
-        }
+        this.audioEngine.crossfade(this.audioEngine.musicBus, 1.0, 0.3);
         this._musicEl.play().catch(() => {});
       } else {
-        this._musicEl.pause();
-        // Disconnect source node so iOS doesn't produce glitchy looping artifacts
-        if (this._musicSourceNode) {
-          try { this._musicSourceNode.disconnect(); } catch (e) {}
+        // Ramp to silence first, then pause; avoids the old iOS looping
+        // artifact without needing to disconnect the source node.
+        if (this.audioEngine.musicBus) {
+          this.audioEngine.crossfade(this.audioEngine.musicBus, 0, 0.25);
+          setTimeout(() => { try { this._musicEl.pause(); } catch (e) {} }, 280);
+        } else {
+          this._musicEl.pause();
         }
       }
       this._updateMusicBtnIcon();
@@ -1195,24 +1191,15 @@ class Game {
     // Init audio before recording so beeps are captured.
     // Eagerly resume + play silent buffer to warm up iOS audio pipeline
     // (avoids 2-3s delay on first real sound).
-    try {
-      if (!this.audioCtx) {
-        this.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-      }
-      if (this.audioCtx.state === 'suspended') {
-        this.audioCtx.resume();
-      }
-      // Silent warmup buffer — primes iOS audio session
-      const buf = this.audioCtx.createBuffer(1, 1, this.audioCtx.sampleRate);
-      const src = this.audioCtx.createBufferSource();
-      src.buffer = buf;
-      src.connect(this.audioCtx.destination);
-      src.start();
-    } catch (e) {}
+    this.audioEngine.ensureContext();
+    this.audioEngine.resume();
+    this.audioEngine.warmup();
+    this.audioCtx = this.audioEngine.ctx; // kept as an alias for the recorder
 
-    // Start recording + selfie immediately so they're visible during countdown
+    // Start recording + selfie immediately so they're visible during countdown.
+    // Passing the engine lets startBuffer attach its mix destination directly.
     this.recorder.setLabels(this.mode);
-    this.recorder.startBuffer(this.audioCtx, this.lobby.audioActive);
+    this.recorder.startBuffer(this.audioCtx, this.lobby.audioActive, this.audioEngine);
     if (this.lobby.cameraActive) {
       this.recorder.startSelfie(this.net && this.net._localMediaStream);
     } else if (this.lobby.auth && this.lobby.auth.isLoggedIn()) {
@@ -1220,21 +1207,17 @@ class Game {
       if (user && user.avatar) this.recorder.showAvatarPip(this.lobby._avatarCache.get(user.avatar) || user.avatar);
     }
 
-    // Route background music through AudioContext so it's captured in recordings
-    if (this.audioCtx && !this._musicSourceNode) {
-      try {
-        this._musicSourceNode = this.audioCtx.createMediaElementSource(this._musicEl);
-        this._musicSourceNode.connect(this.audioCtx.destination);
-      } catch (e) {}
-    }
-    // Also route music to recording destination
-    if (this._musicSourceNode && this.recorder && this.recorder._audioDestination) {
-      try { this._musicSourceNode.connect(this.recorder._audioDestination); } catch (e) {}
-    }
+    // Route background music through the shared audio engine so it lands on
+    // the music bus (duckable + captured by the recorder automatically).
+    this.audioEngine.connectMusicElement(this._musicEl);
     // Play music if enabled
     if (this.lobby.musicActive) {
       this._musicEl.play().catch(() => {});
     }
+    // St2 — duck music during gameplay vs the lobby.
+    this.audioEngine.duckMusic(0.55, 0.8);
+    // Sp3 — start procedural bike motion loop (silent until speed rises).
+    this.audioEngine.startBike();
 
     this._playBeep(400, 0.15);
 
@@ -1313,47 +1296,19 @@ class Game {
     }
   }
 
+  // Thin wrappers over audioEngine so existing call sites keep working. The
+  // engine routes everything through the sfx bus and the recorder tap.
   _playBeep(freq, duration) {
-    try {
-      if (!this.audioCtx) return;
-      const ctx = this.audioCtx;
-      if (ctx.state === 'suspended') ctx.resume();
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      // Also route to recording audio destination (captures beeps in clips)
-      if (this.recorder && this.recorder._audioDestination) {
-        gain.connect(this.recorder._audioDestination);
-      }
-      osc.frequency.value = freq;
-      osc.type = 'square';
-      gain.gain.setValueAtTime(0.12, ctx.currentTime);
-      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
-      osc.start(ctx.currentTime);
-      osc.stop(ctx.currentTime + duration);
-    } catch (e) {}
+    this.audioEngine.tone(freq, duration, { type: 'triangle', gain: 0.14 });
   }
 
   _playChime(freq, duration) {
-    try {
-      if (!this.audioCtx) return;
-      const ctx = this.audioCtx;
-      if (ctx.state === 'suspended') ctx.resume();
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      if (this.recorder && this.recorder._audioDestination) {
-        gain.connect(this.recorder._audioDestination);
-      }
-      osc.frequency.value = freq;
-      osc.type = 'sine';
-      gain.gain.setValueAtTime(0.3, ctx.currentTime);
-      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
-      osc.start(ctx.currentTime);
-      osc.stop(ctx.currentTime + duration);
-    } catch (e) {}
+    this.audioEngine.chime(freq, duration);
+  }
+
+  // Ti1 — noise-based crash impact used for crashes and tree hits.
+  _playCrash(intensity = 1) {
+    this.audioEngine.crash(intensity);
   }
 
   _onTimerExpired() {
@@ -1385,8 +1340,7 @@ class Game {
     flash.classList.remove('visible');
     void flash.offsetWidth; // force reflow to restart animations
     flash.classList.add('visible');
-    this._playBeep(200, 0.3);
-    setTimeout(() => this._playBeep(150, 0.2), 300);
+    this._playCrash(0.9);
 
     // Freeze gameplay during the pause
     this.state = 'gameover';
@@ -1412,10 +1366,10 @@ class Game {
     }
     // Track for recording compositor
     this._checkpointFlashTime = performance.now();
-    // Rising chime: three ascending sine tones
-    this._playChime(523, 0.25);  // C5
-    setTimeout(() => this._playChime(659, 0.25), 100);  // E5
-    setTimeout(() => this._playChime(784, 0.35), 200);  // G5
+    // Rising chime using the shared Tandemonium motif (Re4)
+    this._playChime(MOTIF.C5, 0.25);
+    setTimeout(() => this._playChime(MOTIF.E5, 0.25), 100);
+    setTimeout(() => this._playChime(MOTIF.G5, 0.35), 200);
   }
 
   // ============================================================
@@ -2161,9 +2115,12 @@ class Game {
     }
     this._setOverlayButtons(victoryBtns, hasNext ? 1 : 0);
 
-    this._playBeep(800, 0.3);
-    setTimeout(() => this._playBeep(1000, 0.3), 200);
-    setTimeout(() => this._playBeep(1200, 0.5), 400);
+    // Re4 — victory uses the same C-E-G motif as the checkpoint chime,
+    // giving Tandemonium a recognizable audio signature across cues.
+    this._playChime(MOTIF.C5, 0.3);
+    setTimeout(() => this._playChime(MOTIF.E5, 0.3), 140);
+    setTimeout(() => this._playChime(MOTIF.G5, 0.55), 280);
+    setTimeout(() => this._playChime(MOTIF.G5 * 2, 0.6), 420);
 
     // Input cooldown to prevent accidental taps while pedaling. On mobile,
     // the same touch area is used for pedaling and button taps, so a cooldown
@@ -2383,10 +2340,11 @@ class Game {
     if (!this.lobby.musicActive) {
       this._musicEl.pause();
       this._musicEl.currentTime = 0;
-      if (this._musicSourceNode) {
-        try { this._musicSourceNode.disconnect(); } catch (e) {}
-      }
     }
+    // Stop bike motion loop + restore music from its gameplay duck (St2/Sp3).
+    this.audioEngine.stopBike();
+    this.audioEngine.duckMusic(1.0, 0.8);
+    this.audioEngine.detachRecorderDestination();
     this._hideGameOver();
     this._hideVictory();
     this._hideAllOverlays();
@@ -2470,10 +2428,11 @@ class Game {
     if (!this.lobby.musicActive) {
       this._musicEl.pause();
       this._musicEl.currentTime = 0;
-      if (this._musicSourceNode) {
-        try { this._musicSourceNode.disconnect(); } catch (e) {}
-      }
     }
+    // Stop bike motion loop + restore music from its gameplay duck (St2/Sp3).
+    this.audioEngine.stopBike();
+    this.audioEngine.duckMusic(1.0, 0.8);
+    this.audioEngine.detachRecorderDestination();
     this._hideGameOver();
     this._hideVictory();
     this._hideAllOverlays();
@@ -2986,7 +2945,7 @@ class Game {
         this._recordCrash('obstacle');
         this.bike._fall();
         this.chaseCamera.shakeAmount = 0.25;
-        this._playBeep(150, 0.4);
+        this._playCrash(1.0);
         hapticTreeHit();
       }
       return;
@@ -2998,7 +2957,7 @@ class Game {
       this._recordCrash('tree');
       this.bike._fall();
       this.chaseCamera.shakeAmount = 0.2;
-      this._playBeep(200, 0.3);
+      this._playCrash(0.85);
       hapticTreeHit();
       return;
     }
@@ -3007,7 +2966,7 @@ class Game {
       this._recordCrash('obstacle');
       this.bike._fall();
       this.chaseCamera.shakeAmount = 0.25;
-      this._playBeep(150, 0.4);
+      this._playCrash(1.0);
       hapticTreeHit();
     }
   }
@@ -3072,6 +3031,18 @@ class Game {
         this._updateStoker(dt);
       } else if (this.mode === 'local') {
         this._updateLocal(dt);
+      }
+      // Sp3 — feed bike velocity to the procedural motion loop every frame.
+      if (this.bike) {
+        const frontOff = Math.abs(this.bike._frontWheelOffset || 0);
+        const rearOff = Math.abs(this.bike._rearWheelOffset || 0);
+        const offRoad = Math.min(1, Math.max(0, Math.max(frontOff, rearOff) - 2.5) / 3);
+        this.audioEngine.updateBike(
+          this.bike.speed,
+          TUNE.maxSpeed || 19,
+          offRoad,
+          this.bike.fallen
+        );
       }
     } else {
       // Lobby / countdown / instructions / victory / gameover: render static scene

--- a/js/game.js
+++ b/js/game.js
@@ -3032,18 +3032,6 @@ class Game {
       } else if (this.mode === 'local') {
         this._updateLocal(dt);
       }
-      // Sp3 — feed bike velocity to the procedural motion loop every frame.
-      if (this.bike) {
-        const frontOff = Math.abs(this.bike._frontWheelOffset || 0);
-        const rearOff = Math.abs(this.bike._rearWheelOffset || 0);
-        const offRoad = Math.min(1, Math.max(0, Math.max(frontOff, rearOff) - 2.5) / 3);
-        this.audioEngine.updateBike(
-          this.bike.speed,
-          TUNE.maxSpeed || 19,
-          offRoad,
-          this.bike.fallen
-        );
-      }
     } else {
       // Lobby / countdown / instructions / victory / gameover: render static scene
       if (this.state === 'countdown') this._updateCountdown(dt);
@@ -3054,6 +3042,25 @@ class Game {
       if (this.archIndicator._visible) this.archIndicator.update(this.bike, 0, 0);
 
       this.renderer.render(this.scene, this.camera);
+    }
+
+    // Sp3 — feed bike velocity to the procedural motion loop every frame.
+    // When not actively playing (victory / gameover / lobby / countdown),
+    // feed speed=0 so the loop fades to silence via the engine's internal
+    // ramp instead of holding the last gain value indefinitely.
+    if (this.bike) {
+      const playing = this.state === 'playing';
+      const frontOff = Math.abs(this.bike._frontWheelOffset || 0);
+      const rearOff = Math.abs(this.bike._rearWheelOffset || 0);
+      const offRoad = playing
+        ? Math.min(1, Math.max(0, Math.max(frontOff, rearOff) - 2.5) / 3)
+        : 0;
+      this.audioEngine.updateBike(
+        playing ? this.bike.speed : 0,
+        TUNE.maxSpeed || 19,
+        offRoad,
+        !playing || this.bike.fallen
+      );
     }
 
     // Clear buffered tap flags after all input has been read this frame


### PR DESCRIPTION
Phase 1 of #267 — the immersive-audio improvements that don't require
sourcing audio assets. Design rationale + full taxonomy review lives in
`docs/immersive-audio-techniques-review.md` (branch
`claude/review-audio-techniques-IFHwW`).

## Summary

- New `js/audio-engine.js`: one `AudioContext` with music / SFX / bike
  buses off a shared master (**Sp1/Sp2**). Lazy-created on first user
  gesture, iOS warmup buffer preserved.
- **Sp3** — procedural bike motion loop (lowpass-filtered noise wind,
  bandpass tire hiss, low saw drivetrain). Gains and drivetrain pitch
  track `bike.speed` every frame; silent when stationary or fallen.
  Off-road increases tire-hiss gain via wheel offset.
- **Ti1 (partial)** — crash/tree hits now trigger a noise-burst +
  pitch-falling thump instead of double beeps. Chimes use inharmonic
  partials for a bell-like timbre. Full sampled SFX deferred to Phase 2
  (needs asset sourcing).
- **St2** — music ducks to 0.55 entering gameplay, restores to 1.0 on
  lobby return (both normal solo and multiplayer room-return paths).
- **St3** — `crossfade()` helper; music mute/unmute ramps instead of
  cutting. Replaces the old `disconnect`/`reconnect` dance that worked
  around an iOS looping artifact.
- **Re4** — `MOTIF` constant (C5/E5/G5) shared by the checkpoint chime
  and victory fanfare as a recognizable Tandemonium audio signature.
- `GameRecorder.startBuffer()` accepts the engine and taps its master
  bus, so music + SFX + bike audio all land in clips automatically. No
  more per-node recorder wiring scattered in `_playBeep` / music routing.

## Test plan

- [ ] Desktop: music fades down smoothly on race start, back up on
      return to lobby.
- [ ] Desktop: bike produces audible wind + tire + chain that rises
      with speed and stops when fallen.
- [ ] Desktop: crashes sound like impacts, not double beeps.
- [ ] Desktop: checkpoint and victory use the same C-E-G motif.
- [ ] Desktop: M key still mutes/unmutes music without clicks.
- [ ] iOS Safari: no 2-3s first-sound delay (warmup buffer preserved);
      music pause/resume has no looping glitch.
- [ ] Recorded clip contains music + SFX + bike audio (standard
      MediaRecorder path; WebCodecs path on iOS remains silent as
      before).
- [ ] Multiplayer: music duck/restore still works on room-return.

## Not in this PR (Phase 2, see #267)

- Sampled crash/cheer/bell SFX (Ti1 full)
- Adaptive layered ambient bed (Am1/Am3/Am5)
- Sharing bike motion audio with remote partner over WebRTC (Sp4)
- Diegetic in-world bike radio (St1)
- Single-IR reverb (Ti2)
- Per-course music (Re1)

Closes part of #267.

https://claude.ai/code/session_01DsPKtRriqjtF57tk9Fe2Le