### PR TITLE
Fix #285: recenter gyro before bias recapture at race-start

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1099,21 +1099,39 @@ class Game {
     // Reset background adaptation state for fresh ride
     this._adaptState = null;
 
-    // Fresh bias + tilt calibration for new ride. Timing takes advantage
-    // of the 3s countdown: fusion bias calibration runs ~1.5s and ideally
-    // captures the user's stationary hold-at-rest pose, so integrated
-    // orientation starts from a clean bias when the race begins.
+    // Recenter THEN recapture bias for a new ride. Two layered protections:
     //
-    // Without the bias recalibration, a bias captured during a shaky boot
-    // (user picking controller up while HidEntry was auto-pooling) can
-    // cause rapid orientation drift → bike oscillates extreme L/R.
-    // Skip if tutorial calibration flow already ran (better data).
+    // 1. recenterGyro() clears motionOffset, _gyroRollAccum, _smoothedLean,
+    //    motionLean, and calls fusion.reset() (orientation → identity).
+    //    Without it, orientation drift accumulated during lobby browsing
+    //    can leave motionLean saturated at ±1.0 — joystick input then sums
+    //    with the saturated value, clamps to 0, and the player can only
+    //    neutralize the pull, not flip past center (#285).
+    // 2. calibrateGyro() restarts the slot's gyro-rate bias capture
+    //    (~1.5s). The 3s countdown overlaps the window, so the user's
+    //    stationary hold gives a clean bias for orientation integration.
+    //    Without it, a bias baked during a shaky boot pickup causes rapid
+    //    drift → bike oscillates extreme L/R.
+    //
+    // Note: fusion.startCalibration() does NOT reset orientation — only
+    // fusion.reset() does. So step 1 is required to clear saturated state;
+    // step 2 alone is not sufficient. _resetGame already runs this same
+    // pair (recenter then enter countdown which calibrates); duplicating
+    // here is harmless because recenterGyro is idempotent.
+    //
+    // Skip both if tutorial calibration flow already ran (better data).
     if (this.input.motionEnabled && !this._calibHoldSamples) {
-      if (this.input.gyroConnected) this.input.calibrateGyro();
+      if (this.input.gyroConnected) {
+        this.input.recenterGyro();
+        this.input.calibrateGyro();
+      }
       this.input.startTiltCalibration();
     }
     if (this.inputP2 && this.inputP2.motionEnabled) {
-      if (this.inputP2.gyroConnected) this.inputP2.calibrateGyro();
+      if (this.inputP2.gyroConnected) {
+        this.inputP2.recenterGyro();
+        this.inputP2.calibrateGyro();
+      }
       this.inputP2.startTiltCalibration();
     }
     // Prime P2's held-detection stamp so the _updateLocal isActive() gate


### PR DESCRIPTION
Closes #285.

## Summary

- In `_startCountdown` ([js/game.js:1102-1136](js/game.js#L1102)), call `recenterGyro()` before `calibrateGyro()` for both `this.input` and `this.inputP2`.
- Mirrors the pattern `_resetGame` already uses (recenter, then enter countdown which calibrates).
- One-file change, +28/-10 lines, mostly comments documenting the why.

## Why

Per [#285](https://github.com/petegordon/Tandemonium/issues/285) and the comment thread, the symptom **"joystick fully opposite only reaches center, not the other extreme"** is a clean signature of saturation in the input-sum clamp at [balance-controller.js:88-105](js/balance-controller.js#L88):

```js
leanInput = clamp(keyboard + motion + gamepad, -1, +1);
```

If `motion = -1.0` (saturated by `_applyTilt`'s response curve) and `gpLean = +1.0`, the sum is 0 → bike sits at center regardless of how hard the user pushes opposite. That's exactly what was observed.

The saturation came from orientation drift accumulated during lobby browsing. `_startCountdown` previously ran only `calibrateGyro()` (slot bias recapture). [199d656](https://github.com/petegordon/Tandemonium/commit/199d656)'s commit message asserted that bias recapture also resets orientation — but [`fusion.startCalibration()`](shared/sensor-fusion.js#L140) only restarts bias sampling. The orientation quaternion is preserved. Only `fusion.reset()` (called from [`recenterGyro()`](js/input-manager.js#L636)) sets orientation to identity. So a saturated `motionLean` survived the countdown.

`_resetGame` already calls `recenterGyro()` before entering `_startCountdown` — which is why the bug always cleared after the first crash. The initial race-start path was missing this step.

## What this preserves from prior cycles

We've cycled on this code path:

- **[b3b70b4](https://github.com/petegordon/Tandemonium/commit/b3b70b4)** added `recenterGyro()` at race-start.
- **[199d656](https://github.com/petegordon/Tandemonium/commit/199d656)** removed it 3 hours later, citing a boot-time motion-noise scenario where bias was baked while the user picked up the controller.

This PR is **not** a revert of 199d656. It keeps `calibrateGyro()` exactly where 199d656 placed it (so the boot-time bias-noise fix is intact) and adds `recenterGyro()` *in addition* — layered, not replacement. The two functions handle two different failure modes:

| Function | Clears | Fixes |
|---|---|---|
| `recenterGyro()` | motionOffset, _gyroRollAccum, _smoothedLean, motionLean, fusion orientation | Saturated lean from lobby drift (#285) |
| `calibrateGyro()` | (restarts slot bias capture window) | Boot-time motion-noise bias (199d656) |

Idempotency: `_resetGame` already calls `recenterGyro` before `_startCountdown`. After this change, recenter fires twice on the reset path. That's harmless — `recenterGyro` zeros already-zeroed accumulators and re-snapshots `motionOffset = -_accelRoll` (same value, since pose hasn't changed in a few microseconds).

## Test plan

No automated tests exist for this path; manual repro across the three code paths through `_startCountdown`:

- [ ] **Solo race, DualSense gyro on Steam TV** — the original repro. Browse the lobby for ~30s with the controller in a casual hold (e.g., resting in lap), select "Chill ride to Grandma's", confirm bike tracks straight from countdown end. Push joystick fully one way, confirm it reaches the lean extreme (not just center).
- [ ] **Solo race, mobile tilt (phone gyro)** — confirm `recenterGyro` no-op when `gyroConnected = false` doesn't break the tilt path. The `if (this.input.gyroConnected)` guard handles this.
- [ ] **Local-MP captain side, P1 + P2 both DualSense** — both `this.input` and `this.inputP2` get the recenter. Confirm neither side pulls. b3b70b4's original target.
- [ ] **Remote-MP captain** — race-start with one captain DualSense, stoker on phone tilt. Confirm captain side recenters and stoker side is unaffected (no inputP2 on captain client).
- [ ] **Tutorial → race transition** — `_calibHoldSamples` branch. Skip path is unchanged; confirm tutorial still works and post-tutorial race doesn't double-calibrate.
- [ ] **Crash → respawn** — confirm post-crash recovery still works (it always did; this PR doesn't change `_resetGame`).
- [ ] **Boot-time motion-noise scenario** — pick up controller during boot, immediately start a race. Confirm 199d656's fix is still intact (no extreme L/R oscillation).

## Files changed

- [js/game.js](js/game.js) — `_startCountdown` only. Adds 2 `recenterGyro()` calls (one per input), and rewrites the surrounding comment to explain the saturation issue.