### PR TITLE
Local MP: prime P2 held-detection at countdown start (closes #271)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1117,6 +1117,16 @@ class Game {
       if (this.inputP2.gyroConnected) this.inputP2.calibrateGyro();
       this.inputP2.startTiltCalibration();
     }
+    // Prime P2's held-detection stamp so the _updateLocal isActive() gate
+    // doesn't zero out their gyro lean on frame 1. The stamp was last set
+    // at InputManager construction (JOIN RIDE in the lobby); if >10s of
+    // level browsing + instructions elapsed before countdown starts, P2
+    // would already be "inactive" and their contribution would hard-gate
+    // to 0 until their first trigger press, then snap in and jerk the
+    // bike. Re-priming here covers the two-human case without weakening
+    // the one-human desk-controller protection — that still self-corrects
+    // after 10s of trigger silence.
+    if (this.inputP2) this.inputP2._markActive();
 
     const statusEl = document.getElementById('status');
     statusEl.textContent = '';


### PR DESCRIPTION
## Summary

Fixes #271 — in local MP, P2's gyro was silently discarded on the first frames of gameplay because the `isActive()` gate added in #266 was seeded at `InputManager` construction (JOIN RIDE in the lobby) rather than at race start. Level browsing + instructions screen easily exceed the 10 s activity window, so the first gameplay frame saw `isActive() == false` and the captain+stoker merge degenerated to `(captainLean + 0) * 0.5`. P2's first trigger press then snapped the accumulated lean into the merge, jerking the bike.

## Changes

**`js/game.js` — `_startCountdown()`**
- Call `inputP2._markActive()` alongside the existing P2 calibration refresh. Covers both the initial race and restart-after-crash paths.

## Why this preserves the #266 behavior

The point of the `isActive()` gate was to keep a desk-resting controller in one-human local MP from dragging drift into the 50/50 lean merge. Priming at `_startCountdown` just resets the 10 s clock — the desk-controller case still self-corrects after 10 s of trigger silence, exactly as designed.

## Observed symptoms on Steam `3495e7d`
- Stoker P2 gyro "not picking up" for balancing
- Reduced steering sensitivity (captain's half was halved against a zero partner)
- Sudden jerk in one direction (gate flipping false → true mid-ride)

## Test plan
- [ ] Two-human local MP, two DualSense BT: JOIN RIDE → wait 30 s in lobby → start ride. P2's gyro should steer from frame 1, no jerk on first trigger press.
- [ ] Same setup, restart after crash: P2's gyro should remain smooth through the 3-2-1 countdown.
- [ ] One-human local MP (P1 held, P2 on desk): P2 contributes 0 to the merge after 10 s of inaction — regression check for #266.
- [ ] Captain assist (DDA / assist button) still reaches stoker's half of the merge — regression check for #266 stoker-assist-parity.

## Related
- Closes #271
- Follow-up to #266 (gate rumble on held controllers + stoker assist parity)
- Part of #216 (multiplayer gyro calibration and testing improvements)

https://claude.ai/code/session_01MGpJ5wCXCAybkrD4jq4U3M