### PR TITLE
Cinematic slow-motion finish camera before victory screen

### DIFF
--- a/js/finish-camera-animation.js
+++ b/js/finish-camera-animation.js
@@ -1,0 +1,192 @@
+// ============================================================
+// FINISH CAMERA ANIMATION — cinematic, slow-motion swing to the
+// front of the bike with a final artistic zoom-in. Runs after the
+// race is won and before the victory overlay is revealed.
+// ============================================================
+
+import * as THREE from 'three';
+
+const PHASE = {
+  SWING: 0,    // sweep from behind → side → front of the bike
+  ZOOM: 1,     // hold near the front and dolly in close
+  HOLD: 2,     // brief breath frame before victory UI appears
+  DONE: 3,
+};
+
+export class FinishCameraAnimation {
+  constructor(camera, bike) {
+    this.camera = camera;
+    this.bike = bike;
+
+    // Capture the camera's starting pose so the swing eases out from
+    // wherever the chase cam left it instead of snapping.
+    this.startPos = camera.position.clone();
+    this.startLook = new THREE.Vector3();
+    camera.getWorldDirection(this.startLook);
+    this.startLook.multiplyScalar(10).add(camera.position);
+    this.startFov = camera.fov;
+
+    // Phase durations — generous timings sell the slow-motion feel.
+    this.tSwing = 2.6;
+    this.tZoom = 1.6;
+    this.tHold = 0.5;
+    this.totalDuration = this.tSwing + this.tZoom + this.tHold;
+    this.elapsed = 0;
+    this.phase = PHASE.SWING;
+
+    // Slow-motion factor applied to the bike's residual roll-out. 0.18
+    // keeps wheels turning gently without the world racing past.
+    this.timeScale = 0.18;
+
+    // Reusable temporaries.
+    this._fwd = new THREE.Vector3();
+    this._right = new THREE.Vector3();
+    this._orbitPos = new THREE.Vector3();
+    this._desiredPos = new THREE.Vector3();
+    this._desiredLook = new THREE.Vector3();
+    this._blendedLook = new THREE.Vector3();
+  }
+
+  _easeInOut(t) {
+    return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+  }
+
+  _easeOutQuint(t) {
+    return 1 - Math.pow(1 - t, 5);
+  }
+
+  _lerp(a, b, t) { return a + (b - a) * t; }
+
+  /** Slow-mo dt scale — game.js multiplies its physics dt by this. */
+  getTimeScale() {
+    // Slight ramp from full speed → slow-mo over the first 0.4s so the
+    // transition itself feels deliberate, not a stutter.
+    const ramp = Math.min(1, this.elapsed / 0.4);
+    return this._lerp(1, this.timeScale, ramp);
+  }
+
+  /**
+   * Drive the camera through the cinematic. Returns true once the full
+   * sequence is complete and the victory overlay should be revealed.
+   */
+  update(dt) {
+    this.elapsed += dt;
+    const bike = this.bike;
+
+    // Bike-aligned basis — orbit around the live bike pose so it still
+    // works if the bike is rolling forward during the swing.
+    this._fwd.set(Math.sin(bike.heading), 0, Math.cos(bike.heading));
+    this._right.set(Math.cos(bike.heading), 0, -Math.sin(bike.heading));
+
+    if (this.elapsed < this.tSwing) {
+      this.phase = PHASE.SWING;
+      this._updateSwing(this.elapsed / this.tSwing);
+    } else if (this.elapsed < this.tSwing + this.tZoom) {
+      this.phase = PHASE.ZOOM;
+      this._updateZoom((this.elapsed - this.tSwing) / this.tZoom);
+    } else if (this.elapsed < this.totalDuration) {
+      this.phase = PHASE.HOLD;
+      this._updateHold();
+    } else {
+      this.phase = PHASE.DONE;
+      return true;
+    }
+
+    return false;
+  }
+
+  // theta=0 is in front of the bike, π is behind, π/2 is the bike's right.
+  _orbitOffset(theta, radius, height, out) {
+    const fc = Math.cos(theta) * radius;
+    const rc = Math.sin(theta) * radius;
+    out.set(
+      this._fwd.x * fc + this._right.x * rc,
+      height,
+      this._fwd.z * fc + this._right.z * rc
+    );
+    return out;
+  }
+
+  // Phase 1: orbit from behind (theta=π) around the right side (theta=π/2)
+  // to a low frontal three-quarter view (theta ≈ -0.35), pulling in close
+  // with a generous height drop.
+  _updateSwing(t) {
+    const e = this._easeInOut(t);
+    const bikePos = this.bike.position;
+
+    const theta = this._lerp(Math.PI, -0.35, e);
+    const radius = this._lerp(11, 4.2, e);
+    const height = this._lerp(4.0, 1.7, e);
+
+    this._orbitOffset(theta, radius, height, this._orbitPos);
+    this._desiredPos.copy(bikePos).add(this._orbitPos);
+
+    const lookFwdBias = this._lerp(-0.5, 1.4, e);
+    this._desiredLook.copy(bikePos);
+    this._desiredLook.x += this._fwd.x * lookFwdBias;
+    this._desiredLook.z += this._fwd.z * lookFwdBias;
+    this._desiredLook.y += this._lerp(0.9, 0.65, e);
+
+    // Ease out of the chase cam's last pose for the first ~40% of swing.
+    const blend = Math.min(1, t * 2.5);
+    if (blend < 1) {
+      this.camera.position.copy(this.startPos).lerp(this._desiredPos, blend);
+      this._blendedLook.copy(this.startLook).lerp(this._desiredLook, blend);
+      this.camera.lookAt(this._blendedLook);
+    } else {
+      this.camera.position.copy(this._desiredPos);
+      this.camera.lookAt(this._desiredLook);
+    }
+
+    // Subtle FOV widen for cinematic drama.
+    this.camera.fov = this._lerp(this.startFov, this.startFov + 6, e);
+    this.camera.updateProjectionMatrix();
+  }
+
+  // Phase 2: dolly in close to the front of the bike with a gentle FOV
+  // pull (vertigo-lite) for the artistic zoom.
+  _updateZoom(t) {
+    const e = this._easeOutQuint(t);
+    const bikePos = this.bike.position;
+
+    const theta = this._lerp(-0.35, -0.15, e);
+    const radius = this._lerp(4.2, 2.2, e);
+    const height = this._lerp(1.7, 1.15, e);
+
+    this._orbitOffset(theta, radius, height, this._orbitPos);
+    this._desiredPos.copy(bikePos).add(this._orbitPos);
+    this.camera.position.copy(this._desiredPos);
+
+    this._desiredLook.copy(bikePos);
+    this._desiredLook.x += this._fwd.x * 1.6;
+    this._desiredLook.z += this._fwd.z * 1.6;
+    this._desiredLook.y += this._lerp(0.65, 0.85, e);
+    this.camera.lookAt(this._desiredLook);
+
+    this.camera.fov = this._lerp(this.startFov + 6, this.startFov - 8, e);
+    this.camera.updateProjectionMatrix();
+  }
+
+  // Phase 3: hold the close-up steady for a beat before overlay reveal.
+  _updateHold() {
+    const bikePos = this.bike.position;
+    this._orbitOffset(-0.15, 2.2, 1.15, this._orbitPos);
+    this._desiredPos.copy(bikePos).add(this._orbitPos);
+    this.camera.position.copy(this._desiredPos);
+
+    this._desiredLook.copy(bikePos);
+    this._desiredLook.x += this._fwd.x * 1.6;
+    this._desiredLook.z += this._fwd.z * 1.6;
+    this._desiredLook.y += 0.85;
+    this.camera.lookAt(this._desiredLook);
+
+    this.camera.fov = this.startFov - 8;
+    this.camera.updateProjectionMatrix();
+  }
+
+  /** Restore the camera FOV when the cinematic ends. */
+  cleanup() {
+    this.camera.fov = this.startFov;
+    this.camera.updateProjectionMatrix();
+  }
+}

