### PR TITLE
Fix iOS Chrome freeze with audio still playing after a few races

### DIFF
--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -284,7 +284,15 @@ export class AudioEngine {
     tireSrc.start();
     chainOsc.start();
 
-    this._bike = { windSrc, tireSrc, chainOsc, windGain, tireGain, chainGain };
+    // Track every node so stopBike() can fully tear down the graph.
+    // Without holding refs to the filters, they were leaked-connected to
+    // bikeBus across races and accumulated on iOS WebKit (browser freeze
+    // while audio kept playing — main thread starved by node graph).
+    this._bike = {
+      windSrc, tireSrc, chainOsc,
+      windFilt, tireFilt, chainFilt,
+      windGain, tireGain, chainGain,
+    };
 
     // Fade the bus in; individual sources stay at 0 until speed rises.
     const now = ctx.currentTime;
@@ -303,9 +311,22 @@ export class AudioEngine {
     const b = this._bike;
     this._bike = null;
     setTimeout(() => {
-      try { b.windSrc.stop(); } catch (e) {}
-      try { b.tireSrc.stop(); } catch (e) {}
+      // Stop sources first so they're eligible for auto-release.
+      try { b.windSrc.stop();  } catch (e) {}
+      try { b.tireSrc.stop();  } catch (e) {}
       try { b.chainOsc.stop(); } catch (e) {}
+      // Explicitly disconnect every node from the graph. Sources auto-GC
+      // after stop(), but BiquadFilter / GainNode are kept alive by their
+      // outgoing connection to bikeBus until disconnect() is called.
+      try { b.windSrc.disconnect();  } catch (e) {}
+      try { b.tireSrc.disconnect();  } catch (e) {}
+      try { b.chainOsc.disconnect(); } catch (e) {}
+      try { b.windFilt.disconnect();  } catch (e) {}
+      try { b.tireFilt.disconnect();  } catch (e) {}
+      try { b.chainFilt.disconnect(); } catch (e) {}
+      try { b.windGain.disconnect();  } catch (e) {}
+      try { b.tireGain.disconnect();  } catch (e) {}
+      try { b.chainGain.disconnect(); } catch (e) {}
     }, 400);
   }
 

--- a/js/collectibles.js
+++ b/js/collectibles.js
@@ -367,18 +367,44 @@ export class CollectibleManager {
     for (const slot of this._pool) {
       this.scene.remove(slot.mesh);
     }
-    // Clean up video element if presents theme
+    // Variants may share their geo/mat (presents theme uses a single
+    // geo+mat across 3 variants). Dedupe before dispose so we don't
+    // call .dispose() twice on the same resource.
+    const seenGeo = new Set();
+    const seenMat = new Set();
+    const seenTex = new Set();
     for (const v of this._variants) {
-      if (v.mat.uniforms && v.mat.uniforms.map) {
-        const tex = v.mat.uniforms.map.value;
-        if (tex.image && tex.image.tagName === 'VIDEO') {
-          tex.image.pause();
-          tex.image.src = '';
-          tex.dispose();
-          break; // all variants share same texture
+      if (v.geo && !seenGeo.has(v.geo)) {
+        seenGeo.add(v.geo);
+        v.geo.dispose();
+      }
+      if (v.mat && !seenMat.has(v.mat)) {
+        seenMat.add(v.mat);
+        // Pull video off the texture before disposing — without removing
+        // the .src + .load() the <video> can stay decoding in the
+        // background and pin GPU/decoder memory on iOS.
+        if (v.mat.uniforms && v.mat.uniforms.map) {
+          const tex = v.mat.uniforms.map.value;
+          if (tex && !seenTex.has(tex)) {
+            seenTex.add(tex);
+            if (tex.image && tex.image.tagName === 'VIDEO') {
+              try { tex.image.pause(); } catch (e) {}
+              try {
+                tex.image.removeAttribute('src');
+                tex.image.load();
+              } catch (e) {}
+            }
+            tex.dispose();
+          }
         }
+        if (v.mat.map && !seenTex.has(v.mat.map)) {
+          seenTex.add(v.mat.map);
+          v.mat.map.dispose();
+        }
+        v.mat.dispose();
       }
     }
+    this._variants = [];
     this._pool = [];
     this._items = [];
   }

--- a/js/obstacles.js
+++ b/js/obstacles.js
@@ -136,6 +136,13 @@ export class ObstacleManager {
       depthWrite: false
     });
 
+    // Hold refs to the shared GPU resources so destroy() can dispose them.
+    this._pylonGeo = geo;
+    this._pylonMat = mat;
+    this._shadowGeo = shadowGeo;
+    this._shadowMat = shadowMat;
+    this._shadowTex = shadowTex;
+
     // Create mesh pool (pylon + shadow per slot)
     for (let i = 0; i < POOL_SIZE; i++) {
       const mesh = new THREE.Mesh(geo, mat);
@@ -353,11 +360,21 @@ export class ObstacleManager {
     }
     if (this._video) {
       this._video.pause();
-      this._video.src = '';
+      this._video.removeAttribute('src');
+      this._video.load();
+      this._video = null;
     }
-    if (this._videoTexture) {
-      this._videoTexture.dispose();
-    }
+    if (this._videoTexture) { this._videoTexture.dispose(); this._videoTexture = null; }
+    // Dispose shared GPU resources — the pool meshes share these so we
+    // dispose once. Without this, every race-restart leaks a PlaneGeometry,
+    // a ShaderMaterial, another PlaneGeometry, a MeshBasicMaterial, and a
+    // CanvasTexture, which on iOS Chrome accumulates fast enough to OOM
+    // the renderer after a few races.
+    if (this._pylonGeo)  { this._pylonGeo.dispose();  this._pylonGeo = null; }
+    if (this._pylonMat)  { this._pylonMat.dispose();  this._pylonMat = null; }
+    if (this._shadowGeo) { this._shadowGeo.dispose(); this._shadowGeo = null; }
+    if (this._shadowMat) { this._shadowMat.dispose(); this._shadowMat = null; }
+    if (this._shadowTex) { this._shadowTex.dispose(); this._shadowTex = null; }
     this._pool = [];
     this._items = [];
   }

--- a/js/world.js
+++ b/js/world.js
@@ -1041,7 +1041,32 @@ export class World {
 
   clearRaceMarkers() {
     this._cleanupDestVideo();
-    this._raceMarkers.forEach(m => this.scene.remove(m.mesh));
+    this._raceMarkers.forEach(m => {
+      this.scene.remove(m.mesh);
+      // Dispose materials/textures/geometries on the way out. Without
+      // this, every return-to-room/lobby leaks the per-race arch puffs,
+      // checkpoint/finish markers, and any cloned sprite materials they
+      // own — accumulates as GPU memory on iOS Chrome and contributes
+      // to the renderer-OOM freeze (audio keeps playing, UI locks).
+      if (m.mesh.traverse) {
+        m.mesh.traverse(child => {
+          if (child.material) {
+            const mats = Array.isArray(child.material) ? child.material : [child.material];
+            for (const mat of mats) {
+              if (mat.map) mat.map.dispose();
+              mat.dispose();
+            }
+          }
+          if (child.geometry) child.geometry.dispose();
+        });
+      } else {
+        if (m.mesh.material) {
+          if (m.mesh.material.map) m.mesh.material.map.dispose();
+          m.mesh.material.dispose();
+        }
+        if (m.mesh.geometry) m.mesh.geometry.dispose();
+      }
+    });
     this._raceMarkers = [];
   }
 


### PR DESCRIPTION
## Summary

Reported symptom: after 2–3 races on Chrome iOS the page froze solid (couldn't switch tabs, type a URL, or hit Back) while music and the bike-motion loop kept playing. That's the classic iOS WebKit pattern of the renderer process hitting its memory ceiling — the main thread can no longer schedule work, but the AudioContext runs on a separate audio-rendering thread and keeps going until the OS kills it. 2–3 races to repro is consistent with a per-race leak in the tens of MB.

Found four concrete per-race resource leaks and fixed them.

## Fixes

- **`js/audio-engine.js`** — `startBike()` created six nodes (3 `BiquadFilter` + 3 `GainNode`) that stayed connected to `bikeBus` forever; `stopBike()` only stopped the buffer sources. Sources auto-GC after `stop()`, but filters/gains don't. Now `_bike` holds refs to all nine nodes and `stopBike()` `disconnect()`s every one after the 400 ms fade.
- **`js/obstacles.js`** — `destroy()` removed pool meshes from the scene but never disposed the shared pylon `PlaneGeometry` + `ShaderMaterial` or the shadow `PlaneGeometry` + `MeshBasicMaterial` + `CanvasTexture`. Now disposes all five. Also tears the `<video>` down via `removeAttribute('src')` + `load()` (setting `src=''` can leave the iOS decoder pinned).
- **`js/collectibles.js`** — `destroy()` only sometimes disposed the video texture and never disposed materials/geometries. Now dedupes shared geo/mat across variants (presents share one geo+mat across 3 variants) and disposes each once, plus the video element.
- **`js/world.js`** — `clearRaceMarkers()` removed marker meshes from the scene but never disposed their geometries/materials/textures. The matching `setRaceMarkers` does dispose, but only when called again — returning to the room/lobby leaked the whole arch + finish-marker tree. Now traverses each marker and disposes on the way out, matching the `setRaceMarkers` pattern.

## Things deliberately not touched

- `_setupStartHandler` in `game.js` adds `touchstart`/`click` listeners and a `requestAnimationFrame` polling loop on each call. The RAF self-terminates when state leaves `'instructions'`, and the listeners are removed by `doStart()`. Only leaky if the user backs out of `'instructions'` without ever pressing Start, which isn't the reported flow — left alone to avoid a wider refactor.
- The `MediaRecorder` rolling buffer in `game-recorder.js` correctly prunes to ~20 s, so it's already bounded.

## Test plan

- [ ] On iOS Chrome, play 4+ races back-to-back via "Play Again" and confirm the page no longer freezes.
- [ ] Same flow via "Restart" from the Game Over screen.
- [ ] Bounce in/out of the room (lobby → race → room → race) several times and confirm no freeze.
- [ ] Verify bike motion audio still fades in/out cleanly at race start/end (the disconnect happens after the 400 ms fade — should be inaudible).
- [ ] If possible, attach Safari Web Inspector to a paired iOS device and watch JS heap + GPU memory across races; the per-race delta should now be roughly flat.
- [ ] Sanity-check obstacle pylon video and present collectible video still play and chromakey correctly on a fresh race after a previous race ended.

https://claude.ai/code/session_01Ax6FvXds7E6KKbtJBP9vrM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax6FvXds7E6KKbtJBP9vrM)_