### PR TITLE
Add six track artifacts: ramps, boost pads, mud, drawbridges, choke points, sync gates

### DIFF
--- a/assets/tracks/castle.json
+++ b/assets/tracks/castle.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "id": "castle",
+  "name": "The Castle",
+  "author": "official",
+  "artifacts": [
+    { "type": "boost",      "d":  80, "offset":  0,   "width": 2.5, "length": 4.5, "strength": 1.4,  "decay": 0.9 },
+    { "type": "mud",        "d": 145, "offset":  1.0, "width": 1.6, "length": 3.0, "friction": 0.5 },
+    { "type": "ramp",       "d": 215, "offset":  0,   "width": 2.4, "length": 3.5, "angle": 20, "skin": "wood" },
+    { "type": "sync",       "d": 265, "phaseTolerance": 30, "rewardStrength": 1.4,  "rewardDuration": 1.2 },
+    { "type": "choke",      "d": 325, "offset":  0,   "gap": 2.0, "depth": 1.0, "mode": "crash", "skin": "barrier" },
+    { "type": "boost",      "d": 385, "offset": -0.5, "width": 2.5, "length": 4.0, "strength": 1.35, "decay": 0.8 },
+    { "type": "drawbridge", "d": 450, "period": 6.0, "phase": 1.0, "downRatio": 0.6, "skin": "wood" },
+    { "type": "mud",        "d": 505, "offset": -1.2, "width": 1.6, "length": 3.0, "friction": 0.55 },
+    { "type": "ramp",       "d": 565, "offset":  0,   "width": 2.4, "length": 4.0, "angle": 22, "skin": "metal" },
+    { "type": "sync",       "d": 620, "phaseTolerance": 28, "rewardStrength": 1.45, "rewardDuration": 1.2 },
+    { "type": "choke",      "d": 665, "offset":  0,   "gap": 1.8, "depth": 1.0, "mode": "crash", "skin": "statue" }
+  ]
+}

--- a/assets/tracks/castle.json
+++ b/assets/tracks/castle.json
@@ -4,16 +4,16 @@
   "name": "The Castle",
   "author": "official",
   "artifacts": [
-    { "type": "boost",      "d":  80, "offset":  0,   "width": 2.5, "length": 4.5, "strength": 1.4,  "decay": 0.9 },
+    { "type": "boost",      "d":  80, "offset":  0,   "width": 2.5, "length": 4.5, "strength": 1.7,  "decay": 1.3 },
     { "type": "mud",        "d": 145, "offset":  1.0, "width": 1.6, "length": 3.0, "friction": 0.5 },
     { "type": "ramp",       "d": 215, "offset":  0,   "width": 2.4, "length": 3.5, "angle": 20, "skin": "wood" },
-    { "type": "sync",       "d": 265, "phaseTolerance": 30, "rewardStrength": 1.4,  "rewardDuration": 1.2 },
+    { "type": "sync",       "d": 265, "phaseTolerance": 30, "rewardStrength": 1.7,  "rewardDuration": 1.8 },
     { "type": "choke",      "d": 325, "offset":  0,   "gap": 2.0, "depth": 1.0, "mode": "crash", "skin": "barrier" },
-    { "type": "boost",      "d": 385, "offset": -0.5, "width": 2.5, "length": 4.0, "strength": 1.35, "decay": 0.8 },
+    { "type": "boost",      "d": 385, "offset": -0.5, "width": 2.5, "length": 4.0, "strength": 1.7,  "decay": 1.2 },
     { "type": "drawbridge", "d": 450, "period": 6.0, "phase": 1.0, "downRatio": 0.6, "skin": "wood" },
     { "type": "mud",        "d": 505, "offset": -1.2, "width": 1.6, "length": 3.0, "friction": 0.55 },
     { "type": "ramp",       "d": 565, "offset":  0,   "width": 2.4, "length": 4.0, "angle": 22, "skin": "metal" },
-    { "type": "sync",       "d": 620, "phaseTolerance": 28, "rewardStrength": 1.45, "rewardDuration": 1.2 },
+    { "type": "sync",       "d": 620, "phaseTolerance": 28, "rewardStrength": 1.7,  "rewardDuration": 1.8 },
     { "type": "choke",      "d": 665, "offset":  0,   "gap": 1.8, "depth": 1.0, "mode": "crash", "skin": "statue" }
   ]
 }

--- a/assets/tracks/grandma.json
+++ b/assets/tracks/grandma.json
@@ -4,10 +4,10 @@
   "name": "Grandma's",
   "author": "official",
   "artifacts": [
-    { "type": "boost",      "d": 105, "offset":  0,   "width": 2.5, "length": 4.0, "strength": 1.35, "decay": 0.8 },
+    { "type": "boost",      "d": 105, "offset":  0,   "width": 2.5, "length": 4.0, "strength": 1.7,  "decay": 1.2 },
     { "type": "mud",        "d": 145, "offset": -1.0, "width": 1.5, "length": 2.5, "friction": 0.55 },
     { "type": "ramp",       "d": 200, "offset":  0,   "width": 2.2, "length": 3.0, "angle": 15, "skin": "wood" },
-    { "type": "sync",       "d": 245, "phaseTolerance": 35, "rewardStrength": 1.35, "rewardDuration": 1.0 },
+    { "type": "sync",       "d": 245, "phaseTolerance": 35, "rewardStrength": 1.7,  "rewardDuration": 1.8 },
     { "type": "choke",      "d": 295, "offset":  0,   "gap": 2.4, "depth": 1.0, "mode": "scrape", "skin": "haystack" }
   ]
 }

--- a/assets/tracks/grandma.json
+++ b/assets/tracks/grandma.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "id": "grandma",
+  "name": "Grandma's",
+  "author": "official",
+  "artifacts": [
+    { "type": "boost",      "d": 105, "offset":  0,   "width": 2.5, "length": 4.0, "strength": 1.35, "decay": 0.8 },
+    { "type": "mud",        "d": 145, "offset": -1.0, "width": 1.5, "length": 2.5, "friction": 0.55 },
+    { "type": "ramp",       "d": 200, "offset":  0,   "width": 2.2, "length": 3.0, "angle": 15, "skin": "wood" },
+    { "type": "sync",       "d": 245, "phaseTolerance": 35, "rewardStrength": 1.35, "rewardDuration": 1.0 },
+    { "type": "choke",      "d": 295, "offset":  0,   "gap": 2.4, "depth": 1.0, "mode": "scrape", "skin": "haystack" }
+  ]
+}

--- a/assets/tracks/tutorial.json
+++ b/assets/tracks/tutorial.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "tutorial",
+  "name": "Tutorial",
+  "author": "official",
+  "artifacts": []
+}