--- a/js/finish-camera-animation.js
+++ b/js/finish-camera-animation.js
@@ -143,44 +143,43 @@ export class FinishCameraAnimation {
     this.camera.updateProjectionMatrix();
   }
 
-  // Phase 2: dolly in close to the front of the bike with a gentle FOV
-  // pull (vertigo-lite) for the artistic zoom.
+  // Phase 2: settle on the frontal three-quarter pose the swing landed
+  // on — no further dolly-in. FOV eases back from the swing's wide
+  // bias to the camera's normal value so the held frame doesn't read
+  // as distorted.
   _updateZoom(t) {
     const e = this._easeOutQuint(t);
     const bikePos = this.bike.position;
 
-    const theta = this._lerp(-0.35, -0.2, e);
-    const radius = this._lerp(4.2, 3.6, e);
-    const height = this._lerp(1.7, 1.4, e);
-
-    this._orbitOffset(theta, radius, height, this._orbitPos);
+    this._orbitOffset(-0.35, 4.2, 1.7, this._orbitPos);
     this._desiredPos.copy(bikePos).add(this._orbitPos);
     this.camera.position.copy(this._desiredPos);
 
     this._desiredLook.copy(bikePos);
-    this._desiredLook.x += this._fwd.x * 1.6;
-    this._desiredLook.z += this._fwd.z * 1.6;
-    this._desiredLook.y += this._lerp(0.65, 0.85, e);
+    this._desiredLook.x += this._fwd.x * 1.4;
+    this._desiredLook.z += this._fwd.z * 1.4;
+    this._desiredLook.y += 0.65;
     this.camera.lookAt(this._desiredLook);
 
-    this.camera.fov = this._lerp(this.startFov + 6, this.startFov - 4, e);
+    this.camera.fov = this._lerp(this.startFov + 6, this.startFov, e);
     this.camera.updateProjectionMatrix();
   }
 
