### PR TITLE
Fix #281: reliable FINISH/GAMEOVER + stoker resume recovery

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -706,10 +706,13 @@ class Game {
         }
         this._resetGame(true);
       } else if (eventType === EVT_GAMEOVER) {
+        // Idempotent: captain may retry-send GAMEOVER for reliability.
         if (this.state === 'playing') this._showGameOver(true);
       } else if (eventType === EVT_CHECKPOINT) {
         this._showCheckpointFlash();
       } else if (eventType === EVT_FINISH) {
+        // Idempotent: captain may retry-send FINISH for reliability.
+        if (this.state === 'victory') return;
         // Tutorial: show completion screen instead of normal victory
         if (this._tutorialActive) {
           this._showStokerTutorialComplete();
@@ -1650,8 +1653,10 @@ class Game {
       setTimeout(() => btns.forEach(b => b.style.pointerEvents = ''), 3000);
     }
 
-    if (!fromRemote && this.net) {
-      this.net.sendEvent(EVT_GAMEOVER);
+    if (!fromRemote && this.net && this.net.connected) {
+      // Terminal event — retry a few times so a transient drop doesn't
+      // leave the stoker stuck on a "playing" screen.
+      this.net.sendEventReliable(EVT_GAMEOVER);
     }
   }
 
@@ -1737,15 +1742,18 @@ class Game {
       this._showVictory();
       hapticFinish();
 
-      // Send authoritative finish stats to stoker before the finish event
-      if (this.mode === 'captain' && this.net) {
+      // Send authoritative finish stats to stoker before the finish event.
+      // FINISH is one-shot and terminal — use the reliable variant so a
+      // single dropped packet at the relay/WebRTC boundary doesn't strand
+      // the stoker waiting at a frozen race screen.
+      if (this.mode === 'captain' && this.net && this.net.connected) {
         this.raceManager.inputSource = this.balanceCtrl.getSteerSource();
         this.net.sendProfile({
           type: 'finishStats',
           raceSummary: this.raceManager.getSummary(this.bike.distanceTraveled),
           contribSummary: this.contributionTracker ? this.contributionTracker.getSummary() : null,
         });
-        this.net.sendEvent(EVT_FINISH);
+        this.net.sendEventReliable(EVT_FINISH);
       }
     }
   }
@@ -4499,7 +4507,7 @@ class Game {
 
     // Notify stoker that tutorial is complete (multiplayer)
     if (this.mode === 'captain' && this.net && this.net.connected) {
-      this.net.sendEvent(EVT_FINISH);
+      this.net.sendEventReliable(EVT_FINISH);
     }
 
     // Stop the game loop for this ride

--- a/js/network-manager.js
+++ b/js/network-manager.js
@@ -69,6 +69,23 @@ export class NetworkManager {
     this._leanBuf = new ArrayBuffer(5);
     this._leanView = new DataView(this._leanBuf);
     this._leanBytes = new Uint8Array(this._leanBuf);
+
+    // Pending retries for sendEventReliable (eventByte → setTimeout id list)
+    this._reliableEventTimers = [];
+
+    // Tab/network resume → force a fresh reconnect when the partner could
+    // have silently dropped while we were backgrounded or offline. Stored so
+    // destroy() can detach.
+    this._onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') this._maybeRecoverFromIdle('visible');
+    };
+    this._onOnline = () => this._maybeRecoverFromIdle('online');
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', this._onVisibilityChange);
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', this._onOnline);
+    }
   }
 
   generateRoomCode() {
@@ -262,6 +279,39 @@ export class NetworkManager {
 
   sendEvent(eventType) {
     this._send(new Uint8Array([MSG_EVENT, eventType]));
+  }
+
+  // Send a one-shot terminal event (FINISH, GAMEOVER) with retries so a
+  // single dropped packet at the relay/WebRTC boundary doesn't strand the
+  // partner waiting forever. Receiver-side handlers must be idempotent
+  // (state-guarded) — they already are for FINISH and GAMEOVER.
+  sendEventReliable(eventType, attempts = 3, intervalMs = 200) {
+    const msg = new Uint8Array([MSG_EVENT, eventType]);
+    this._send(msg);
+    for (let i = 1; i < attempts; i++) {
+      const t = setTimeout(() => {
+        this._send(msg);
+        // Drop the timer id from the list once it fires
+        const idx = this._reliableEventTimers.indexOf(t);
+        if (idx >= 0) this._reliableEventTimers.splice(idx, 1);
+      }, intervalMs * i);
+      this._reliableEventTimers.push(t);
+    }
+  }
+
+  // If we've been silent (tab hidden / network offline) the partner's
+  // WebSocket may have been killed by a carrier/proxy or NAT. When the tab
+  // resumes or we come back online, force a reconnect cycle if the last
+  // heartbeat is stale — `_relayWs.readyState` can lie OPEN locally even
+  // after the server-side socket is gone.
+  _maybeRecoverFromIdle(reason) {
+    if (!this.roomCode) return; // not in a room
+    const since = this._lastRemoteHeartbeat
+      ? performance.now() - this._lastRemoteHeartbeat
+      : Infinity;
+    if (since < 3000 && this.connected) return; // healthy
+    console.log('NET: idle recovery (' + reason + '), heartbeat age=' + Math.round(since) + 'ms');
+    try { this.retryConnection(); } catch (e) { console.warn('NET: retry on resume failed:', e); }
   }
 
   sendProfile(data) {
@@ -708,6 +758,16 @@ export class NetworkManager {
     clearTimeout(this._p2pUpgradeTimeout);
     clearTimeout(this._p2pUpgradeRetryTimeout);
     this._stopRelayKeepalive();
+    // Cancel any pending reliable-event retries
+    for (const t of this._reliableEventTimers) clearTimeout(t);
+    this._reliableEventTimers.length = 0;
+    // Detach resume listeners
+    if (typeof document !== 'undefined' && this._onVisibilityChange) {
+      document.removeEventListener('visibilitychange', this._onVisibilityChange);
+    }
+    if (typeof window !== 'undefined' && this._onOnline) {
+      window.removeEventListener('online', this._onOnline);
+    }
     // Stop local media tracks
     if (this._localMediaStream) {
       this._localMediaStream.getTracks().forEach(t => t.stop());


### PR DESCRIPTION
## Summary
- Closes #281. Addresses both failures from the reported "Steam captain + mobile stoker, browser frozen, never ended ride" bug.
- **Reliable terminal events:** captain's `EVT_FINISH` and `EVT_GAMEOVER` now send 3× spaced 200ms apart so a single dropped packet at the relay/WebRTC boundary doesn't strand the stoker on a still-playing screen.
- **Stoker resume recovery:** `NetworkManager` listens for `visibilitychange` (visible) and `online`; if the partner heartbeat is stale (>3s) or `connected === false` on resume, it forces `retryConnection()`. This catches the case where mobile carriers/proxies kill an idle WebSocket while the tab was throttled — `readyState` reports OPEN locally even though the server-side socket is gone.
- **Idempotent receivers:** stoker's `EVT_FINISH` handler now early-returns when already in `'victory'` state so retry duplicates no-op; `EVT_GAMEOVER` was already state-gated.
- **Connected guard:** added the missing `this.net.connected` check at `game.js:1741` to mirror the 20Hz state-send pattern.

## Files
- `js/network-manager.js`
  - new `sendEventReliable(eventType, attempts=3, intervalMs=200)`
  - new `_maybeRecoverFromIdle(reason)` + `visibilitychange`/`online` listeners attached in constructor, detached in `destroy()`
  - cancel pending retry timers in `destroy()`
- `js/game.js`
  - captain-side FINISH (race + tutorial) and GAMEOVER → `sendEventReliable`
  - `connected` guard at FINISH send site
  - stoker `EVT_FINISH` receiver idempotent

## Out of scope (deferred to follow-ups)
- Full ACK protocol with sequence numbers (not needed for once-per-game terminal events; would complicate the wire format)
- Captain-side "stoker disconnected" toast — the 8s no-heartbeat detection at `network-manager.js:312` already calls `_handleDisconnect`; surfacing it in-game UI is its own change
- Analytics breadcrumbs for event delivery success/failure

## Test plan
- [ ] Captain (Steam) + Stoker (mobile browser): play through full lap, cross finish line, confirm both screens show victory.
- [ ] Same setup, mobile backgrounded ~30s mid-ride then resumed: confirm stoker reconnects and resyncs (watch for the `NET: idle recovery (visible)` console log).
- [ ] Same setup, mobile briefly toggled airplane mode: confirm `online` event triggers reconnect on restore.
- [ ] Captain crashes (no checkpoint progress): confirm stoker sees game-over overlay even if first GAMEOVER packet drops (simulate by temporarily disabling network on mobile right before crash if testable).
- [ ] Solo mode (no `this.net`): confirm finish/game-over still work without errors.
- [ ] Tutorial captain + stoker: confirm tutorial completion still propagates (uses `sendEventReliable(EVT_FINISH)` via the existing connected guard).
- [ ] Confirm `destroy()` removes the visibility/online listeners (check via DevTools that no orphaned listeners persist after returning to lobby).

🤖 Generated with [Claude Code](https://claude.com/claude-code)