--- a/docs/track-artifacts-design.md
+++ b/docs/track-artifacts-design.md
@@ -1,0 +1,528 @@
+# Track Artifacts — Design & Implementation Plan
+
+> Status: Draft
+> Branch: `claude/game-progression-world-design-1IoCh`
+> Related issues: see "New Track Artifacts" and "Track Builder + UGC" in this repo.
+
+## 1. Motivation
+
+Current races (Grandma's, Castle) are 250–500 m straight rides with only three
+content primitives: **checkpoints**, **collectibles**, **obstacles** (pylons).
+This produces short, low-variety play sessions. Players see all the mechanics
+in ~90 seconds.
+
+This document defines **six new track artifacts** that:
+
+1. Add new verbs to gameplay (jump, accelerate, slow, time, squeeze, sync).
+2. Slot into the existing road / pool / chromakey architecture used by
+   `obstacles.js` and `collectibles.js`.
+3. Expose a parameter surface that can be authored by hand *and* by a future
+   user-generated content (UGC) track builder.
+4. Work in single-player and tandem multiplayer (one bike, two riders) as
+   well as networked multiplayer (multiple bikes).
+
+The artifacts are: **ramps, boost pads, mud patches, drawbridges, choke
+points, sync gates.**
+
+## 2. Architectural Fit
+
+### 2.1 Today
+
+```
+race-config.js   →   LEVELS[]: { id, distance, collectibles, checkpointInterval, ... }
+road-path.js     →   parametric road; getPointAtDistance(d) → {x,y,z,heading}
+road-chunks.js   →   streaming road mesh chunks around the player
+collectibles.js  →   per-level pool, deterministic seeded placement
+obstacles.js     →   per-level pool, deterministic seeded placement, hit radius 0.75m
+race-manager.js  →   checkpoints, segment timer, finish
+world.js         →   scene root, scenery, race markers (checkpoint/destination billboards)
+```
+
+Each content manager exposes the same lifecycle: `constructor(scene, roadPath, level, ...)`,
+`update(dt, distanceTraveled, bikePos)`, optional `checkCollision(bikePos)`, and a
+shared pool + visibility window pattern (200 m ahead, 40 m behind).
+
+### 2.2 Proposal
+
+Introduce a **single artifact subsystem** that hosts all six new artifact
+managers behind a common interface, plus a per-level **track manifest** that
+lists artifact instances with their position and per-instance params.
+
+```
+js/artifacts/
+    artifact-base.js        // shared pool helpers, visibility, collision math
+    ramp.js
+    boost-pad.js
+    mud-patch.js
+    drawbridge.js
+    choke-point.js
+    sync-gate.js
+    artifact-manager.js     // owns all six per level, dispatches update/collision
+    track-manifest.js       // load + validate manifests (hand-authored or UGC)
+```
+
+`game.js` constructs **one** `ArtifactManager` per race instead of N
+managers. The manager loads the track manifest for the active level and
+spawns the appropriate sub-managers.
+
+`race-config.js` gains a `track` field that either inlines a manifest or
+references one in `assets/tracks/<id>.json`.
+
+`race-manager.js` is unchanged except for an optional callback for
+artifacts that need to gate finish/checkpoint logic (e.g. drawbridges
+extending the timer; sync gates contributing bonus time).
+
+### 2.3 Why one manager, not six
+
+* Lifetime / pool ownership is consistent.
+* Collision pass becomes one ordered iteration (important when multiple
+  artifacts overlap — e.g. boost pad after a ramp landing).
+* Future builder UI iterates over a single registry of artifact types.
+
+## 3. The Six Artifacts
+
+Each spec below lists: **player verb**, **physics effect**, **visual**,
+**collision shape**, **data params**, **UGC-safe param ranges**,
+**multiplayer rules**.
+
+### 3.1 Ramp
+
+* **Verb:** jump.
+* **Effect:** While crossing the ramp footprint, the bike's Y is raised
+  along an arc. On launch (last 0.5 m of footprint), apply an upward
+  velocity component; bike enters a 0.2–1.5 s airborne state where steering
+  is reduced and pedaling does not affect ground speed; landing within
+  expected zone gives a small forward boost, landing wide skids and
+  optionally crashes.
+* **Visual:** Wooden / metal ramp mesh (textured plane + side fascia).
+  Trail effect on launch. Future: trick particles in air.
+* **Collision shape:** Axis-aligned along road tangent. Footprint width
+  defines lateral extent; player must hit center band to launch cleanly.
+* **Data params:**
+
+  ```jsonc
+  {
+    "type": "ramp",
+    "d": 120,                // distance along road
+    "offset": 0,             // lateral, meters from centerline
+    "width": 2.0,            // meters
+    "length": 3.0,           // meters
+    "angle": 22,             // launch angle degrees
+    "airTime": 0.8,          // seconds (auto-clamped from speed + angle)
+    "skin": "wood"           // wood | metal | dirt | ugc:<assetId>
+  }
+  ```
+
+* **UGC-safe ranges:** `width` 1.0–3.5, `length` 1.5–6.0, `angle` 5–35.
+* **Multiplayer:** Each bike resolves jump independently. Mid-air bikes
+  do not collide. Networked: send `airborne=true/false` in remote state so
+  partners see jumps.
+
+### 3.2 Boost Pad
+
+* **Verb:** accelerate.
+* **Effect:** While the bike center is on the pad, apply an additive
+  forward speed bonus that decays over a configurable duration after exit
+  (so chaining pads through a corner feels good). Cap final speed so
+  boosts can't break the world.
+* **Visual:** Striped chevron pad on the road surface; animated chevrons
+  sliding forward. Faint exhaust particles trailing the bike during decay.
+* **Collision shape:** Rectangle on ground; trigger volume, no crash.
+* **Data params:**
+
+  ```jsonc
+  {
+    "type": "boost",
+    "d": 90,
+    "offset": 0,
+    "width": 2.5,
+    "length": 4.0,
+    "strength": 1.4,         // multiplier of base speed at peak
+    "decay": 1.0,            // seconds after exit
+    "skin": "chevron"
+  }
+  ```
+
+* **UGC-safe ranges:** `strength` 1.1–1.8, `decay` 0.3–2.0,
+  `width` 1.5–4.0, `length` 2.0–8.0. Hard cap on per-segment cumulative
+  boost so a builder can't spam pads.
+* **Multiplayer:** Per-bike. Visual chevrons sync from the artifact, not
+  from each bike.
+
+### 3.3 Mud Patch
+
+* **Verb:** slow.
+* **Effect:** While on the patch, multiply forward speed by `friction`
+  (0.4–0.8). Pedal input continues to apply but with reduced effectiveness.
+  Steering also reduced. Optional spray particles.
+* **Visual:** Irregular brown organic decal on the road. Sound: wet
+  squelch / splatter.
+* **Collision shape:** Rectangle or polygon on ground. For MVP rectangle.
+* **Data params:**
+
+  ```jsonc
+  {
+    "type": "mud",
+    "d": 160,
+    "offset": -1.2,
+    "width": 1.5,
+    "length": 3.0,
+    "friction": 0.5,
+    "skin": "mud"            // mud | sand | ice | ugc:<assetId>
+  }
+  ```
+
+* **UGC-safe ranges:** `friction` 0.4–0.9, `width` 1.0–3.5,
+  `length` 1.0–6.0.
+* **Multiplayer:** Per-bike. Other bikes see your spray particles via
+  remote state's `surface` field.
+
+### 3.4 Drawbridge
+
+* **Verb:** time it.
+* **Effect:** Two-state object that cycles open ↔ closed on a fixed
+  period offset by phase. While **down**, treat like normal road. While
+  **rising / up**, treat as solid wall (crash) and visually occlude. Half
+  an animation cycle is the windowless period.
+* **Visual:** Two hinged road planks that lift toward each other (or a
+  single plank that drops/lifts). Warning paint on the road approaching.
+  Optional siren sound while transitioning.
+* **Collision shape:** Two states. Cosmetic mesh + scripted boolean
+  collider. When transitioning, collider extends as a wall across both lanes.
+* **Data params:**
+
+  ```jsonc
+  {
+    "type": "drawbridge",
+    "d": 300,
+    "period": 6.0,           // seconds for a full cycle
+    "phase": 0.0,            // seconds offset
+    "downRatio": 0.6,        // 0..1 fraction of period spent fully down
+    "skin": "wood"
+  }
+  ```
+
+* **UGC-safe ranges:** `period` 3.0–12.0, `downRatio` 0.4–0.8 (prevents
+  unfair "always up" bridges).
+* **Multiplayer:** Bridge state is **derived from race wall-clock time
+  and seed**, so it is identical for every client without network sync.
+
+### 3.5 Choke Point
+
+* **Verb:** squeeze through.
+* **Effect:** Narrows the drivable corridor at this distance. Outside the
+  corridor the bike crashes (or scrapes — see param). Used to force
+  steering precision and, in multiplayer, to create overtake pressure.
+* **Visual:** Pair of opposing scenery objects (cones+barriers,
+  haystacks, knight statues) bordering the corridor. Optional flashing
+  warning markers ~5 m ahead.
+* **Collision shape:** Two opposing rectangles, leaving a `gap` lane.
+* **Data params:**
+
+  ```jsonc
+  {
+    "type": "choke",
+    "d": 220,
+    "offset": 0,             // centerline of the gap
+    "gap": 1.8,              // meters
+    "depth": 1.0,            // meters along road
+    "mode": "crash",         // crash | scrape  (scrape = slow, no crash)
+    "skin": "haystack"       // haystack | barrier | statue | ugc:<assetId>
+  }
+  ```
+
+* **UGC-safe ranges:** `gap` 1.2–3.5 (bike body is ~0.7 m;
+  below 1.2 is unfair). `offset` clamped to road width minus gap/2.
+* **Multiplayer:** In networked play, the artifact's mesh is shared; per-bike
+  collision is independent so two bikes can pass simultaneously *if* the
+  builder placed the gap wide enough. This creates the overtake pressure
+  organically without extra logic.
+
+### 3.6 Sync Gate
+
+* **Verb:** coordinate (the tandem-unique mechanic).
+* **Effect:** A wide gate the bike must cross. While crossing, sample
+  the in-phase metric from `shared-pedal-controller.js` (or the
+  single-player equivalent of pedal-vs-target). If both riders are within
+  `phaseTolerance` of each other during the crossing window, award a
+  **boost** (similar magnitude to boost pad) and play a chime; otherwise no
+  effect.
+* **Visual:** Two glowing rings on poles arching over the road, like a
+  finish gate. Color pulses with the bike's current sync metric so players
+  can see whether they're "in tune" before they hit it. Green = synced,
+  red = off.
+* **Collision shape:** Trigger volume spanning full road width; no crash.
+* **Data params:**
+
+  ```jsonc
+  {
+    "type": "sync",
+    "d": 180,
+    "phaseTolerance": 30,    // degrees of pedal phase difference allowed
+    "rewardStrength": 1.5,   // boost multiplier
+    "rewardDuration": 1.2,
+    "skin": "neon"
+  }
+  ```
+
+* **UGC-safe ranges:** `phaseTolerance` 15–60, `rewardStrength` 1.1–1.7,
+  `rewardDuration` 0.5–2.0.
+* **Multiplayer:** Each bike (each tandem pair) resolves independently.
+  In single-player, the second rider's phase is derived from the bot
+  pedal-controller; tolerance auto-widens so solo play stays winnable.
+
+## 4. Track Manifest Schema
+
+A track manifest describes ordered artifacts along a level's road. Same
+schema is used for built-in tracks and UGC tracks.
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "id": "grandma",
+  "name": "Grandma's",
+  "distance": 350,
+  "collectibles": "presents",
+  "checkpointInterval": 70,
+  "seed": 4242,
+  "author": "official",           // or a player handle for UGC
+  "artifacts": [
+    { "type": "ramp",        "d":  60, "offset": 0,    "width": 2.0, "length": 3.0, "angle": 18, "skin": "wood" },
+    { "type": "boost",       "d":  85, "offset": 0,    "width": 2.5, "length": 4.0, "strength": 1.35, "decay": 0.8 },
+    { "type": "mud",         "d": 130, "offset": -1.2, "width": 1.5, "length": 2.5, "friction": 0.55 },
+    { "type": "choke",       "d": 180, "offset": 0,    "gap": 2.0, "depth": 1.0, "mode": "crash", "skin": "haystack" },
+    { "type": "sync",        "d": 230, "phaseTolerance": 30, "rewardStrength": 1.4, "rewardDuration": 1.0 },
+    { "type": "drawbridge",  "d": 290, "period": 5.0, "phase": 0.0, "downRatio": 0.6 }
+  ]
+}
+```
+
+### 4.1 Validation rules (enforced for UGC, advisory for hand-authored)
+
+* `schemaVersion` must match a known version.
+* All artifacts must have `d` ≥ 0 and `d` ≤ `distance - 5`.
+* `offset` clamped to drivable road half-width.
+* Per-type `UGC-safe ranges` (see Section 3) enforced.
+* Spacing: any two artifacts of the same type must be ≥ 8 m apart;
+  any artifact and a checkpoint ≥ 15 m apart (mirrors the existing
+  `cpClearance` in `obstacles.js`).
+* Cumulative `(boost.strength - 1) * boost.length` per 100 m segment
+  capped to prevent "boost spam".
+* Maximum 80 artifacts per track.
+
+Validation lives in `track-manifest.js` and runs:
+
+1. At engine load for built-in manifests (assert).
+2. At UGC import time (reject with human-readable error).
+3. Server-side at UGC publish time (Cloudflare Worker — see Section 7).
+
+## 5. Visual & Asset Plan
+
+Each artifact ships with **two skins minimum** built-in. UGC skins are
+added later (see Section 7.3).
+
+| Artifact     | Built-in skins      | Asset type         | Source |
+|--------------|--------------------|--------------------|---|
+| Ramp         | wood, metal        | textured mesh      | new |
+| Boost pad    | chevron, neon      | tiled decal + shader | new |
+| Mud patch    | mud, sand, ice     | ground decal + particles | new |
+| Drawbridge   | wood, stone        | hinged mesh        | new |
+| Choke point  | haystack, barrier, knight statue | reused obstacle pool + 2 new meshes | partial reuse |
+| Sync gate    | neon, festival     | emissive arch mesh | new |
+
+All artifacts reuse the existing **chromakey video shader** pattern from
+`obstacles.js` *only* if they have animated visuals (boost pad chevrons,
+sync gate pulse). Static artifacts use a plain `MeshBasicMaterial` or
+`MeshLambertMaterial`.
+
+## 6. Integration With Existing Races
+
+Updating `race-config.js`:
+
+```jsonc
+LEVELS = [
+  { id: "tutorial", ..., track: "assets/tracks/tutorial.json" },
+  { id: "grandma",  ..., distance: 350, track: "assets/tracks/grandma.json" },
+  { id: "castle",   ..., distance: 700, track: "assets/tracks/castle.json" }
+]
+```
+
+### 6.1 Grandma's (350 m, was 250 m)
+
+Theme: friendly neighborhood. Light challenge.
+
+* 1 ramp (small)
+* 2 boost pads
+* 1 mud patch
+* 1 sync gate
+* 1 choke point (gap 2.2, scrape mode)
+* No drawbridge (saved for harder levels)
+
+### 6.2 Castle (700 m, was 500 m)
+
+Theme: medieval, moat, drawbridge. Full toolkit.
+
+* 2 ramps (one long jump over a moat)
+* 3 boost pads
+* 2 mud patches
+* 1 drawbridge (over moat)
+* 2 choke points (between battlements; tighter gap)
+* 2 sync gates (bonus time)
+
+### 6.3 Tutorial — unchanged
+
+Tutorial keeps only the pylon mechanic; we do **not** introduce artifacts
+in the tutorial in this phase. (A later phase will add a per-artifact
+tutorial scene gated behind first encounter.)
+
+## 7. UGC: Sharing, Validation, Moderation
+
+This section defines the parameter surface only. Builder UI is its own
+issue (#TBD: "Track Builder + UGC").
+
+### 7.1 Share format: track codes
+
+A track is a base64url-encoded, gzip-compressed JSON manifest, prefixed
+with the schema version: `T1.<base64url>`. Typical 30-artifact manifest
+compresses to ~250–400 chars — short enough to paste into a chat.
+
+Importing a code:
+
+1. Decode → JSON.
+2. Run full validation (Section 4.1).
+3. Render an unmodifiable preview.
+4. Player can play it locally or save it to their library.
+
+This requires **no server** for peer-to-peer sharing — important for
+launch.
+
+### 7.2 Optional publish: server-side moderation
+
+When a player wants to publish to a public gallery:
+
+1. Client posts the manifest JSON to a new Cloudflare Worker endpoint
+   `POST /tracks` (rate-limited by the existing relay/leaderboard
+   pattern).
+2. Worker re-runs validation server-side.
+3. **Automated review** (pre-MVP, cheap):
+   * Profanity filter on `name` and `author` (use existing handle
+     filter from leaderboard if present).
+   * Geometry sanity: at least one checkpoint reachable; finish
+     reachable; no artifact past `distance`.
+   * No "wall of crashes" — count: artifacts of type `mud` /
+     `choke` / `drawbridge` ≤ 40% of total.
+4. **Manual review queue**: status defaults to `pending`. Tracks visible
+   only to author until approved.
+5. Approved tracks land in a paginated gallery keyed by play count, like
+   the existing leaderboard.
+
+D1 schema addition:
+
+```sql
+CREATE TABLE tracks (
+  id           TEXT PRIMARY KEY,
+  author_id    TEXT NOT NULL,
+  author_name  TEXT NOT NULL,
+  name         TEXT NOT NULL,
+  manifest     TEXT NOT NULL,  -- raw JSON
+  status       TEXT NOT NULL,  -- pending|approved|rejected
+  created_at   INTEGER NOT NULL,
+  play_count   INTEGER DEFAULT 0,
+  rating_avg   REAL DEFAULT 0
+);
+CREATE INDEX tracks_status_created ON tracks(status, created_at DESC);
+```
+
+### 7.3 UGC skins — out of scope for v1
+
+Players choose from built-in skin enums only. Custom textures or meshes
+are deferred: they introduce asset hosting, copyright, and texture
+budget issues that v1 should not pay for.
+
+## 8. Multiplayer Considerations
+
+* All six artifacts are **deterministic given the manifest**. No need to
+  sync per-artifact state across clients.
+* Drawbridge phase is computed from `(race_time + manifest.phase) % period`
+  — same on every client because race start time is already synced via
+  `network-manager.js`.
+* Per-bike effects (boost, slow, airborne) are local; the only network
+  field added is `airborne: bool` so partners see jumps. Confirm there is
+  budget in `remote-bike-state.js` payload before adding.
+* Sync gates only resolve when *both* of the local tandem's riders are
+  in phase — they do **not** require cross-bike sync.
+* In races with multiple bikes, choke points organically gate overtakes
+  (intentional design lever, not a bug).
+
+## 9. Implementation Plan
+
+### Phase 1 — Foundation (1 PR)
+
+* `js/artifacts/artifact-base.js` — shared pool helper with the
+  visibility window + lateral offset math borrowed from `obstacles.js`.
+* `js/artifacts/artifact-manager.js` — owns sub-managers, single
+  `update()` and `checkCollision()` entry points.
+* `js/artifacts/track-manifest.js` — schema, loader, validator.
+* `assets/tracks/grandma.json`, `castle.json`, `tutorial.json` —
+  initially **empty** `artifacts: []` to preserve current play.
+* Wire `game.js` to construct `ArtifactManager` and call its hooks
+  alongside the existing obstacle/collectible managers.
+* No gameplay change yet.
+
+### Phase 2 — Static artifacts (1 PR each)
+
+In order of risk:
+
+1. **Boost pad** — pure speed delta, no new physics state.
+2. **Mud patch** — same shape, opposite sign.
+3. **Choke point** — reuses obstacle collision math with two colliders.
+
+### Phase 3 — Dynamic artifacts (1 PR each)
+
+4. **Drawbridge** — adds a time-driven collider; deterministic from
+   race clock.
+5. **Ramp** — introduces airborne state in `bike-model.js` /
+   `balance-controller.js`; needs care to not break tutorial or DDA.
+6. **Sync gate** — depends on phase-difference signal already present
+   in `shared-pedal-controller.js`; verify the single-player equivalent
+   first.
+
+### Phase 4 — Race content update (1 PR)
+
+* Author the Section 6 manifests for Grandma's and Castle.
+* Update level distances in `race-config.js`.
+* Adjust segment timer budgets.
+* Manual playtest + DDA pass.
+
+### Phase 5 — UGC import (separate epic, see "Track Builder + UGC" issue)
+
+* Track code import + preview screen.
+* Worker endpoint + D1 table + moderation queue.
+
+## 10. Risks & Open Questions
+
+* **Ramps + balance**: airborne state interacts with the lean / tilt
+  system. Need a spike to confirm `balance-controller.js` can pause
+  cleanly during airtime without flipping the bike on landing. **Mitigation:**
+  start with very small ramps and short airtimes in Phase 3.
+* **Boost stacking**: chained pads through curves could let players
+  exceed top speed targets used by DDA. **Mitigation:** absolute speed
+  cap; per-segment cumulative boost cap in validator.
+* **Mobile perf**: more meshes per scene. **Mitigation:** all artifacts
+  share pools, visibility window matches obstacles, fall back to lower
+  poly meshes on `lowEnd`.
+* **Tutorial impact**: must not break existing tutorial flow.
+  Phase 1 ships empty manifests for that reason.
+* **Multiplayer payload**: adding `airborne` to remote state. Confirm
+  byte budget; if tight, derive from vertical velocity instead.
+
+## 11. Out of Scope (v1)
+
+* Loops, half-pipes, see-saws (Section B from brainstorm)
+* Open hub world
+* UGC custom skins / meshes
+* Cross-bike cooperative switches
+* Power-ups (Mario Kart-style items)
+
+These remain in the design backlog and should be re-evaluated after the
+six-artifact set ships.

--- a/docs/track-artifacts-design.md
+++ b/docs/track-artifacts-design.md
@@ -18,8 +18,10 @@ This document defines **six new track artifacts** that:
    `obstacles.js` and `collectibles.js`.
 3. Expose a parameter surface that can be authored by hand *and* by a future
    user-generated content (UGC) track builder.
-4. Work in single-player and tandem multiplayer (one bike, two riders) as
-   well as networked multiplayer (multiple bikes).
+4. Work in both single-player and **tandem multiplayer** — the current
+   multiplayer model, where two players (Captain + Stoker) share one bike
+   over the network. There is no versus / multi-bike mode today; designing
+   for one is explicitly out of scope here.
 
 The artifacts are: **ramps, boost pads, mud patches, drawbridges, choke
 points, sync gates.**
@@ -114,9 +116,12 @@ Each spec below lists: **player verb**, **physics effect**, **visual**,
   ```
 
 * **UGC-safe ranges:** `width` 1.0–3.5, `length` 1.5–6.0, `angle` 5–35.
-* **Multiplayer:** Each bike resolves jump independently. Mid-air bikes
-  do not collide. Networked: send `airborne=true/false` in remote state so
-  partners see jumps.
+* **Multiplayer (Captain + Stoker on one bike):** The airborne state is
+  a property of the single shared bike. The client running the bike
+  physics computes the jump from bike position + manifest (deterministic);
+  the partner client mirrors via the existing remote-bike-state sync. One
+  added field: `airborne: bool` so the partner renders the bike off the
+  ground.
 
 ### 3.2 Boost Pad
 