-  // Phase 3: hold the close-up steady for a beat before overlay reveal.
+  // Phase 3: hold the same frontal three-quarter pose for a beat
+  // before the victory overlay reveals — no zoom past the swing.
   _updateHold() {
     const bikePos = this.bike.position;
-    this._orbitOffset(-0.2, 3.6, 1.4, this._orbitPos);
+    this._orbitOffset(-0.35, 4.2, 1.7, this._orbitPos);
     this._desiredPos.copy(bikePos).add(this._orbitPos);
     this.camera.position.copy(this._desiredPos);
 
     this._desiredLook.copy(bikePos);
-    this._desiredLook.x += this._fwd.x * 1.6;
-    this._desiredLook.z += this._fwd.z * 1.6;
-    this._desiredLook.y += 0.85;
+    this._desiredLook.x += this._fwd.x * 1.4;
+    this._desiredLook.z += this._fwd.z * 1.4;
+    this._desiredLook.y += 0.65;
     this.camera.lookAt(this._desiredLook);
 
-    this.camera.fov = this.startFov - 4;
+    this.camera.fov = this.startFov;
     this.camera.updateProjectionMatrix();
   }
 

--- a/js/finish-camera-animation.js
+++ b/js/finish-camera-animation.js
@@ -149,9 +149,9 @@ export class FinishCameraAnimation {
     const e = this._easeOutQuint(t);
     const bikePos = this.bike.position;
 
-    const theta = this._lerp(-0.35, -0.15, e);
-    const radius = this._lerp(4.2, 2.2, e);
-    const height = this._lerp(1.7, 1.15, e);
+    const theta = this._lerp(-0.35, -0.2, e);
+    const radius = this._lerp(4.2, 3.6, e);
+    const height = this._lerp(1.7, 1.4, e);
 
     this._orbitOffset(theta, radius, height, this._orbitPos);
     this._desiredPos.copy(bikePos).add(this._orbitPos);
@@ -163,14 +163,14 @@ export class FinishCameraAnimation {
     this._desiredLook.y += this._lerp(0.65, 0.85, e);
     this.camera.lookAt(this._desiredLook);
 
-    this.camera.fov = this._lerp(this.startFov + 6, this.startFov - 8, e);
+    this.camera.fov = this._lerp(this.startFov + 6, this.startFov - 4, e);
     this.camera.updateProjectionMatrix();
   }
 
   // Phase 3: hold the close-up steady for a beat before overlay reveal.
   _updateHold() {
     const bikePos = this.bike.position;
-    this._orbitOffset(-0.15, 2.2, 1.15, this._orbitPos);
+    this._orbitOffset(-0.2, 3.6, 1.4, this._orbitPos);
     this._desiredPos.copy(bikePos).add(this._orbitPos);
     this.camera.position.copy(this._desiredPos);
 
@@ -180,7 +180,7 @@ export class FinishCameraAnimation {
     this._desiredLook.y += 0.85;
     this.camera.lookAt(this._desiredLook);
 
-    this.camera.fov = this.startFov - 8;
+    this.camera.fov = this.startFov - 4;
     this.camera.updateProjectionMatrix();
   }
 

--- a/js/game.js
+++ b/js/game.js
@@ -17,6 +17,7 @@ import { BalanceController } from './balance-controller.js';
 import { BikeModel } from './bike-model.js';
 import { RemoteBikeState } from './remote-bike-state.js';
 import { ChaseCamera } from './chase-camera.js';
+import { FinishCameraAnimation } from './finish-camera-animation.js';
 import { World } from './world.js';
 import { HUD } from './hud.js';
 import { GrassParticles } from './grass-particles.js';
@@ -476,7 +477,8 @@ class Game {
     this._olPrevA = false;
 
     // Game state
-    this.state = 'lobby'; // 'lobby' | 'instructions' | 'countdown' | 'playing' | 'gameover' | 'victory'
+    this.state = 'lobby'; // 'lobby' | 'instructions' | 'countdown' | 'playing' | 'finishCinematic' | 'gameover' | 'victory'
+    this._finishCinematic = null;
     this.countdownTimer = 0;
     this._lastCountNum = 3;
     this.instructionsEl = document.getElementById('instructions');
@@ -712,12 +714,12 @@ class Game {
         this._showCheckpointFlash();
       } else if (eventType === EVT_FINISH) {
         // Idempotent: captain may retry-send FINISH for reliability.
-        if (this.state === 'victory') return;
+        if (this.state === 'victory' || this.state === 'finishCinematic') return;
         // Tutorial: show completion screen instead of normal victory
         if (this._tutorialActive) {
           this._showStokerTutorialComplete();
         } else {
-          this._showVictory(true);
+          this._startFinishCinematic(true);
         }
       } else if (eventType === EVT_RETURN_ROOM) {
         this._returnToRoom();
@@ -1757,13 +1759,17 @@ class Game {
     } else if (raceEvent.event === 'finish') {
       // Tutorial completion is handled by _updateTutorial, not the normal victory flow
       if (this._tutorialActive) return;
-      this._showVictory();
       hapticFinish();
 
-      // Send authoritative finish stats to stoker before the finish event.
-      // FINISH is one-shot and terminal — use the reliable variant so a
-      // single dropped packet at the relay/WebRTC boundary doesn't strand
-      // the stoker waiting at a frozen race screen.
+      // Kick off the cinematic finish camera; victory overlay reveals
+      // when the swing-and-zoom sequence completes.
+      this._startFinishCinematic();
+
+      // Send authoritative finish stats to stoker so their side can run
+      // its own cinematic in lockstep. FINISH is one-shot and terminal —
+      // use the reliable variant so a single dropped packet at the
+      // relay/WebRTC boundary doesn't strand the stoker on a frozen
+      // race screen.
       if (this.mode === 'captain' && this.net && this.net.connected) {
         this.raceManager.inputSource = this.balanceCtrl.getSteerSource();
         this.net.sendProfile({
@@ -1895,6 +1901,68 @@ class Game {
     }
     profile.bikeColor = this._getFrameColor(this.lobby.selectedPreset);
     this.net.sendProfile(profile);
+  }
+
+  /**
+   * Begin the cinematic finish: a stylized slow-motion swing around the
+   * bike that ends on a tight artistic close-up of the front of the
+   * frame. The victory overlay is held back until the camera move
+   * completes.
+   */
+  _startFinishCinematic(fromRemote = false) {
+    this.state = 'finishCinematic';
+    this._finishFromRemote = fromRemote;
+    this.hud.hideTimer();
+    // Briefly damp the chase cam's residual shake so the cinematic
+    // starts from a clean pose.
+    if (this.chaseCamera) this.chaseCamera.shakeAmount = 0;
+    this._finishCinematic = new FinishCameraAnimation(this.camera, this.bike);
+  }
+
+  /**
+   * Drive the finish-line cinematic: slow-mo bike physics, full-rate
+   * camera move, then hand off to _showVictory when the sequence ends.
+   */
+  _updateFinishCinematic(dt) {
+    const cinematic = this._finishCinematic;
+    if (!cinematic) {
+      this._showVictory(this._finishFromRemote);
+      return;
+    }
+
+    const slowDt = dt * cinematic.getTimeScale();
+
+    // Let the bike roll out under its own friction with neutral input
+    // so wheels and pedals keep turning briefly into the slow-motion.
+    if (this.bike) {
+      const neutralPedal = { crankAngle: this.bike.crankAngle, braking: false, acceleration: 0, wobble: 0 };
+      const neutralBalance = { leanInput: 0, gyroActive: false };
+      this.bike.update(neutralPedal, neutralBalance, slowDt, true, false);
+    }
+
+    // Keep the world streaming so terrain/scenery don't pop while the
+    // bike rolls forward, but at slow-motion pace.
+    if (this.world) {
+      this.world.update(this.bike.position, this.bike.roadD, slowDt);
+    }
+    if (this.grassParticles) {
+      this.grassParticles.update(this.bike, slowDt);
+    }
+
+    // Camera moves at real time so the cinematic timing is consistent
+    // regardless of the bike's slow-mo wind-down.
+    const done = cinematic.update(dt);
+
+    this.renderer.render(this.scene, this.camera);
+
+    if (done) {
+      cinematic.cleanup();
+      this._finishCinematic = null;
+      // Reset chase cam so a future race doesn't snap from the
+      // close-up pose.
+      if (this.chaseCamera) this.chaseCamera.initialized = false;
+      this._showVictory(this._finishFromRemote);
+    }
   }
 
   _showVictory(fromRemote = false) {
@@ -3068,6 +3136,10 @@ class Game {
       } else if (this.mode === 'local') {
         this._updateLocal(dt);
       }
+    } else if (this.state === 'finishCinematic') {
+      // Cinematic finish camera owns its own world/bike updates and
+      // render — bypass the chase cam so it doesn't fight the swing.
+      this._updateFinishCinematic(dt);
     } else {
       // Lobby / countdown / instructions / victory / gameover: render static scene
       if (this.state === 'countdown') this._updateCountdown(dt);


### PR DESCRIPTION
Closes #287.

## Summary

- New `FinishCameraAnimation` module (`js/finish-camera-animation.js`) drives a swing → zoom → hold cinematic when the race is won. Cubic ease-in-out for the orbit, quintic ease-out for the dolly, plus a subtle FOV widen-then-pull for vertigo-lite drama.
- New `'finishCinematic'` game state owns its own world/bike/render branch in `_loop` so the chase camera doesn't fight the move. Bike rolls forward under neutral input with a slow-motion `dt` scale (~0.18×) so wheels and pedals keep turning into the freeze frame.
- Captain still emits authoritative `FINISH` + `finishStats` up front so the stoker plays its own cinematic in lockstep on the other side. Tutorial completion path is untouched.

## Test plan

- [ ] Solo race → cross finish line → cinematic plays (~4.7s) and resolves into the existing You Did It overlay + stats.
- [ ] Restart from victory → next finish triggers cinematic again from a clean chase-cam pose.
- [ ] Multiplayer captain + stoker → both sides run cinematics independently; victory stats render on both sides; reconnect/retry FINISH still works.
- [ ] Local 2P → both players see the cinematic; YOU BOTH MADE IT! header appears at the end.
- [ ] Tutorial path → tutorial completion screen still shows (cinematic is bypassed for tutorial finish).
- [ ] Confirm camera FOV is restored after the cinematic (no lingering wide/narrow FOV in the lobby/next race).

https://claude.ai/code/session_01WqjPX4VgtLVxnrVa5CFZ4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqjPX4VgtLVxnrVa5CFZ4p)_