@@ -146,8 +151,11 @@ Each spec below lists: **player verb**, **physics effect**, **visual**,
 * **UGC-safe ranges:** `strength` 1.1–1.8, `decay` 0.3–2.0,
   `width` 1.5–4.0, `length` 2.0–8.0. Hard cap on per-segment cumulative
   boost so a builder can't spam pads.
-* **Multiplayer:** Per-bike. Visual chevrons sync from the artifact, not
-  from each bike.
+* **Multiplayer (Captain + Stoker on one bike):** Speed effect is applied
+  to the single shared bike; both clients derive the same effect
+  deterministically from bike position vs the manifest. Visual chevrons
+  animate from the artifact's local clock, not bike state, so they look
+  identical on both clients.
 
 ### 3.3 Mud Patch
 
@@ -174,8 +182,9 @@ Each spec below lists: **player verb**, **physics effect**, **visual**,
 
 * **UGC-safe ranges:** `friction` 0.4–0.9, `width` 1.0–3.5,
   `length` 1.0–6.0.
-* **Multiplayer:** Per-bike. Other bikes see your spray particles via
-  remote state's `surface` field.
+* **Multiplayer (Captain + Stoker on one bike):** Slow effect applies to
+  the single shared bike; deterministic from position vs manifest so both
+  clients agree without extra sync.
 
 ### 3.4 Drawbridge
 
@@ -211,8 +220,9 @@ Each spec below lists: **player verb**, **physics effect**, **visual**,
 
 * **Verb:** squeeze through.
 * **Effect:** Narrows the drivable corridor at this distance. Outside the
-  corridor the bike crashes (or scrapes — see param). Used to force
-  steering precision and, in multiplayer, to create overtake pressure.
+  corridor the bike crashes (or scrapes — see param). Forces steering
+  precision from the Captain and a brief moment of tension. Pairs well
+  placed right after a boost pad or ramp landing.
 * **Visual:** Pair of opposing scenery objects (cones+barriers,
   haystacks, knight statues) bordering the corridor. Optional flashing
   warning markers ~5 m ahead.
@@ -233,10 +243,10 @@ Each spec below lists: **player verb**, **physics effect**, **visual**,
 
 * **UGC-safe ranges:** `gap` 1.2–3.5 (bike body is ~0.7 m;
   below 1.2 is unfair). `offset` clamped to road width minus gap/2.
-* **Multiplayer:** In networked play, the artifact's mesh is shared; per-bike
-  collision is independent so two bikes can pass simultaneously *if* the
-  builder placed the gap wide enough. This creates the overtake pressure
-  organically without extra logic.
+* **Multiplayer (Captain + Stoker on one bike):** Single bike, single
+  collision — no extra logic needed. Steering ownership stays with whoever
+  has it today (Captain). The Stoker can still affect outcome via the
+  shared pedal contribution / balance signal feeding the lean.
 
 ### 3.6 Sync Gate
 
@@ -267,9 +277,12 @@ Each spec below lists: **player verb**, **physics effect**, **visual**,
 
 * **UGC-safe ranges:** `phaseTolerance` 15–60, `rewardStrength` 1.1–1.7,
   `rewardDuration` 0.5–2.0.
-* **Multiplayer:** Each bike (each tandem pair) resolves independently.
-  In single-player, the second rider's phase is derived from the bot
-  pedal-controller; tolerance auto-widens so solo play stays winnable.
+* **Multiplayer (Captain + Stoker on one bike):** This is the headline
+  artifact for tandem play — the gate explicitly rewards Captain and
+  Stoker pedaling in phase. Phase data already exists in
+  `shared-pedal-controller.js` / `contribution-tracker.js`. In single-player
+  the Stoker phase comes from the bot pedal controller and tolerance
+  auto-widens so solo play stays winnable.
 
 ## 4. Track Manifest Schema
 
@@ -441,18 +454,32 @@ budget issues that v1 should not pay for.
 
 ## 8. Multiplayer Considerations
 
-* All six artifacts are **deterministic given the manifest**. No need to
-  sync per-artifact state across clients.
-* Drawbridge phase is computed from `(race_time + manifest.phase) % period`
-  — same on every client because race start time is already synced via
-  `network-manager.js`.
-* Per-bike effects (boost, slow, airborne) are local; the only network
-  field added is `airborne: bool` so partners see jumps. Confirm there is
-  budget in `remote-bike-state.js` payload before adding.
-* Sync gates only resolve when *both* of the local tandem's riders are
-  in phase — they do **not** require cross-bike sync.
-* In races with multiple bikes, choke points organically gate overtakes
-  (intentional design lever, not a bug).
+**Current model: one bike, two riders (Captain + Stoker), one per
+client, kept in sync via `network-manager.js` and `remote-bike-state.js`.**
+There is no versus / multi-bike mode today. The design below targets only
+the single-bike tandem case; see Section 11 for the multi-bike future.
+
+* All six artifacts are **deterministic given the manifest + race clock**,
+  so the artifact world is identical on Captain and Stoker clients with
+  no per-artifact network messages.
+* **Drawbridge** phase derives from `(race_time + manifest.phase) % period`
+  — race start is already synced via `network-manager.js`, so both clients
+  draw the bridge at the same position every frame.
+* **Boost, mud, airborne (ramp), sync-gate boost** all act on the single
+  shared bike. They are applied identically on both clients because:
+  - The manifest is shared.
+  - The bike's distance-along-road is already part of the synced state.
+  - The effect formula is pure (`f(bike position, artifact params, time)`).
+* The only new field added to the synced bike state is `airborne: bool`
+  (or, if payload budget is tight, derive from vertical velocity already
+  in state — confirm in Phase 3).
+* **Sync gate** explicitly evaluates Captain + Stoker pedal phase using
+  the signal already exposed by `shared-pedal-controller.js` /
+  `contribution-tracker.js`. This is the most tandem-specific artifact
+  and the most likely to feel uniquely satisfying in multiplayer.
+* **Steering / collision ownership:** Whichever client owns bike physics
+  today (Captain in current code) keeps owning collision checks for the
+  new artifacts. Stoker mirrors. No new authority model needed.
 
 ## 9. Implementation Plan
 
@@ -513,16 +540,29 @@ In order of risk:
   poly meshes on `lowEnd`.
 * **Tutorial impact**: must not break existing tutorial flow.
   Phase 1 ships empty manifests for that reason.
-* **Multiplayer payload**: adding `airborne` to remote state. Confirm
-  byte budget; if tight, derive from vertical velocity instead.
+* **Tandem-multiplayer payload**: adding `airborne` to the shared bike
+  state. Confirm byte budget in `remote-bike-state.js`; if tight, derive
+  the airborne flag on the partner client from vertical velocity that's
+  already in state instead of adding a new field.
 
 ## 11. Out of Scope (v1)
 
 * Loops, half-pipes, see-saws (Section B from brainstorm)
 * Open hub world
 * UGC custom skins / meshes
-* Cross-bike cooperative switches
 * Power-ups (Mario Kart-style items)
+* **Versus / multi-bike racing mode.** Today's multiplayer is one bike
+  shared by Captain + Stoker; a versus mode would be a separate
+  initiative. If/when it's introduced, the artifacts here mostly carry
+  over with two additions worth noting now so we don't paint into a
+  corner:
+  - **Choke point** becomes an organic overtake-pressure mechanic
+    (a feature, not a problem) — already wide enough by spec for two
+    bikes if the builder picks `gap >= 3.5`.
+  - **Boost / mud / ramp** would need per-bike effect application, which
+    today is "the bike" rather than "this bike vs that bike." The
+    `ArtifactManager` should keep the effect-apply call site narrow so a
+    future refactor can swap "the bike" for a bike list.
 
 These remain in the design backlog and should be re-evaluated after the
 six-artifact set ships.

--- a/js/artifacts/artifact-base.js
+++ b/js/artifacts/artifact-base.js
@@ -1,0 +1,69 @@
+// ============================================================
+// ARTIFACT BASE — shared helpers for placement, visibility,
+// road-frame transforms, and AABB-on-road collision math.
+// (Pure math + DOM-free so it can be unit-tested under Node.)
+// ============================================================
+
+export const VISIBLE_AHEAD = 220;   // meters
+export const VISIBLE_BEHIND = 40;
+
+/**
+ * Compute the world-space position + heading at a point on the road,
+ * with an optional lateral offset from the centerline.
+ */
+export function roadFrame(roadPath, d, lateralOffset = 0) {
+  const pt = roadPath.getPointAtDistance(d);
+  // right vector in world-XZ (90deg clockwise from heading)
+  const rightX = Math.cos(pt.heading);
+  const rightZ = -Math.sin(pt.heading);
+  return {
+    x: pt.x + rightX * lateralOffset,
+    y: pt.y,
+    z: pt.z + rightZ * lateralOffset,
+    heading: pt.heading,
+    rightX, rightZ,
+    forwardX: Math.sin(pt.heading),
+    forwardZ: Math.cos(pt.heading)
+  };
+}
+
+/** Whether an artifact at `artifactD` is in the visibility window. */
+export function inVisibilityWindow(artifactD, bikeDistanceTraveled, loopLen) {
+  // Use loop-aware delta so artifacts placed near distance == raceDistance
+  // are still visible when the bike is "near" them on the underlying loop.
+  let delta = artifactD - bikeDistanceTraveled;
+  return delta >= -VISIBLE_BEHIND && delta <= VISIBLE_AHEAD;
+}
+
+/**
+ * Test whether a world-space bike position is inside an oriented rectangle
+ * lying flat on the road at distance `d` with width × length and lateral offset.
+ * Returns the (normalizedAlong, normalizedAcross) within the rectangle, or null.
+ */
+export function pointInRoadRect(roadPath, d, offset, width, length, bikePos) {
+  const f = roadFrame(roadPath, d, offset);
+  const dx = bikePos.x - f.x;
+  const dz = bikePos.z - f.z;
+  // Project onto road-aligned axes
+  const along = dx * f.forwardX + dz * f.forwardZ;   // meters along road
+  const across = dx * f.rightX + dz * f.rightZ;      // meters perpendicular
+  const halfW = width / 2;
+  const halfL = length / 2;
+  if (along < -halfL || along > halfL) return null;
+  if (across < -halfW || across > halfW) return null;
+  return { along, across, alongNorm: (along + halfL) / length, acrossNorm: (across + halfW) / width };
+}
+
+/** Cheap circle-vs-circle collision in XZ plane. */
+export function circleHit(x1, z1, r1, x2, z2, r2) {
+  const dx = x1 - x2;
+  const dz = z1 - z2;
+  const r = r1 + r2;
+  return dx * dx + dz * dz < r * r;
+}
+
+/** Make the mesh face the camera's yaw without copying full quaternion. */
+export function billboardYaw(mesh, camera) {
+  if (!camera) return;
+  mesh.quaternion.copy(camera.quaternion);
+}

--- a/js/artifacts/artifact-manager.js
+++ b/js/artifacts/artifact-manager.js
@@ -95,7 +95,7 @@ export class ArtifactManager {
       if (type === 'choke') {
         const result = inst.checkCollision(bikePos);
         if (result === 'crash') return 'choke_point';
-        if (result === 'scrape') inst.applyScrape(bike, dt);
+        if (result === 'scrape') inst.applyScrape(bike, bikePos, dt);
       } else if (type === 'drawbridge') {
         if (inst.checkCollision(bikePos)) return 'drawbridge';
       }

--- a/js/artifacts/artifact-manager.js
+++ b/js/artifacts/artifact-manager.js
@@ -103,6 +103,17 @@ export class ArtifactManager {
     return null;
   }
 
+  /** Reset every artifact's per-pass state when the bike is sent back to a
+   *  checkpoint or restarted from game-over. Without this, ramps and sync
+   *  gates remember they already fired on this race and refuse to re-engage. */
+  reset(bike) {
+    for (const { inst } of this._artifacts) {
+      if (typeof inst.reset === 'function') {
+        try { inst.reset(bike); } catch (err) { console.warn('[ArtifactManager] reset failed:', err); }
+      }
+    }
+  }
+
   destroy() {
     for (const { inst } of this._artifacts) {
       try { inst.destroy(); } catch {}

--- a/js/artifacts/artifact-manager.js
+++ b/js/artifacts/artifact-manager.js
@@ -1,0 +1,113 @@
+// ============================================================
+// ARTIFACT MANAGER — owns all artifact instances for a race.
+// Dispatches per-frame update() and one checkCollision() pass.
+// ============================================================
+
+import { BoostPad } from './boost-pad.js';
+import { MudPatch } from './mud-patch.js';
+import { ChokePoint } from './choke-point.js';
+import { Drawbridge } from './drawbridge.js';
+import { Ramp } from './ramp.js';
+import { SyncGate } from './sync-gate.js';
+import { loadManifest, emptyManifest, validateManifest } from './track-manifest.js';
+
+const TYPE_CTORS = {
+  boost:      BoostPad,
+  mud:        MudPatch,
+  choke:      ChokePoint,
+  drawbridge: Drawbridge,
+  ramp:       Ramp,
+  sync:       SyncGate
+};
+
+export class ArtifactManager {
+  constructor(scene, roadPath, level, camera) {
+    this.scene = scene;
+    this.roadPath = roadPath;
+    this.level = level;
+    this.camera = camera;
+    this._artifacts = [];
+    this._raceStartTime = 0;
+    this._ready = false;
+  }
+
+  /** Load + spawn artifacts for this level. Returns a promise. */
+  async load() {
+    const manifest = await this._loadManifest();
+    if (!manifest || !Array.isArray(manifest.artifacts)) {
+      this._ready = true;
+      return;
+    }
+    for (const art of manifest.artifacts) {
+      const Ctor = TYPE_CTORS[art.type];
+      if (!Ctor) {
+        console.warn(`[ArtifactManager] unknown artifact type: ${art.type}`);
+        continue;
+      }
+      try {
+        const inst = new Ctor(this.scene, this.roadPath, art);
+        if (inst.setRaceStart) inst.setRaceStart(this._raceStartTime);
+        this._artifacts.push({ type: art.type, inst });
+      } catch (err) {
+        console.warn(`[ArtifactManager] failed to spawn ${art.type}:`, err);
+      }
+    }
+    this._ready = true;
+  }
+
+  async _loadManifest() {
+    if (!this.level.track) return emptyManifest(this.level.id);
+    try {
+      const checkpoints = [];
+      for (let d = this.level.checkpointInterval; d < this.level.distance; d += this.level.checkpointInterval) {
+        checkpoints.push(d);
+      }
+      return await loadManifest(this.level.track, this.level.distance, checkpoints);
+    } catch (err) {
+      console.warn(`[ArtifactManager] failed to load track manifest:`, err);
+      return emptyManifest(this.level.id);
+    }
+  }
+
+  /** Tell time-based artifacts when the race started (epoch in performance.now()/1000). */
+  setRaceStart(t) {
+    this._raceStartTime = t;
+    for (const { inst } of this._artifacts) {
+      if (inst.setRaceStart) inst.setRaceStart(t);
+    }
+  }
+
+  update(dt, bikeDistanceTraveled, bikePos, bike, sharedPedal) {
+    if (!this._ready) return;
+    for (const { inst } of this._artifacts) {
+      inst.update(dt, bikeDistanceTraveled, bikePos, bike, sharedPedal);
+    }
+  }
+
+  /**
+   * Returns the first artifact-collision cause ('choke_point' | 'drawbridge'),
+   * or null. Handles 'scrape' mode on choke points by applying drag rather
+   * than returning a crash.
+   */
+  checkCollision(bikePos, bike, dt) {
+    if (!this._ready) return null;
+    for (const { type, inst } of this._artifacts) {
+      if (type === 'choke') {
+        const result = inst.checkCollision(bikePos);
+        if (result === 'crash') return 'choke_point';
+        if (result === 'scrape') inst.applyScrape(bike, dt);
+      } else if (type === 'drawbridge') {
+        if (inst.checkCollision(bikePos)) return 'drawbridge';
+      }
+    }
+    return null;
+  }
+
+  destroy() {
+    for (const { inst } of this._artifacts) {
+      try { inst.destroy(); } catch {}
+    }
+    this._artifacts = [];
+    this._ready = false;
+  }
+}

--- a/js/artifacts/boost-pad.js
+++ b/js/artifacts/boost-pad.js
@@ -102,6 +102,12 @@ export class BoostPad {
     }
   }
 
+  /** Called by ArtifactManager on a checkpoint/game-over reset. */
+  reset() {
+    this._inside = false;
+    this._boostRemaining = 0;
+  }
+
   destroy() {
     this.scene.remove(this.mesh);
     this.mesh.geometry.dispose();

--- a/js/artifacts/boost-pad.js
+++ b/js/artifacts/boost-pad.js
@@ -1,0 +1,111 @@
+// ============================================================
+// BOOST PAD — flat decal on the road; speed bonus while crossing,
+// decaying boost for `decay` seconds after exit.
+// ============================================================
+
+import * as THREE from 'three';
+import { roadFrame, inVisibilityWindow, pointInRoadRect, VISIBLE_BEHIND } from './artifact-base.js';
+
+function makeChevronTexture() {
+  const c = document.createElement('canvas');
+  c.width = 64; c.height = 128;
+  const g = c.getContext('2d');
+  g.fillStyle = '#1a1a1a';
+  g.fillRect(0, 0, 64, 128);
+  // Forward-pointing chevrons
+  g.fillStyle = '#ffd33d';
+  for (let y = 0; y < 128; y += 32) {
+    g.beginPath();
+    g.moveTo(0, y + 8);
+    g.lineTo(32, y);
+    g.lineTo(64, y + 8);
+    g.lineTo(64, y + 20);
+    g.lineTo(32, y + 12);
+    g.lineTo(0, y + 20);
+    g.closePath();
+    g.fill();
+  }
+  const tex = new THREE.CanvasTexture(c);
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  return tex;
+}
+
+let sharedTexture = null;
+
+export class BoostPad {
+  constructor(scene, roadPath, params) {
+    this.scene = scene;
+    this.roadPath = roadPath;
+    this.p = params;
+
+    if (!sharedTexture) sharedTexture = makeChevronTexture();
+    const tex = sharedTexture.clone();
+    tex.needsUpdate = true;
+    tex.repeat.set(1, Math.max(1, params.length / 1.5));
+
+    const geo = new THREE.PlaneGeometry(params.width, params.length);
+    const mat = new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      opacity: 0.92,
+      depthWrite: false
+    });
+    this.mesh = new THREE.Mesh(geo, mat);
+    this.mesh.rotation.x = -Math.PI / 2;
+    this.mesh.renderOrder = 1;
+    this.mesh.visible = false;
+    scene.add(this.mesh);
+
+    this._tex = tex;
+    this._scrollOffset = 0;
+
+    // Per-bike runtime state
+    this._inside = false;
+    this._boostRemaining = 0;
+  }
+
+  update(dt, bikeDistanceTraveled, bikePos, bike) {
+    const visible = inVisibilityWindow(this.p.d, bikeDistanceTraveled);
+    this.mesh.visible = visible;
+    if (visible) {
+      const f = roadFrame(this.roadPath, this.p.d, this.p.offset || 0);
+      this.mesh.position.set(f.x, f.y + 0.03, f.z);
+      this.mesh.rotation.set(-Math.PI / 2, 0, -f.heading);
+      // Scroll chevrons toward the bike to suggest forward push
+      this._scrollOffset = (this._scrollOffset + dt * 0.6) % 1;
+      this._tex.offset.y = -this._scrollOffset;
+    }
+
+    if (bike.fallen) return;
+
+    // Test bike inside the pad
+    const r = pointInRoadRect(this.roadPath, this.p.d, this.p.offset || 0, this.p.width, this.p.length, bikePos);
+    if (r) {
+      if (!this._inside) {
+        this._inside = true;
+        this._boostRemaining = this.p.decay;
+      }
+      // Apply peak boost while crossing
+      const peakBonus = (this.p.strength - 1) * 6.0; // tuned: 0.35x strength gives ~2.1 m/s of bonus over the pad
+      bike.speed = Math.min(bike.maxSpeed, bike.speed + peakBonus * dt);
+    } else if (this._inside) {
+      this._inside = false;
+      // _boostRemaining was set at entry; leave it ticking down via update path
+    }
+
+    // Decaying after-glow once we've left the pad
+    if (!this._inside && this._boostRemaining > 0) {
+      const decayBonus = (this.p.strength - 1) * 3.0 * (this._boostRemaining / this.p.decay);
+      bike.speed = Math.min(bike.maxSpeed, bike.speed + decayBonus * dt);
+      this._boostRemaining -= dt;
+    }
+  }
+
+  destroy() {
+    this.scene.remove(this.mesh);
+    this.mesh.geometry.dispose();
+    this.mesh.material.dispose();
+    this._tex.dispose();
+  }
+}

--- a/js/artifacts/choke-point.js
+++ b/js/artifacts/choke-point.js
@@ -1,0 +1,108 @@
+// ============================================================
+// CHOKE POINT — two opposing scenery blocks bordering a `gap` lane.
+// Crash on contact (or scrape = slow, if mode==='scrape').
+// ============================================================
+
+import * as THREE from 'three';
+import { roadFrame, inVisibilityWindow, pointInRoadRect, circleHit } from './artifact-base.js';
+
+const BIKE_RADIUS = 0.45;
+
+function makeSideMesh(skin, width, depth) {
+  // Both sides are a stack of 2 boxes for "haystack" look, or a single box for "barrier".
+  const grp = new THREE.Group();
+  if (skin === 'barrier') {
+    const geo = new THREE.BoxGeometry(width, 0.9, depth);
+    const mat = new THREE.MeshLambertMaterial({ color: 0xc0392b });
+    const m = new THREE.Mesh(geo, mat);
+    m.position.y = 0.45;
+    grp.add(m);
+    // White stripes
+    const stripeGeo = new THREE.BoxGeometry(width * 1.02, 0.18, depth * 1.02);
+    const stripeMat = new THREE.MeshLambertMaterial({ color: 0xffffff });
+    const s = new THREE.Mesh(stripeGeo, stripeMat);
+    s.position.y = 0.6;
+    grp.add(s);
+  } else if (skin === 'statue') {
+    const geo = new THREE.BoxGeometry(width, 1.6, depth);
+    const mat = new THREE.MeshLambertMaterial({ color: 0x8d8d8d });
+    const m = new THREE.Mesh(geo, mat);
+    m.position.y = 0.8;
+    grp.add(m);
+  } else {
+    // haystack (default): two stacked cylinders, golden
+    const matH = new THREE.MeshLambertMaterial({ color: 0xc9a23a });
+    const lower = new THREE.Mesh(new THREE.CylinderGeometry(width * 0.55, width * 0.55, 0.6, 12), matH);
+    lower.position.y = 0.3;
+    grp.add(lower);
+    const upper = new THREE.Mesh(new THREE.CylinderGeometry(width * 0.45, width * 0.45, 0.5, 12), matH);
+    upper.position.y = 0.85;
+    grp.add(upper);
+  }
+  return grp;
+}
+
+export class ChokePoint {
+  constructor(scene, roadPath, params) {
+    this.scene = scene;
+    this.roadPath = roadPath;
+    this.p = params;
+
+    const ROAD_HW = 2.5;
+    const halfGap = params.gap / 2;
+    const sideInnerEdge = (params.offset || 0); // center of gap
+    // Each side block fills from inner edge to road edge
+    this._sideAWidth = Math.max(0.4, (ROAD_HW + (sideInnerEdge - halfGap)));
+    this._sideBWidth = Math.max(0.4, (ROAD_HW - (sideInnerEdge + halfGap)));
+    this._sideAOffset = (sideInnerEdge - halfGap) - this._sideAWidth / 2;
+    this._sideBOffset = (sideInnerEdge + halfGap) + this._sideBWidth / 2;
+
+    this.groupA = makeSideMesh(params.skin, this._sideAWidth, params.depth);
+    this.groupB = makeSideMesh(params.skin, this._sideBWidth, params.depth);
+    this.groupA.visible = false;
+    this.groupB.visible = false;
+    scene.add(this.groupA);
+    scene.add(this.groupB);
+
+    // Track per-crossing so the same artifact doesn't re-trigger every frame
+    this._lastTriggerFrame = -1;
+  }
+
+  update(dt, bikeDistanceTraveled, bikePos) {
+    const visible = inVisibilityWindow(this.p.d, bikeDistanceTraveled);
+    this.groupA.visible = visible;
+    this.groupB.visible = visible;
+    if (!visible) return;
+    const fA = roadFrame(this.roadPath, this.p.d, this._sideAOffset);
+    const fB = roadFrame(this.roadPath, this.p.d, this._sideBOffset);
+    this.groupA.position.set(fA.x, fA.y, fA.z);
+    this.groupA.rotation.y = fA.heading;
+    this.groupB.position.set(fB.x, fB.y, fB.z);
+    this.groupB.rotation.y = fB.heading;
+  }
+
+  /** Returns 'crash' | 'scrape' | null when bike enters a side block. */
+  checkCollision(bikePos) {
+    const hitA = pointInRoadRect(this.roadPath, this.p.d, this._sideAOffset,
+                                 this._sideAWidth + BIKE_RADIUS * 2, this.p.depth + BIKE_RADIUS * 2, bikePos);
+    const hitB = pointInRoadRect(this.roadPath, this.p.d, this._sideBOffset,
+                                 this._sideBWidth + BIKE_RADIUS * 2, this.p.depth + BIKE_RADIUS * 2, bikePos);
+    if (!hitA && !hitB) return null;
+    return this.p.mode === 'scrape' ? 'scrape' : 'crash';
+  }
+
+  /** Called by manager if mode==='scrape' and bike is intersecting. */
+  applyScrape(bike, dt) {
+    bike.speed *= Math.max(0, 1 - 3.0 * dt);
+  }
+
+  destroy() {
+    for (const grp of [this.groupA, this.groupB]) {
+      this.scene.remove(grp);
+      grp.traverse(o => {
+        if (o.geometry) o.geometry.dispose();
+        if (o.material) o.material.dispose();
+      });
+    }
+  }
+}

--- a/js/artifacts/choke-point.js
+++ b/js/artifacts/choke-point.js
@@ -91,9 +91,42 @@ export class ChokePoint {
     return this.p.mode === 'scrape' ? 'scrape' : 'crash';
   }
 
-  /** Called by manager if mode==='scrape' and bike is intersecting. */
-  applyScrape(bike, dt) {
-    bike.speed *= Math.max(0, 1 - 3.0 * dt);
+  /**
+   * Called by manager if mode==='scrape' and bike is intersecting.
+   * Hard-wall pushback: clamps the bike laterally so it can't penetrate the
+   * side block, then drags speed so scraping costs real momentum.
+   */
+  applyScrape(bike, bikePos, dt) {
+    const halfGap = this.p.gap / 2;
+    const sideInner = (this.p.offset || 0);
+    const innerA = sideInner - halfGap; // right edge of left block (faces gap)
+    const innerB = sideInner + halfGap; // left edge of right block (faces gap)
+
+    const f = roadFrame(this.roadPath, this.p.d, 0);
+    const dx = bikePos.x - f.x;
+    const dz = bikePos.z - f.z;
+    const lat = dx * f.rightX + dz * f.rightZ;
+    const along = dx * f.forwardX + dz * f.forwardZ;
+
+    // Only push laterally if we're actually within the block's depth window
+    if (Math.abs(along) <= this.p.depth / 2 + BIKE_RADIUS) {
+      const EPS = 0.05; // small buffer so the bike pops out of the inflated rect
+      let push = 0;
+      if (lat - BIKE_RADIUS < innerA) {
+        push = (innerA + BIKE_RADIUS + EPS) - lat;     // push toward +lat (right)
+      } else if (lat + BIKE_RADIUS > innerB) {
+        push = (innerB - BIKE_RADIUS - EPS) - lat;     // push toward -lat (left)
+      }
+      if (push !== 0) {
+        bike.position.x += push * f.rightX;
+        bike.position.z += push * f.rightZ;
+        // Dampen the lean that drove the bike into the wall, so it doesn't
+        // instantly squish back in next frame.
+        bike.leanVelocity *= 0.4;
+      }
+    }
+    // Strong drag while scraping
+    bike.speed *= Math.max(0, 1 - 5.0 * dt);
   }
 
   destroy() {

--- a/js/artifacts/drawbridge.js
+++ b/js/artifacts/drawbridge.js
@@ -1,0 +1,149 @@
+// ============================================================
+// DRAWBRIDGE — two hinged planks that lift/lower on a fixed cycle.
+// State is derived from race-clock time (race.startTime), so both
+// Captain and Stoker clients render the same state with no sync.
+// ============================================================
+
+import * as THREE from 'three';
+import { roadFrame, inVisibilityWindow } from './artifact-base.js';
+
+const ROAD_HW = 2.5;
+const PLANK_LEN = 3.0; // each plank length
+const PLANK_THICK = 0.2;
+const BIKE_RADIUS = 0.45;
+
+function makePlank(skin) {
+  const color = skin === 'stone' ? 0x9a9a9a : 0x7b4b2a;
+  const mat = new THREE.MeshLambertMaterial({ color });
+  const geo = new THREE.BoxGeometry(ROAD_HW * 2, PLANK_THICK, PLANK_LEN);
+  return new THREE.Mesh(geo, mat);
+}
+
+export class Drawbridge {
+  constructor(scene, roadPath, params) {
+    this.scene = scene;
+    this.roadPath = roadPath;
+    this.p = params;
+
+    // Pivot groups (hinges at outer edges of the bridge gap)
+    this.pivotA = new THREE.Group();
+    this.pivotB = new THREE.Group();
+    const plankA = makePlank(params.skin);
+    plankA.position.z = -PLANK_LEN / 2;
+    this.pivotA.add(plankA);
+    const plankB = makePlank(params.skin);
+    plankB.position.z = PLANK_LEN / 2;
+    this.pivotB.add(plankB);
+
+    // Warning paint stripes on the road approach
+    const warnTex = this._makeWarnTexture();
+    const warnGeo = new THREE.PlaneGeometry(ROAD_HW * 2, PLANK_LEN);
+    const warnMat = new THREE.MeshBasicMaterial({ map: warnTex, transparent: true, opacity: 0.7, depthWrite: false });
+    this.warnMesh = new THREE.Mesh(warnGeo, warnMat);
+    this.warnMesh.rotation.x = -Math.PI / 2;
+    this.warnMesh.renderOrder = 1;
+
+    this.pivotA.visible = false;
+    this.pivotB.visible = false;
+    this.warnMesh.visible = false;
+    scene.add(this.pivotA);
+    scene.add(this.pivotB);
+    scene.add(this.warnMesh);
+
+    this._raceStartTime = 0; // set by manager before first update
+    this._warnTex = warnTex;
+  }
+
+  setRaceStart(t) { this._raceStartTime = t; }
+
+  _makeWarnTexture() {
+    const c = document.createElement('canvas');
+    c.width = 64; c.height = 64;
+    const g = c.getContext('2d');
+    g.fillStyle = '#1a1a1a';
+    g.fillRect(0, 0, 64, 64);
+    g.fillStyle = '#ffd33d';
+    for (let i = 0; i < 8; i++) {
+      g.fillRect(i * 8, 0, 4, 64);
+    }
+    return new THREE.CanvasTexture(c);
+  }
+
+  /**
+   * Bridge openness: 0 = fully down (passable), 1 = fully up (wall).
+   * Cycle is: downRatio fraction of period fully down, then equal
+   * rise / up / fall over the rest.
+   */
+  _openness(t) {
+    const period = this.p.period;
+    const phase = ((t + this.p.phase) % period + period) % period;
+    const downSec = period * this.p.downRatio;
+    const transSec = (period - downSec) / 3;
+    if (phase < downSec) return 0;
+    const after = phase - downSec;
+    if (after < transSec) return after / transSec;          // rising
+    if (after < transSec * 2) return 1;                      // fully up
+    return 1 - (after - transSec * 2) / transSec;            // falling
+  }
+
+  update(dt, bikeDistanceTraveled, bikePos) {
+    const visible = inVisibilityWindow(this.p.d, bikeDistanceTraveled);
+    this.pivotA.visible = visible;
+    this.pivotB.visible = visible;
+    this.warnMesh.visible = visible;
+    if (!visible) return;
+
+    const f = roadFrame(this.roadPath, this.p.d, 0);
+    // Position pivots at the inner edges of the bridge gap (z=±PLANK_LEN/2 in plank-local)
+    // ... but in world the hinges sit at d ± PLANK_LEN/2 along the road forward axis.
+    const pA = { x: f.x - f.forwardX * (PLANK_LEN / 2), z: f.z - f.forwardZ * (PLANK_LEN / 2) };
+    const pB = { x: f.x + f.forwardX * (PLANK_LEN / 2), z: f.z + f.forwardZ * (PLANK_LEN / 2) };
+    this.pivotA.position.set(pA.x, f.y + PLANK_THICK / 2, pA.z);
+    this.pivotB.position.set(pB.x, f.y + PLANK_THICK / 2, pB.z);
+    this.pivotA.rotation.y = f.heading;
+    this.pivotB.rotation.y = f.heading;
+    this.warnMesh.position.set(f.x, f.y + 0.02, f.z);
+    this.warnMesh.rotation.set(-Math.PI / 2, 0, -f.heading);
+
+    // Rotate planks based on openness. Hinge axis is along road's right-vector,
+    // i.e. local X after yaw — so rotate on local X.
+    const now = performance.now() / 1000;
+    const t = this._raceStartTime > 0 ? now - this._raceStartTime : now;
+    const o = this._openness(t);
+    // A lifts at its inner end (positive Z within group); rotate +X
+    // B lifts at its inner end (negative Z within group); rotate -X
+    const angle = o * (Math.PI / 2 - 0.05);
+    this.pivotA.children[0].rotation.x = -angle;
+    this.pivotB.children[0].rotation.x = angle;
+    this._currentOpenness = o;
+  }
+
+  /** Crash when the bridge is sufficiently up AND bike is in the span. */
+  checkCollision(bikePos) {
+    if (this._currentOpenness === undefined) return false;
+    if (this._currentOpenness < 0.15) return false; // safe to pass
+    // bike in span?
+    const f = roadFrame(this.roadPath, this.p.d, 0);
+    const dx = bikePos.x - f.x;
+    const dz = bikePos.z - f.z;
+    const along = dx * f.forwardX + dz * f.forwardZ;
+    if (Math.abs(along) > PLANK_LEN + BIKE_RADIUS) return false;
+    const across = dx * f.rightX + dz * f.rightZ;
+    if (Math.abs(across) > ROAD_HW + BIKE_RADIUS) return false;
+    return true;
+  }
+
+  destroy() {
+    for (const grp of [this.pivotA, this.pivotB]) {
+      this.scene.remove(grp);
+      grp.traverse(o => {
+        if (o.geometry) o.geometry.dispose();
+        if (o.material) o.material.dispose();
+      });
+    }
+    this.scene.remove(this.warnMesh);
+    this.warnMesh.geometry.dispose();
+    this.warnMesh.material.dispose();
+    this._warnTex.dispose();
+  }
+}

--- a/js/artifacts/mud-patch.js
+++ b/js/artifacts/mud-patch.js
@@ -1,0 +1,85 @@
+// ============================================================
+// MUD PATCH — slows the bike while it's on the patch.
+// ============================================================
+
+import * as THREE from 'three';
+import { roadFrame, inVisibilityWindow, pointInRoadRect } from './artifact-base.js';
+
+function makeMudTexture(skin) {
+  const c = document.createElement('canvas');
+  c.width = 128; c.height = 128;
+  const g = c.getContext('2d');
+  const base = skin === 'sand' ? [220, 190, 130]
+            : skin === 'ice'  ? [200, 230, 245]
+            : /* mud */         [85, 55, 30];
+  g.fillStyle = `rgb(${base[0]},${base[1]},${base[2]})`;
+  g.fillRect(0, 0, 128, 128);
+  // splotch noise
+  const img = g.getImageData(0, 0, 128, 128);
+  const d = img.data;
+  for (let i = 0; i < d.length; i += 4) {
+    const n = (Math.random() - 0.5) * 40;
+    d[i]     = Math.max(0, Math.min(255, d[i]     + n));
+    d[i + 1] = Math.max(0, Math.min(255, d[i + 1] + n));
+    d[i + 2] = Math.max(0, Math.min(255, d[i + 2] + n));
+  }
+  g.putImageData(img, 0, 0);
+  // dark blobs
+  for (let i = 0; i < 25; i++) {
+    g.fillStyle = `rgba(0,0,0,${0.15 + Math.random() * 0.2})`;
+    g.beginPath();
+    g.arc(Math.random() * 128, Math.random() * 128, 4 + Math.random() * 12, 0, Math.PI * 2);
+    g.fill();
+  }
+  return new THREE.CanvasTexture(c);
+}
+
+export class MudPatch {
+  constructor(scene, roadPath, params) {
+    this.scene = scene;
+    this.roadPath = roadPath;
+    this.p = params;
+
+    const tex = makeMudTexture(params.skin);
+    const geo = new THREE.PlaneGeometry(params.width, params.length);
+    const mat = new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      opacity: 0.95,
+      depthWrite: false
+    });
+    this.mesh = new THREE.Mesh(geo, mat);
+    this.mesh.rotation.x = -Math.PI / 2;
+    this.mesh.renderOrder = 1;
+    this.mesh.visible = false;
+    scene.add(this.mesh);
+    this._tex = tex;
+  }
+
+  update(dt, bikeDistanceTraveled, bikePos, bike) {
+    const visible = inVisibilityWindow(this.p.d, bikeDistanceTraveled);
+    this.mesh.visible = visible;
+    if (visible) {
+      const f = roadFrame(this.roadPath, this.p.d, this.p.offset || 0);
+      this.mesh.position.set(f.x, f.y + 0.025, f.z);
+      this.mesh.rotation.set(-Math.PI / 2, 0, -f.heading);
+    }
+
+    if (bike.fallen) return;
+
+    const r = pointInRoadRect(this.roadPath, this.p.d, this.p.offset || 0, this.p.width, this.p.length, bikePos);
+    if (r) {
+      // Multiplicative slow: friction=0.55 means speed *= 0.55 per crossing window of ~1s
+      // Apply as continuous drag: speed *= (1 - (1-friction) * dt * 4)
+      const drag = (1 - this.p.friction) * 4.0;
+      bike.speed *= Math.max(0, 1 - drag * dt);
+    }
+  }
+
+  destroy() {
+    this.scene.remove(this.mesh);
+    this.mesh.geometry.dispose();
+    this.mesh.material.dispose();
+    this._tex.dispose();
+  }
+}

--- a/js/artifacts/ramp.js
+++ b/js/artifacts/ramp.js
@@ -176,6 +176,22 @@ export class Ramp {
     }
   }
 
+  /** Called by ArtifactManager when the bike is hard-reset to a checkpoint
+   *  or game-over respawn. Clears all per-pass state and any airborne flags
+   *  on the bike so the next traversal triggers cleanly. */
+  reset(bike) {
+    this._launched = false;
+    this._onSlope = false;
+    this._airT = 0;
+    this._v0y = 0;
+    this._launchY = 0;
+    this._lastResetD = -Infinity;
+    if (bike) {
+      bike._airborne = false;
+      bike._airYOffset = 0;
+    }
+  }
+
   destroy() {
     this.scene.remove(this.group);
     this.group.traverse(o => {

--- a/js/artifacts/ramp.js
+++ b/js/artifacts/ramp.js
@@ -12,12 +12,17 @@ function makeRampMesh(skin, width, length, angle) {
   const height = Math.sin(angleRad) * length;
   const grp = new THREE.Group();
   const color = skin === 'metal' ? 0xa1a8b3 : skin === 'dirt' ? 0x8a5a2d : 0x7c4a26;
-  const mat = new THREE.MeshLambertMaterial({ color });
+  // DoubleSide everywhere so the wedge reads correctly from any camera angle.
+  // The slope's normal tilts toward -Z so the bike sees its back face during
+  // the close approach; without DoubleSide the slope visually disappears and
+  // the wedge looks "backwards".
+  const mat = new THREE.MeshLambertMaterial({ color, side: THREE.DoubleSide });
 
   // Top surface (the ramp face). Slope rises in the +Z direction so the bike,
   // moving along the road's forward axis, climbs the wedge and launches off
   // the high end. Rotation sign is `-angleRad` so the +Y edge of the plane
-  // ends up at the HIGH end (z = +halfL, y = height).
+  // ends up at the LOW end (z = -halfL, y = 0) and the -Y edge at the HIGH
+  // end (z = +halfL, y = height).
   const topGeo = new THREE.PlaneGeometry(width, length);
   const top = new THREE.Mesh(topGeo, mat);
   top.rotation.x = -Math.PI / 2 - angleRad;
@@ -36,12 +41,11 @@ function makeRampMesh(skin, width, length, angle) {
   ], 3));
   sideGeo.setIndex([0, 1, 2]);
   sideGeo.computeVertexNormals();
-  const sideMat = new THREE.MeshLambertMaterial({ color, side: THREE.DoubleSide });
-  const sideL = new THREE.Mesh(sideGeo, sideMat);
+  const sideL = new THREE.Mesh(sideGeo, mat);
   sideL.position.x = -width / 2;
   sideL.rotation.y = Math.PI / 2;
   grp.add(sideL);
-  const sideR = new THREE.Mesh(sideGeo, sideMat);
+  const sideR = new THREE.Mesh(sideGeo, mat);
   sideR.position.x = width / 2;
   sideR.rotation.y = Math.PI / 2;
   grp.add(sideR);

--- a/js/artifacts/ramp.js
+++ b/js/artifacts/ramp.js
@@ -14,21 +14,25 @@ function makeRampMesh(skin, width, length, angle) {
   const color = skin === 'metal' ? 0xa1a8b3 : skin === 'dirt' ? 0x8a5a2d : 0x7c4a26;
   const mat = new THREE.MeshLambertMaterial({ color });
 
-  // Top surface (the ramp face)
+  // Top surface (the ramp face). Slope rises in the +Z direction so the bike,
+  // moving along the road's forward axis, climbs the wedge and launches off
+  // the high end. Rotation sign is `-angleRad` so the +Y edge of the plane
+  // ends up at the HIGH end (z = +halfL, y = height).
   const topGeo = new THREE.PlaneGeometry(width, length);
   const top = new THREE.Mesh(topGeo, mat);
-  top.rotation.x = -Math.PI / 2 + angleRad;
+  top.rotation.x = -Math.PI / 2 - angleRad;
   top.position.y = height / 2;
   top.position.z = 0;
   grp.add(top);
 
-  // Two side triangles (BufferGeometry)
+  // Two side triangles (BufferGeometry). Vertical edge at +halfL (high end),
+  // horizontal base from -halfL to +halfL, hypotenuse rising as z increases.
   const sideGeo = new THREE.BufferGeometry();
   const halfL = length / 2;
   sideGeo.setAttribute('position', new THREE.Float32BufferAttribute([
-    -halfL, 0, 0,
      halfL, 0, 0,
-     halfL, height, 0
+    -halfL, 0, 0,
+    -halfL, height, 0
   ], 3));
   sideGeo.setIndex([0, 1, 2]);
   sideGeo.computeVertexNormals();
@@ -42,7 +46,8 @@ function makeRampMesh(skin, width, length, angle) {
   sideR.rotation.y = Math.PI / 2;
   grp.add(sideR);
 
-  // Back wall (the tall end of the ramp, so it doesn't look hollow)
+  // Back wall (the tall end of the ramp, so it doesn't look hollow).
+  // Sits at the high end (z = +halfL) on the bike's exit side.
   const backGeo = new THREE.PlaneGeometry(width, height);
   const back = new THREE.Mesh(backGeo, mat);
   back.position.y = height / 2;

--- a/js/artifacts/ramp.js
+++ b/js/artifacts/ramp.js
@@ -91,6 +91,19 @@ export class Ramp {
       this.group.rotation.y = f.heading;
     }
 
+    // Detect a checkpoint/respawn reset: bike distance moved backward past
+    // the last launch point. Re-arm the ramp and clear any stale airborne
+    // state on the bike so a second pass triggers cleanly.
+    if (bikeDistanceTraveled < this._lastResetD) {
+      this._lastResetD = -Infinity;
+      if (this._launched || this._onSlope) {
+        this._launched = false;
+        this._onSlope = false;
+        bike._airborne = false;
+        bike._airYOffset = 0;
+      }
+    }
+
     if (bike.fallen) {
       if (this._launched || this._onSlope) {
         this._launched = false;

--- a/js/artifacts/ramp.js
+++ b/js/artifacts/ramp.js
@@ -1,0 +1,144 @@
+// ============================================================
+// RAMP — wedge mesh on the road; sets bike._airYOffset during a
+// jump arc, plus an airborne flag.  Clean landing = small boost.
+// ============================================================
+
+import * as THREE from 'three';
+import { roadFrame, inVisibilityWindow, pointInRoadRect } from './artifact-base.js';
+
+function makeRampMesh(skin, width, length, angle) {
+  // Wedge: a quad slanted up at `angle` from the road surface.
+  const angleRad = angle * Math.PI / 180;
+  const height = Math.sin(angleRad) * length;
+  const grp = new THREE.Group();
+  const color = skin === 'metal' ? 0xa1a8b3 : skin === 'dirt' ? 0x8a5a2d : 0x7c4a26;
+  const mat = new THREE.MeshLambertMaterial({ color });
+
+  // Top surface (the ramp face)
+  const topGeo = new THREE.PlaneGeometry(width, length);
+  const top = new THREE.Mesh(topGeo, mat);
+  top.rotation.x = -Math.PI / 2 + angleRad;
+  top.position.y = height / 2;
+  top.position.z = 0;
+  grp.add(top);
+
+  // Two side triangles (BufferGeometry)
+  const sideGeo = new THREE.BufferGeometry();
+  const halfL = length / 2;
+  sideGeo.setAttribute('position', new THREE.Float32BufferAttribute([
+    -halfL, 0, 0,
+     halfL, 0, 0,
+     halfL, height, 0
+  ], 3));
+  sideGeo.setIndex([0, 1, 2]);
+  sideGeo.computeVertexNormals();
+  const sideMat = new THREE.MeshLambertMaterial({ color, side: THREE.DoubleSide });
+  const sideL = new THREE.Mesh(sideGeo, sideMat);
+  sideL.position.x = -width / 2;
+  sideL.rotation.y = Math.PI / 2;
+  grp.add(sideL);
+  const sideR = new THREE.Mesh(sideGeo, sideMat);
+  sideR.position.x = width / 2;
+  sideR.rotation.y = Math.PI / 2;
+  grp.add(sideR);
+
+  // Back wall (the tall end of the ramp, so it doesn't look hollow)
+  const backGeo = new THREE.PlaneGeometry(width, height);
+  const back = new THREE.Mesh(backGeo, mat);
+  back.position.y = height / 2;
+  back.position.z = halfL;
+  grp.add(back);
+
+  grp.userData.height = height;
+  return grp;
+}
+
+export class Ramp {
+  constructor(scene, roadPath, params) {
+    this.scene = scene;
+    this.roadPath = roadPath;
+    this.p = params;
+    this.group = makeRampMesh(params.skin, params.width, params.length, params.angle);
+    this.group.visible = false;
+    scene.add(this.group);
+    this._height = this.group.userData.height;
+
+    this._airT = 0;       // seconds since launch
+    this._airDur = 0;     // total airtime
+    this._airSpeed0 = 0;  // launch speed
+    this._launched = false;
+    this._lastResetD = -Infinity;
+  }
+
+  update(dt, bikeDistanceTraveled, bikePos, bike) {
+    const visible = inVisibilityWindow(this.p.d, bikeDistanceTraveled);
+    this.group.visible = visible;
+    if (visible) {
+      const f = roadFrame(this.roadPath, this.p.d, this.p.offset || 0);
+      this.group.position.set(f.x, f.y, f.z);
+      this.group.rotation.y = f.heading;
+    }
+
+    if (bike.fallen) {
+      // If the bike fell mid-jump, end the airborne state cleanly.
+      if (this._launched) {
+        this._launched = false;
+        bike._airborne = false;
+        bike._airYOffset = 0;
+      }
+      return;
+    }
+
+    // Allow re-trigger only after the bike has progressed past + lap-distance gap.
+    // Detect crossing of the ramp footprint center (entering from behind).
+    const r = pointInRoadRect(this.roadPath, this.p.d, this.p.offset || 0, this.p.width, this.p.length, bikePos);
+    if (r && !this._launched && bikeDistanceTraveled > this._lastResetD + 50) {
+      // Launch when bike center crosses the front half of the ramp
+      if (r.alongNorm > 0.6) {
+        this._launched = true;
+        this._airT = 0;
+        this._airSpeed0 = bike.speed;
+        // Airtime scales with speed × ramp angle. Clamp to params hint and ground truth.
+        const angleRad = this.p.angle * Math.PI / 180;
+        const v0y = Math.min(8, bike.speed * Math.sin(angleRad) * 1.4);
+        this._airDur = Math.max(0.2, Math.min(1.5, (2 * v0y) / 9.8));
+        this._v0y = v0y;
+        bike._airborne = true;
+        bike._airYOffset = 0;
+        this._lastResetD = bikeDistanceTraveled;
+      }
+    }
+
+    // Integrate jump arc
+    if (this._launched) {
+      this._airT += dt;
+      const t = this._airT;
+      const y = this._v0y * t - 0.5 * 9.8 * t * t;
+      bike._airYOffset = Math.max(0, y);
+      // Keep speed roughly constant (no air drag); slight forward continuance
+      if (this._airT >= this._airDur) {
+        // Landing
+        const cleanLanding = Math.abs(bike._lateralOffset) < 1.5;
+        bike._airYOffset = 0;
+        bike._airborne = false;
+        this._launched = false;
+        if (cleanLanding) {
+          // Small forward boost as reward
+          bike.speed = Math.min(bike.maxSpeed, bike.speed + 1.5);
+        } else {
+          // Skid: shake the bike a bit by adding lean velocity
+          bike.leanVelocity += (Math.random() - 0.5) * 1.5;
+          bike.speed *= 0.85;
+        }
+      }
+    }
+  }
+
+  destroy() {
+    this.scene.remove(this.group);
+    this.group.traverse(o => {
+      if (o.geometry) o.geometry.dispose();
+      if (o.material) o.material.dispose();
+    });
+  }
+}

--- a/js/artifacts/ramp.js
+++ b/js/artifacts/ramp.js
@@ -75,7 +75,10 @@ export class Ramp {
     this._airT = 0;       // seconds since launch
     this._airDur = 0;     // total airtime
     this._airSpeed0 = 0;  // launch speed
+    this._v0y = 0;
+    this._launchY = 0;    // bike Y at the moment of ballistic launch
     this._launched = false;
+    this._onSlope = false;
     this._lastResetD = -Infinity;
   }
 
@@ -89,57 +92,74 @@ export class Ramp {
     }
 
     if (bike.fallen) {
-      // If the bike fell mid-jump, end the airborne state cleanly.
-      if (this._launched) {
+      if (this._launched || this._onSlope) {
         this._launched = false;
+        this._onSlope = false;
         bike._airborne = false;
         bike._airYOffset = 0;
       }
       return;
     }
 
-    // Allow re-trigger only after the bike has progressed past + lap-distance gap.
-    // Detect crossing of the ramp footprint center (entering from behind).
-    const r = pointInRoadRect(this.roadPath, this.p.d, this.p.offset || 0, this.p.width, this.p.length, bikePos);
-    if (r && !this._launched && bikeDistanceTraveled > this._lastResetD + 50) {
-      // Launch when bike center crosses the front half of the ramp
-      if (r.alongNorm > 0.6) {
-        this._launched = true;
-        this._airT = 0;
-        this._airSpeed0 = bike.speed;
-        // Airtime scales with speed × ramp angle. Clamp to params hint and ground truth.
-        const angleRad = this.p.angle * Math.PI / 180;
-        const v0y = Math.min(8, bike.speed * Math.sin(angleRad) * 1.4);
-        this._airDur = Math.max(0.2, Math.min(1.5, (2 * v0y) / 9.8));
-        this._v0y = v0y;
-        bike._airborne = true;
-        bike._airYOffset = 0;
-        this._lastResetD = bikeDistanceTraveled;
-      }
-    }
-
-    // Integrate jump arc
+    // Phase B: in the air after launch — integrate ballistic arc, then land.
     if (this._launched) {
       this._airT += dt;
       const t = this._airT;
-      const y = this._v0y * t - 0.5 * 9.8 * t * t;
-      bike._airYOffset = Math.max(0, y);
-      // Keep speed roughly constant (no air drag); slight forward continuance
-      if (this._airT >= this._airDur) {
-        // Landing
+      const y = this._launchY + this._v0y * t - 0.5 * 9.8 * t * t;
+      if (y <= 0 || this._airT >= this._airDur) {
         const cleanLanding = Math.abs(bike._lateralOffset) < 1.5;
         bike._airYOffset = 0;
         bike._airborne = false;
         this._launched = false;
         if (cleanLanding) {
-          // Small forward boost as reward
-          bike.speed = Math.min(bike.maxSpeed, bike.speed + 1.5);
+          bike.speed = Math.min(bike.maxSpeed, bike.speed + 2.0);
         } else {
-          // Skid: shake the bike a bit by adding lean velocity
           bike.leanVelocity += (Math.random() - 0.5) * 1.5;
           bike.speed *= 0.85;
         }
+      } else {
+        bike._airYOffset = y;
       }
+      return;
+    }
+
+    // Phase A: bike is rolling across the wedge footprint. Lift the bike's
+    // Y-offset linearly with progress so it visibly climbs the slope, then
+    // launch off the top with the slope's apex as the starting altitude.
+    const r = pointInRoadRect(this.roadPath, this.p.d, this.p.offset || 0, this.p.width, this.p.length, bikePos);
+    const canEngage = bikeDistanceTraveled > this._lastResetD + 50;
+
+    if (r && canEngage) {
+      const slopeY = r.alongNorm * this._height;
+      bike._airYOffset = slopeY;
+      this._onSlope = true;
+
+      // Launch near the top of the slope.
+      if (r.alongNorm > 0.85) {
+        const angleRad = this.p.angle * Math.PI / 180;
+        const v0y = Math.min(8, bike.speed * Math.sin(angleRad) * 1.8 + 1.5);
+        const g = 9.8;
+        const launchY = slopeY;
+        // Time until y returns to 0 (ground): solve launchY + v0y*t - 0.5*g*t² = 0.
+        const airDur = Math.min(2.0, (v0y + Math.sqrt(v0y * v0y + 2 * g * launchY)) / g);
+
+        this._launched = true;
+        this._onSlope = false;
+        this._airT = 0;
+        this._airSpeed0 = bike.speed;
+        this._v0y = v0y;
+        this._launchY = launchY;
+        this._airDur = airDur;
+        bike._airborne = true;
+        // Forward kick — the ramp throws you forward as well as up.
+        bike.speed = Math.min(bike.maxSpeed, bike.speed + 1.5);
+        this._lastResetD = bikeDistanceTraveled;
+      }
+    } else if (this._onSlope) {
+      // Left the footprint without launching (stopped on the ramp, fell off
+      // the side, etc.) — drop back to road level.
+      this._onSlope = false;
+      bike._airYOffset = 0;
     }
   }
 

--- a/js/artifacts/sync-gate.js
+++ b/js/artifacts/sync-gate.js
@@ -77,6 +77,15 @@ export class SyncGate {
 
     if (bike.fallen) return;
 
+    // Checkpoint/respawn reset — re-arm so a second pass can score the gate.
+    if (bikeDistanceTraveled < this._lastResetD) {
+      this._lastResetD = -Infinity;
+      this._resolved = false;
+      this._minSyncWhileInside = 1.0;
+      this._inside = false;
+      this._rewardRemaining = 0;
+    }
+
     const r = pointInRoadRect(this.roadPath, this.p.d, 0, 5.0, 1.2, bikePos);
 
     // Re-arm only after the bike has moved on

--- a/js/artifacts/sync-gate.js
+++ b/js/artifacts/sync-gate.js
@@ -118,6 +118,15 @@ export class SyncGate {
     }
   }
 
+  /** Called by ArtifactManager on a checkpoint/game-over reset. */
+  reset() {
+    this._inside = false;
+    this._resolved = false;
+    this._minSyncWhileInside = 1.0;
+    this._rewardRemaining = 0;
+    this._lastResetD = -Infinity;
+  }
+
   destroy() {
     this.scene.remove(this.group);
     this.group.traverse(o => {

--- a/js/artifacts/sync-gate.js
+++ b/js/artifacts/sync-gate.js
@@ -31,10 +31,11 @@ export class SyncGate {
     right.position.set(2.4, POLE_HEIGHT / 2, 0);
     this.group.add(right);
 
-    // Arch: a torus segment (half-circle) connecting the two pole tops
+    // Arch: a torus segment (half-circle) connecting the two pole tops.
+    // Half-torus is built in the XY plane spanning x = ±radius through y = +radius,
+    // which lines up directly with the poles at x = ±2.4 — no extra rotation needed.
     const archGeo = new THREE.TorusGeometry(2.4, ARCH_RADIUS, 8, 24, Math.PI);
     this.archMesh = new THREE.Mesh(archGeo, archMat);
-    this.archMesh.rotation.y = Math.PI / 2;
     this.archMesh.position.set(0, POLE_HEIGHT, 0);
     this.group.add(this.archMesh);
 

--- a/js/artifacts/sync-gate.js
+++ b/js/artifacts/sync-gate.js
@@ -1,0 +1,118 @@
+// ============================================================
+// SYNC GATE — two poles + arch.  Rewards in-phase pedaling between
+// Captain and Stoker (uses sharedPedal.offsetScore) when the bike
+// crosses.  Pulses green when synced, red when off.
+// ============================================================
+
+import * as THREE from 'three';
+import { roadFrame, inVisibilityWindow, pointInRoadRect } from './artifact-base.js';
+
+const POLE_HEIGHT = 3.0;
+const POLE_RADIUS = 0.08;
+const ARCH_RADIUS = 0.18;
+
+export class SyncGate {
+  constructor(scene, roadPath, params) {
+    this.scene = scene;
+    this.roadPath = roadPath;
+    this.p = params;
+
+    this.group = new THREE.Group();
+
+    const archMat = new THREE.MeshBasicMaterial({ color: 0xff5050 });
+    const poleMat = new THREE.MeshLambertMaterial({ color: 0x444444 });
+    const poleGeo = new THREE.CylinderGeometry(POLE_RADIUS, POLE_RADIUS, POLE_HEIGHT, 8);
+
+    const left = new THREE.Mesh(poleGeo, poleMat);
+    left.position.set(-2.4, POLE_HEIGHT / 2, 0);
+    this.group.add(left);
+
+    const right = new THREE.Mesh(poleGeo, poleMat);
+    right.position.set(2.4, POLE_HEIGHT / 2, 0);
+    this.group.add(right);
+
+    // Arch: a torus segment (half-circle) connecting the two pole tops
+    const archGeo = new THREE.TorusGeometry(2.4, ARCH_RADIUS, 8, 24, Math.PI);
+    this.archMesh = new THREE.Mesh(archGeo, archMat);
+    this.archMesh.rotation.y = Math.PI / 2;
+    this.archMesh.position.set(0, POLE_HEIGHT, 0);
+    this.group.add(this.archMesh);
+
+    // Banner across the top
+    const bannerGeo = new THREE.PlaneGeometry(4.0, 0.3);
+    this.bannerMat = new THREE.MeshBasicMaterial({ color: 0xff5050, transparent: true, opacity: 0.8 });
+    this.bannerMesh = new THREE.Mesh(bannerGeo, this.bannerMat);
+    this.bannerMesh.position.set(0, POLE_HEIGHT - 0.5, 0);
+    this.group.add(this.bannerMesh);
+
+    this.group.visible = false;
+    scene.add(this.group);
+
+    this._inside = false;
+    this._minSyncWhileInside = 1.0;   // tracks worst (lowest) offsetScore mid-crossing
+    this._resolved = false;
+    this._lastResetD = -Infinity;
+    this._rewardRemaining = 0;
+  }
+
+  /**
+   * @param {object} sharedPedal — must expose `offsetScore` (0–1).  May be null in solo
+   *                              (we then read a synthetic phase via bike.pedalPower).
+   */
+  update(dt, bikeDistanceTraveled, bikePos, bike, sharedPedal) {
+    const visible = inVisibilityWindow(this.p.d, bikeDistanceTraveled);
+    this.group.visible = visible;
+    if (visible) {
+      const f = roadFrame(this.roadPath, this.p.d, 0);
+      this.group.position.set(f.x, f.y, f.z);
+      this.group.rotation.y = f.heading;
+
+      // Live sync indicator color — green when synced, red when off
+      const liveSync = sharedPedal ? sharedPedal.offsetScore : 0.7;
+      const c = new THREE.Color().setHSL(liveSync * 0.35, 1.0, 0.55);
+      this.archMesh.material.color.copy(c);
+      this.bannerMat.color.copy(c);
+    }
+
+    if (bike.fallen) return;
+
+    const r = pointInRoadRect(this.roadPath, this.p.d, 0, 5.0, 1.2, bikePos);
+
+    // Re-arm only after the bike has moved on
+    if (!r && this._resolved && bikeDistanceTraveled > this._lastResetD + 50) {
+      this._resolved = false;
+      this._minSyncWhileInside = 1.0;
+      this._inside = false;
+    }
+
+    if (r && !this._resolved) {
+      this._inside = true;
+      const sync = sharedPedal ? sharedPedal.offsetScore : 0.7; // solo: assume reasonable
+      if (sync < this._minSyncWhileInside) this._minSyncWhileInside = sync;
+    } else if (!r && this._inside && !this._resolved) {
+      // Just exited — score the crossing
+      this._resolved = true;
+      this._lastResetD = bikeDistanceTraveled;
+      // phaseTolerance is in degrees of pedal phase; map to offsetScore threshold.
+      // offsetScore=1 means perfectly offset; tolerance=30deg -> require >=0.6.
+      const reqScore = 1 - (this.p.phaseTolerance / 90);
+      if (this._minSyncWhileInside >= reqScore) {
+        this._rewardRemaining = this.p.rewardDuration;
+      }
+    }
+
+    if (this._rewardRemaining > 0) {
+      const bonus = (this.p.rewardStrength - 1) * 4.0 * (this._rewardRemaining / this.p.rewardDuration);
+      bike.speed = Math.min(bike.maxSpeed, bike.speed + bonus * dt);
+      this._rewardRemaining -= dt;
+    }
+  }
+
+  destroy() {
+    this.scene.remove(this.group);
+    this.group.traverse(o => {
+      if (o.geometry) o.geometry.dispose();
+      if (o.material) o.material.dispose();
+    });
+  }
+}

--- a/js/artifacts/track-manifest.js
+++ b/js/artifacts/track-manifest.js
@@ -1,0 +1,160 @@
+// ============================================================
+// TRACK MANIFEST — schema + validation for built-in and UGC tracks
+// ============================================================
+
+export const SCHEMA_VERSION = 1;
+export const MAX_ARTIFACTS = 80;
+export const CHECKPOINT_CLEARANCE = 15;   // meters from any checkpoint
+export const SAME_TYPE_MIN_SPACING = 8;   // meters between same-type artifacts
+
+// Per-type validators. Each returns { ok: boolean, errors: string[] }.
+// Validators also clamp params in-place to the UGC-safe ranges.
+const TYPE_SPECS = {
+  ramp: {
+    defaults: { offset: 0, width: 2.0, length: 3.0, angle: 18, skin: 'wood' },
+    ranges: {
+      offset: [-2.2, 2.2], width: [1.0, 3.5], length: [1.5, 6.0], angle: [5, 35]
+    }
+  },
+  boost: {
+    defaults: { offset: 0, width: 2.5, length: 4.0, strength: 1.35, decay: 0.8, skin: 'chevron' },
+    ranges: {
+      offset: [-2.2, 2.2], width: [1.5, 4.0], length: [2.0, 8.0],
+      strength: [1.1, 1.8], decay: [0.3, 2.0]
+    }
+  },
+  mud: {
+    defaults: { offset: 0, width: 1.5, length: 2.5, friction: 0.55, skin: 'mud' },
+    ranges: {
+      offset: [-2.2, 2.2], width: [1.0, 3.5], length: [1.0, 6.0],
+      friction: [0.4, 0.9]
+    }
+  },
+  drawbridge: {
+    defaults: { period: 5.0, phase: 0.0, downRatio: 0.6, skin: 'wood' },
+    ranges: {
+      period: [3.0, 12.0], phase: [0, 12.0], downRatio: [0.4, 0.8]
+    }
+  },
+  choke: {
+    defaults: { offset: 0, gap: 2.0, depth: 1.0, mode: 'crash', skin: 'haystack' },
+    ranges: { offset: [-1.5, 1.5], gap: [1.2, 3.5], depth: [0.5, 2.0] }
+  },
+  sync: {
+    defaults: { phaseTolerance: 30, rewardStrength: 1.4, rewardDuration: 1.0, skin: 'neon' },
+    ranges: {
+      phaseTolerance: [15, 60], rewardStrength: [1.1, 1.7], rewardDuration: [0.5, 2.0]
+    }
+  }
+};
+
+function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+
+function applyDefaultsAndClamp(art) {
+  const spec = TYPE_SPECS[art.type];
+  if (!spec) return { ok: false, errors: [`unknown artifact type: ${art.type}`] };
+  // Apply defaults for missing fields
+  for (const [k, v] of Object.entries(spec.defaults)) {
+    if (art[k] === undefined) art[k] = v;
+  }
+  // Clamp numeric ranges
+  for (const [k, [lo, hi]] of Object.entries(spec.ranges)) {
+    if (typeof art[k] === 'number') art[k] = clamp(art[k], lo, hi);
+  }
+  return { ok: true, errors: [] };
+}
+
+/**
+ * Validate + normalize a track manifest. Mutates the manifest in place
+ * (clamps numeric params to UGC-safe ranges, fills in defaults).
+ * @returns {{ ok: boolean, errors: string[], warnings: string[] }}
+ */
+export function validateManifest(manifest, raceDistance, checkpoints = []) {
+  const errors = [];
+  const warnings = [];
+
+  if (!manifest || typeof manifest !== 'object') {
+    return { ok: false, errors: ['manifest is not an object'], warnings };
+  }
+  if (manifest.schemaVersion !== SCHEMA_VERSION) {
+    errors.push(`schemaVersion must be ${SCHEMA_VERSION}, got ${manifest.schemaVersion}`);
+  }
+  if (!Array.isArray(manifest.artifacts)) {
+    return { ok: false, errors: ['manifest.artifacts must be an array'], warnings };
+  }
+  if (manifest.artifacts.length > MAX_ARTIFACTS) {
+    errors.push(`too many artifacts: ${manifest.artifacts.length} > ${MAX_ARTIFACTS}`);
+  }
+
+  // Per-artifact validation
+  for (const [i, art] of manifest.artifacts.entries()) {
+    if (typeof art.d !== 'number' || art.d < 0 || art.d > raceDistance - 5) {
+      errors.push(`#${i} (${art.type}): d=${art.d} must be 0..${raceDistance - 5}`);
+      continue;
+    }
+    const r = applyDefaultsAndClamp(art);
+    if (!r.ok) errors.push(`#${i}: ${r.errors.join('; ')}`);
+    // Checkpoint clearance (warning, not error — built-in manifests may bend it)
+    for (const cp of checkpoints) {
+      if (Math.abs(art.d - cp) < CHECKPOINT_CLEARANCE) {
+        warnings.push(`#${i} (${art.type}) at d=${art.d} is within ${CHECKPOINT_CLEARANCE}m of checkpoint ${cp}`);
+        break;
+      }
+    }
+  }
+
+  // Same-type spacing
+  const byType = {};
+  for (const art of manifest.artifacts) {
+    (byType[art.type] = byType[art.type] || []).push(art);
+  }
+  for (const [type, items] of Object.entries(byType)) {
+    items.sort((a, b) => a.d - b.d);
+    for (let i = 1; i < items.length; i++) {
+      const gap = items[i].d - items[i - 1].d;
+      if (gap < SAME_TYPE_MIN_SPACING) {
+        warnings.push(`two ${type} within ${SAME_TYPE_MIN_SPACING}m (d=${items[i - 1].d} and ${items[i].d})`);
+      }
+    }
+  }
+
+  // Cumulative boost budget per 100m segment
+  const boosts = manifest.artifacts.filter(a => a.type === 'boost');
+  const segCount = Math.max(1, Math.ceil(raceDistance / 100));
+  const buckets = new Array(segCount).fill(0);
+  for (const b of boosts) {
+    const idx = Math.min(segCount - 1, Math.floor(b.d / 100));
+    buckets[idx] += (b.strength - 1) * b.length;
+  }
+  const MAX_BOOST_BUDGET = 6.0;
+  for (let i = 0; i < buckets.length; i++) {
+    if (buckets[i] > MAX_BOOST_BUDGET) {
+      warnings.push(`boost budget exceeded in 100m segment ${i} (${buckets[i].toFixed(2)} > ${MAX_BOOST_BUDGET})`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Fetch + parse + validate a track manifest JSON file.
+ * Throws on validation failure (built-in tracks are expected to be valid).
+ */
+export async function loadManifest(url, raceDistance, checkpoints) {
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`track manifest ${url}: HTTP ${resp.status}`);
+  const manifest = await resp.json();
+  const { ok, errors, warnings } = validateManifest(manifest, raceDistance, checkpoints);
+  if (warnings.length) {
+    console.warn(`[track-manifest] ${url} warnings:`, warnings);
+  }
+  if (!ok) {
+    throw new Error(`track manifest ${url} invalid: ${errors.join('; ')}`);
+  }
+  return manifest;
+}
+
+/** Empty manifest fallback for levels without a track JSON. */
+export function emptyManifest(id) {
+  return { schemaVersion: SCHEMA_VERSION, id, artifacts: [] };
+}

--- a/js/bike-model.js
+++ b/js/bike-model.js
@@ -28,6 +28,10 @@ export class BikeModel {
     this._braking = false;
     this.boostTimer = 0;
 
+    // Airborne state (set by ramp artifacts in artifact-manager.js)
+    this._airborne = false;
+    this._airYOffset = 0;
+
     // Balance assist (0 = off, 0-1 = graduated assist strength)
     this._balanceAssist = 0;
 
@@ -379,7 +383,7 @@ export class BikeModel {
         const rearRightZ = -Math.sin(rearPt.heading);
         this._rearWheelOffset = rearDx * rearRightX + rearDz * rearRightZ;
 
-        this.position.y = this.roadPath.getPointAtDistance(this.roadD).y;
+        this.position.y = this.roadPath.getPointAtDistance(this.roadD).y + (this._airYOffset || 0);
       }
     }
 

--- a/js/game.js
+++ b/js/game.js
@@ -374,6 +374,7 @@ class Game {
         this.raceManager.passedCheckpoints.add(nextCp);
         this.raceManager.resetSegmentTimer(nextCp);
         this.bike.resetToDistance(nextCp);
+        if (this.artifactManager) this.artifactManager.reset(this.bike);
         if (this.ddaManager) this.ddaManager.onCheckpointPassed(nextCp);
         this._showCheckpointFlash();
       }
@@ -1435,6 +1436,10 @@ class Game {
     } else {
       this.bike.fullReset();
     }
+    // Clear per-pass artifact state (ramps, sync gates, boost pads) so they
+    // re-engage on the next traversal after a checkpoint reset or game-over
+    // restart.
+    if (this.artifactManager) this.artifactManager.reset(this.bike);
 
     // Reset segment timer for current segment on checkpoint restart
     if (this.raceManager && checkpointD > 0) {

--- a/js/game.js
+++ b/js/game.js
@@ -9,6 +9,7 @@ import { getLevelById, LEVELS } from './race-config.js';
 import { ContributionTracker } from './contribution-tracker.js';
 import { CollectibleManager } from './collectibles.js';
 import { ObstacleManager } from './obstacles.js';
+import { ArtifactManager } from './artifacts/artifact-manager.js';
 import { AchievementManager, showAchievementToast, updateBadgeDisplay } from './achievements.js';
 import { InputManager } from './input-manager.js';
 import { PedalController } from './pedal-controller.js';
@@ -682,6 +683,7 @@ class Game {
         // Stoker receives GO from captain — clear countdown flavor so "1" doesn't stick
         this.state = 'playing';
         if (this.raceManager) this.raceManager.start();
+        if (this.artifactManager) this.artifactManager.setRaceStart(performance.now() / 1000);
         const flavorNum = document.getElementById('countdown-flavor-num');
         const flavorIcon = document.getElementById('countdown-flavor-icon');
         const flavorText = document.getElementById('countdown-flavor-text');
@@ -1172,6 +1174,10 @@ class Game {
     this.collectibleManager = new CollectibleManager(this.scene, this.world.roadPath, level, this.camera, difficultyName);
     if (this.obstacleManager) this.obstacleManager.destroy();
     this.obstacleManager = new ObstacleManager(this.scene, this.world.roadPath, level, this.camera, difficultyName);
+    if (this.artifactManager) this.artifactManager.destroy();
+    this.artifactManager = new ArtifactManager(this.scene, this.world.roadPath, level, this.camera);
+    // Kick off async manifest load; safe to update before ready (it no-ops).
+    this.artifactManager.load().catch(err => console.warn('[ArtifactManager] load failed:', err));
 
     // Wire up collectibles total for analytics
     this.raceManager.setCollectiblesTotal(this.collectibleManager.getTotalItems());
@@ -1293,6 +1299,7 @@ class Game {
       }
       this._playBeep(800, 0.4);
       if (this.raceManager) this.raceManager.start();
+      if (this.artifactManager) this.artifactManager.setRaceStart(performance.now() / 1000);
 
       // Update analytics input method now that motion/gyro has had time to activate
       const steerSrc = this.balanceCtrl.getSteerSource();
@@ -3039,7 +3046,7 @@ class Game {
     }
   }
 
-  _checkTreeCollision() {
+  _checkTreeCollision(dt) {
     if (this.bike.fallen || this.bike.speed < 0.5) return;
     // Skip tree collision when level config disables it — only pylons matter
     const level = this.lobby.selectedLevel;
@@ -3051,7 +3058,9 @@ class Game {
         this.chaseCamera.shakeAmount = 0.25;
         this._playCrash(1.0);
         hapticTreeHit();
+        return;
       }
+      this._checkArtifactCollision(dt);
       return;
     }
     const result = this.world.checkTreeCollision(
@@ -3068,6 +3077,22 @@ class Game {
     // Pylon obstacle collision
     if (this.obstacleManager && this.obstacleManager.checkCollision(this.bike.position)) {
       this._recordCrash('obstacle');
+      this.bike._fall();
+      this.chaseCamera.shakeAmount = 0.25;
+      this._playCrash(1.0);
+      hapticTreeHit();
+      return;
+    }
+    this._checkArtifactCollision(dt);
+  }
+
+  _checkArtifactCollision(dt) {
+    if (!this.artifactManager) return;
+    // Skip artifact crashes while airborne (ramp jump)
+    if (this.bike._airborne) return;
+    const cause = this.artifactManager.checkCollision(this.bike.position, this.bike, dt || 0.016);
+    if (cause) {
+      this._recordCrash(cause);
       this.bike._fall();
       this.chaseCamera.shakeAmount = 0.25;
       this._playCrash(1.0);
@@ -3195,7 +3220,7 @@ class Game {
 
     const wasFallen = this.bike.fallen;
     this.bike.update(pedalResult, balanceResult, dt, this.safetyMode, this.autoSpeed);
-    this._checkTreeCollision();
+    this._checkTreeCollision(dt);
 
     this._recordBalanceCrashIfNew(wasFallen);
 
@@ -3282,7 +3307,7 @@ class Game {
 
     const wasFallen = this.bike.fallen;
     this.bike.update(pedalResult, balanceResult, dt, this.safetyMode, this.autoSpeed);
-    this._checkTreeCollision();
+    this._checkTreeCollision(dt);
 
     this._recordBalanceCrashIfNew(wasFallen);
 
@@ -3447,6 +3472,9 @@ class Game {
     }
     if (this.obstacleManager) {
       this.obstacleManager.update(dt, this.bike.distanceTraveled, this.bike.position);
+    }
+    if (this.artifactManager) {
+      this.artifactManager.update(dt, this.bike.distanceTraveled, this.bike.position, this.bike, this.sharedPedal);
     }
   }
 

--- a/js/race-config.js
+++ b/js/race-config.js
@@ -9,31 +9,34 @@ export const LEVELS = [
     distance: 225,
     collectibles: 'presents',
     checkpointInterval: 225,   // single checkpoint = entire ride
-    icon: '\uD83D\uDEB4',        // 🚴
+    icon: '🚴',        // 🚴
     description: 'Master pedaling and steering!',
     isTutorial: true,
     coaching: { dodgeArrow: true, collectIndicator: true },
     timerEnabled: false,
     treeCollision: false,
-    motionAdaptation: false
+    motionAdaptation: false,
+    track: 'assets/tracks/tutorial.json'
   },
   {
     id: 'grandma',
     name: "Grandma's",
-    distance: 250,
+    distance: 350,
     collectibles: 'presents',
-    checkpointInterval: 62,
-    icon: '\uD83C\uDFE0',        // 🏠
-    description: 'Grandma called — she needs her presents!'
+    checkpointInterval: 88,
+    icon: '🏠',        // 🏠
+    description: 'Grandma called — she needs her presents!',
+    track: 'assets/tracks/grandma.json'
   },
   {
     id: 'castle',
     name: 'The Castle',
-    distance: 500,
+    distance: 700,
     collectibles: 'gems',
-    checkpointInterval: 125,
-    icon: '\uD83C\uDFF0',        // 🏰
-    description: 'The King awaits! Collect gems on the road to glory!'
+    checkpointInterval: 175,
+    icon: '🏰',        // 🏰
+    description: 'The King awaits! Collect gems on the road to glory!',
+    track: 'assets/tracks/castle.json'
   }
 ];
 

--- a/test/track-artifacts.test.mjs
+++ b/test/track-artifacts.test.mjs
@@ -1,0 +1,125 @@
+// Node smoke test for pure-logic track-artifact pieces.
+// Run with:  node test/track-artifacts.test.mjs
+//
+// Doesn't load Three.js — only tests the manifest validator + road-frame
+// math + the JSON manifests for tutorial / grandma / castle.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+
+const { validateManifest } = await import(join(root, 'js/artifacts/track-manifest.js'));
+const { pointInRoadRect, roadFrame, inVisibilityWindow } =
+  await import(join(root, 'js/artifacts/artifact-base.js'));
+
+let pass = 0, fail = 0;
+const ok = (name, cond, extra) => {
+  if (cond) { pass++; console.log(`  PASS  ${name}`); }
+  else      { fail++; console.log(`  FAIL  ${name}`, extra || ''); }
+};
+
+// ---------- validator ----------
+console.log('# validator');
+{
+  const m = { schemaVersion: 1, artifacts: [
+    { type: 'boost', d: 50 },
+    { type: 'mud',   d: 100 },
+    { type: 'ramp',  d: 150, angle: 50 }, // angle clamped to 35
+    { type: 'choke', d: 200, gap: 0.5 },  // gap clamped to 1.2
+    { type: 'sync',  d: 250 },
+    { type: 'drawbridge', d: 300, downRatio: 0.1 } // clamped to 0.4
+  ] };
+  const r = validateManifest(m, 350, [88, 176, 264]);
+  ok('validates a manifest', r.ok, r.errors);
+  ok('ramp angle clamped',       m.artifacts[2].angle === 35);
+  ok('choke gap clamped',        m.artifacts[3].gap === 1.2);
+  ok('drawbridge downRatio clamped', m.artifacts[5].downRatio === 0.4);
+}
+{
+  const r = validateManifest({ schemaVersion: 1, artifacts: [{ type: 'unknown', d: 10 }] }, 100, []);
+  ok('rejects unknown type', !r.ok);
+}
+{
+  const r = validateManifest({ schemaVersion: 2, artifacts: [] }, 100, []);
+  ok('rejects wrong schema version', !r.ok);
+}
+{
+  const r = validateManifest({ schemaVersion: 1, artifacts: [{ type: 'boost', d: 200 }] }, 100, []);
+  ok('rejects d > distance-5', !r.ok);
+}
+{
+  const m = { schemaVersion: 1, artifacts: [{ type: 'boost', d: 80 }] };
+  const r = validateManifest(m, 100, [80]);
+  ok('warns on checkpoint clearance', r.ok && r.warnings.length > 0);
+}
+
+// ---------- road-frame math ----------
+console.log('# road-frame math');
+// Fake straight road along +Z, y=0
+const roadPath = {
+  loopLength: 1200,
+  getPointAtDistance(d) { return { x: 0, y: 0, z: d, heading: 0 }; }
+};
+{
+  const f = roadFrame(roadPath, 100, 1.5);
+  ok('straight road lateral offset', Math.abs(f.x - 1.5) < 1e-6 && Math.abs(f.z - 100) < 1e-6);
+  ok('straight road forward = +Z', Math.abs(f.forwardZ - 1) < 1e-6 && Math.abs(f.forwardX) < 1e-6);
+}
+
+// Heading = π/2 (east-pointing): forward = +X, right = -Z (since right is heading - 90deg)
+const eastRoad = {
+  loopLength: 1200,
+  getPointAtDistance(d) { return { x: d, y: 0, z: 0, heading: Math.PI / 2 }; }
+};
+{
+  const f = roadFrame(eastRoad, 50, 0);
+  ok('east road forward = +X', Math.abs(f.forwardX - 1) < 1e-6 && Math.abs(f.forwardZ) < 1e-6);
+}
+
+// ---------- pointInRoadRect ----------
+console.log('# pointInRoadRect');
+{
+  // 2x4 rect at d=100, offset 0 on straight road
+  const inside = pointInRoadRect(roadPath, 100, 0, 2, 4, { x: 0, z: 100 });
+  ok('center hit',         inside !== null);
+  const justInside = pointInRoadRect(roadPath, 100, 0, 2, 4, { x: 0.9, z: 101.9 });
+  ok('near corner hit',    justInside !== null);
+  const tooFarX = pointInRoadRect(roadPath, 100, 0, 2, 4, { x: 1.5, z: 100 });
+  ok('outside wide miss',  tooFarX === null);
+  const tooFarZ = pointInRoadRect(roadPath, 100, 0, 2, 4, { x: 0, z: 103 });
+  ok('outside long miss',  tooFarZ === null);
+  const offset = pointInRoadRect(roadPath, 100, 1.0, 2, 4, { x: 1.0, z: 100 });
+  ok('lateral offset hit', offset !== null);
+}
+
+// ---------- visibility window ----------
+console.log('# visibility window');
+{
+  ok('right ahead', inVisibilityWindow(150, 100, 1200) === true);
+  ok('just behind', inVisibilityWindow(95,  100, 1200) === true);
+  ok('too far ahead', inVisibilityWindow(400, 100, 1200) === false);
+  ok('too far behind', inVisibilityWindow(40,  100, 1200) === false);
+}
+
+// ---------- built-in manifests ----------
+console.log('# built-in manifests');
+async function loadAndCheck(file, dist, cps) {
+  const raw = await readFile(join(root, file), 'utf8');
+  const m = JSON.parse(raw);
+  const r = validateManifest(m, dist, cps);
+  ok(`${file}: valid`, r.ok, r.errors);
+  if (r.warnings.length) console.log(`         warnings:`, r.warnings);
+}
+const grandmaCps = [88, 176, 264];
+const castleCps = [175, 350, 525];
+await loadAndCheck('assets/tracks/tutorial.json', 225, [225]);
+await loadAndCheck('assets/tracks/grandma.json', 350, grandmaCps);
+await loadAndCheck('assets/tracks/castle.json',  700, castleCps);
+
+// ---------- summary ----------
+console.log('');
+console.log(`RESULT: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary

Implements all six track artifacts from [#297](https://github.com/petegordon/Tandemonium/issues/297) in a single PR so you can play the full updated Grandma's and Castle races and feel them end-to-end. Builds on the design doc in [`docs/track-artifacts-design.md`](https://github.com/petegordon/Tandemonium/blob/claude/game-progression-world-design-1IoCh/docs/track-artifacts-design.md).

The six artifacts:

| Artifact      | Verb           | What you'll feel |
|---------------|----------------|-------------------|
| Boost pad     | Accelerate     | Yellow chevron strip — speed bonus while crossing + a brief afterglow. |
| Mud patch     | Slow           | Brown splotch — drags speed down while you're on it. |
| Choke point   | Squeeze through| Paired haystacks / barriers / statues; thread the gap or crash (or "scrape" + slow on easier ones). |
| Drawbridge    | Time it        | Two planks lift/lower on a 6s cycle — hit the gap when it's down or wall yourself. |
| Ramp          | Jump           | Wooden / metal wedge launches the bike into a ballistic arc; clean landing rewards +1.5 m/s. |
| Sync gate     | Coordinate     | Arch pulses **green** when Captain+Stoker pedal phases match (`sharedPedal.offsetScore`), **red** when off. Crossing in sync = boost. (Tandem-unique.) |

## What's in this PR

### Foundation (`js/artifacts/`)
- `track-manifest.js` — JSON schema + validator with UGC-safe parameter clamps, checkpoint clearance, same-type spacing, per-100m cumulative boost budget. Used by both built-in manifests and (later) the UGC builder.
- `artifact-base.js` — pure-math helpers (road-frame transform, oriented-rectangle hit test, visibility window). DOM-free so it can be unit-tested.
- `artifact-manager.js` — owns all artifact instances for a race, single `update()` + `checkCollision()` per frame, anchors drawbridge phase to race start.
- `boost-pad.js`, `mud-patch.js`, `choke-point.js`, `drawbridge.js`, `ramp.js`, `sync-gate.js` — the six artifact types.

### Track manifests (`assets/tracks/`)
- `tutorial.json` — empty (tutorial flow unchanged).
- `grandma.json` — 5 artifacts laced through 350 m: boost → mud → ramp → sync gate → scrape-mode choke.
- `castle.json` — 11 artifacts across 700 m, including a drawbridge over the "moat" at 450 m and a 3-statue gauntlet at the end.

### Integration
- `bike-model.js` — added `_airYOffset` + `_airborne` fields; ramps add the offset on top of the road-height query.
- `game.js` — constructs `ArtifactManager` next to obstacles, calls `update()` + `checkCollision()` from the main loop and the stoker-side fallback, passes `dt` through `_checkTreeCollision`, anchors race start time for drawbridges.
- `race-config.js` — Grandma's `250→350m`, Castle `500→700m`, checkpoint intervals adjusted to clear the new artifacts, and each level gains a `track` field.

### Tests
- `test/track-artifacts.test.mjs` — 23 Node-runnable assertions covering the validator, geometry helpers, and all three built-in manifests. Runs without Three.js:
  ```sh
  node test/track-artifacts.test.mjs
  # RESULT: 23 passed, 0 failed
  ```

## What I didn't test (and why)

The remote execution environment's network policy blocks the jsdelivr CDN where Three.js is hosted, so I couldn't load the game in a headless browser here. All pure-logic pieces are unit-tested, syntax is checked, and the integration touch points match the existing obstacle/collectible pattern — but **the actual feel of each artifact in your dev environment is the real test**. That's the point of this single-PR shape.

## Things to check on your machine

1. **Grandma's race** — feels longer and more varied; 5 artifacts in 350 m.
2. **Castle race** — full 6-artifact gauntlet; pay attention to the drawbridge timing (6 s cycle, phase 1 s) and the final 3-statue choke gauntlet.
3. **Tandem multiplayer sync gate** — pedal in phase with the Stoker and watch the arch turn green before you cross; if green, you should feel a brief boost on the far side.
4. **Ramps** — wedge mesh + ~0.4–0.8 s airtime. Landing wide skids; landing centered gives +1.5 m/s.
5. **Drawbridge in multiplayer** — both clients should render the bridge in identical positions because the openness is derived from race time + manifest, not synced.
6. **Crash recovery** — a fall mid-ramp clears `_airborne` cleanly so the bike doesn't stick in mid-air.

## Tuning knobs

If anything feels too punishing or too easy, the per-artifact params live in the JSON files (`assets/tracks/*.json`) — `strength`, `decay`, `friction`, `period`, `gap`, `phaseTolerance`, etc. The validator clamps to safe ranges so you can't break the world by editing them, but within those ranges it's all yours.

## Related

- Closes (in part) #297 once shipped — phases 1–4 land together; Phase 5 (per-artifact tutorial coaching) is deferred as planned.
- Companion: #298 (Track Builder + UGC) is unblocked once this lands — the validator and JSON schema it depends on are in this PR.
- Design doc: [`docs/track-artifacts-design.md`](https://github.com/petegordon/Tandemonium/blob/claude/game-progression-world-design-1IoCh/docs/track-artifacts-design.md)

## Test plan

- [ ] `node test/track-artifacts.test.mjs` passes (23/23)
- [ ] Start a solo Grandma's race — see all 5 artifacts, no console errors
- [ ] Start a solo Castle race — see all 11 artifacts including drawbridge motion
- [ ] Hit each artifact type at least once; confirm the felt effect matches the table above
- [ ] Tandem multiplayer Grandma's — confirm the sync gate rewards in-phase pedaling and that both clients see the same drawbridge state
- [ ] Crash mid-ramp (steer wide) — confirm bike lands+falls cleanly with no airborne stickiness
- [ ] Crash into a choke (Castle d=325 or 665) — same crash flow as pylons


---
_Generated by [Claude Code](https://claude.ai/code/session_01863uwWZUKhU69hKvwCPskk)_