### PR TITLE
Vendor controller-core v0.2.0 (Steam report-id gate + reconnect recovery)

### DIFF
--- a/shared/CONTROLLER_CORE_VERSION.json
+++ b/shared/CONTROLLER_CORE_VERSION.json
@@ -1,7 +1,7 @@
 {
   "package": "@usersfirst/controller-core",
-  "version": "0.1.0",
-  "sourceCommit": "3415823",
-  "sourceRef": "core-v0.1.0",
-  "syncedAt": "2026-06-06"
+  "version": "0.2.0",
+  "sourceCommit": "71366bc",
+  "sourceRef": "core-v0.2.0",
+  "syncedAt": "2026-06-07"
 }

--- a/shared/drivers/steam-controller-driver.js
+++ b/shared/drivers/steam-controller-driver.js
@@ -34,10 +34,16 @@
 
 import { ControllerDriver } from './base-driver.js';
 
-// 53-byte STATE report on the 2026 device. SteamlessController docs
-// list other shorter report shapes (status, secondary), so gating on
-// length filters those out without us having to enumerate ids.
+// 53-byte STATE report on the 2026 device. Length alone is NOT enough to
+// identify it: the firmware emits *multiple* 53-byte report types (a real
+// at-rest Puck capture showed 0x45 ×1343 STATE plus 0x7b ×9 and 0x43 ×2
+// non-STATE, all 53 bytes). The non-STATE reports parse as garbage —
+// phantom buttons/sticks + zeroed IMU that trips the stuck-IMU self-heal.
+// So we gate on BOTH length and the STATE report id. 2026 firmware uses
+// 0x45; SteamlessController docs note 0x42 — accept both, reject the rest.
+// See issue #28.
 const STATE_REPORT_LEN = 53;
+const STATE_REPORT_IDS = new Set([0x45, 0x42]);
 
 const PUCK_PID = 0x1304;
 const LIZARD_HEARTBEAT_MS = 800;
@@ -271,13 +277,21 @@ export class SteamControllerDriver extends ControllerDriver {
   }
 
   parseReport(reportId, data) {
-    // Gate on the STATE report's length (53 bytes on the 2026 device).
-    // Other report shapes from this firmware (status @ 5 bytes, etc.)
-    // get filtered out without us having to enumerate report ids; the
-    // 0x42-vs-0x45 reportId discrepancy between SteamlessController's
-    // docs and our captures becomes moot. Log the actual id once per
-    // instance so future debugging still has the data point.
+    // Gate on length AND the STATE report id. The 2026 firmware emits
+    // several 53-byte report types; only 0x45 (and per docs 0x42) is the
+    // STATE report. Parsing the others (0x7b, 0x43, …) as STATE produced
+    // phantom button/stick input and zeroed IMU that tripped the manager's
+    // stuck-IMU self-heal — the spurious-input + gyro-dropout bug (#28).
+    // Reject anything not on the allow-list. Log accepted and rejected
+    // ids once each so future firmware variants are easy to spot.
     if (data.byteLength !== STATE_REPORT_LEN) return null;
+    if (!STATE_REPORT_IDS.has(reportId)) {
+      if (!this._loggedReportIds.has(reportId)) {
+        this._loggedReportIds.add(reportId);
+        console.log(`Steam Controller: ignoring non-STATE 53-byte report id 0x${reportId.toString(16)} (#28 guard)`);
+      }
+      return null;
+    }
     if (!this._loggedReportIds.has(reportId)) {
       this._loggedReportIds.add(reportId);
       console.log(`Steam Controller STATE report id observed: 0x${reportId.toString(16)} (${data.byteLength} bytes)`);

--- a/shared/manager.js
+++ b/shared/manager.js
@@ -20,7 +20,12 @@
 // ============================================================
 
 import { ControllerRegistry } from './drivers/controller-registry.js';
-import { SensorFusion } from './sensor-fusion.js';
+// NOTE: SensorFusion (and its `three` dependency) is loaded lazily in
+// poolDevice — the only place a real fusion is constructed — so importing
+// this module for its slot/claim/reconnect logic doesn't drag in `three`.
+// That keeps the headless manager tests dependency-free (CI runs them with
+// no `npm install`) and matches core's package.json, which doesn't declare
+// `three` directly.
 
 const DEFAULTS = {
   releaseHoldMs: 2000,
@@ -157,10 +162,10 @@ const IMU_ZERO_TIMEOUT_MS = 500;
 const MAX_IMU_REINIT = 2;
 
 class HidEntry {
-  constructor(device, driver) {
+  constructor(device, driver, fusion) {
     this.device = device;
     this.driver = driver;
-    this.fusion = new SensorFusion();
+    this.fusion = fusion;
     this.fusion.startCalibration(driver?.connectionType);
     this.synthetic = makeSyntheticGamepad(device);
     this.hasButtons = false;
@@ -507,7 +512,10 @@ export class ControllerManager {
     if (this._isDeviceInPoolOrSlot(device)) return this._hidPool.get(device) || null;
     try {
       const driver = await ControllerRegistry.connect(device);
-      const entry = new HidEntry(device, driver);
+      // Lazy-load SensorFusion (pulls in `three`) only here, where a real
+      // fusion is actually needed — see the import note at the top.
+      const { SensorFusion } = await import('./sensor-fusion.js');
+      const entry = new HidEntry(device, driver, new SensorFusion());
       this._hidPool.set(device, entry);
       return entry;
     } catch (err) {
@@ -601,6 +609,48 @@ export class ControllerManager {
     return null;
   }
 
+  /**
+   * Find an already-claimed slot that this pool entry belongs to but isn't
+   * yet bound to — matched by the slot's gamepad vid:pid OR by productName
+   * substring (covers multi-interface pads like GameSir Super Nova where
+   * the Gamepad API and WebHID report different vid:pid for one physical
+   * device). Returns the slot or null. Binding-only: never creates a slot.
+   */
+  _findClaimedUnboundSlotForEntry(entry) {
+    return this.slots.find((s) =>
+      s.state === 'claimed' && !s._hidEntry && this._entryMatchesSlot(entry, s)
+    ) || null;
+  }
+
+  /**
+   * Does this pool entry belong to `slot`'s controller? Matched by the
+   * slot's gamepad vid:pid OR by productName substring (covers multi-
+   * interface pads like GameSir Super Nova where the Gamepad API and
+   * WebHID report different vid:pid for one physical device). Works for
+   * orphaned slots too — orphan() keeps controllerLabel.
+   */
+  _entryMatchesSlot(entry, slot) {
+    const vp = ControllerRegistry.parseGamepadVendorProduct(slot.controllerLabel);
+    if (vp && vp.vendorId === entry.device.vendorId && vp.productId === entry.device.productId) return true;
+    const name = (entry.device.productName || '').trim().toLowerCase();
+    if (name && slot.controllerLabel && slot.controllerLabel.toLowerCase().includes(name)) return true;
+    return false;
+  }
+
+  /**
+   * A live Gamepad-API pad whose stable id matches `slot`'s remembered
+   * controller and that no OTHER slot already owns. Used for sticky
+   * reconnect (an orphaned slot recovering the SAME physical controller,
+   * keeping its player number).
+   */
+  _findReturningPadForSlot(slot, pads) {
+    if (!slot.controllerId) return null;
+    return pads.find((p) =>
+      p && stableIdFor(p) === slot.controllerId &&
+      !this.slots.some((o) => o !== slot && o.gamepadIndex === p.index)
+    ) || null;
+  }
+
   ingestFrame(pads, now) {
     const claimedThisFrame = [];
     const releasedThisFrame = [];
@@ -622,6 +672,52 @@ export class ControllerManager {
       const gpActive = gamepadHasActivity(gp);
       const synthActive = s._hidEntry && gamepadHasActivity(s._hidEntry.synthetic);
       if (!gpActive && !synthActive) s._awaitingSilence = false;
+    }
+
+    // ── Reconnect recovery ──
+    // An orphaned slot — its controller dropped, e.g. the GameSir Super
+    // Nova docking on its charger — is reclaimed by the SAME controller
+    // when it returns, keeping its player number. Without this, orphan was
+    // a dead end: nothing ever transitioned a slot out of it, so a re-
+    // paired controller recovered neither buttons nor gyro (#30 State 2).
+    // Two signals can bring it back; take whichever lands first and the
+    // other half wires up afterward:
+    //   (1) its Gamepad-API pad re-enumerates (match by stable id), or
+    //   (2) its WebHID handle re-pools (match by vid:pid / productName) —
+    //       restores gyro immediately; the adopt pass below re-attaches
+    //       buttons if/when the Gamepad pad returns.
+    for (const s of this.slots) {
+      if (s.state !== 'orphan') continue;
+      const gp = this._findReturningPadForSlot(s, pads);
+      if (gp) {
+        s.claim(gp, { controllerTypeHint: s.controllerType, silent: true });
+        this._attachMatchingPoolEntry(s);
+        s._emit('claimed');
+        claimedThisFrame.push(s.id);
+        console.log(`[manager] ${s.id}: reconnected — re-claimed orphan via Gamepad API`);
+        continue;
+      }
+      const entry = [...this._hidPool.values()].find((e) => this._entryMatchesSlot(e, s));
+      if (entry) {
+        const pseudo = { index: -1, id: s.controllerLabel || `HID::${entry.device.productName || ''}`, mapping: 'standard' };
+        s.claim(pseudo, { controllerTypeHint: s.controllerType, silent: true });
+        this._attachEntryToSlot(s, entry);
+        s._emit('claimed');
+        claimedThisFrame.push(s.id);
+        console.log(`[manager] ${s.id}: reconnected — re-claimed orphan via WebHID (gyro restored, awaiting Gamepad pad)`);
+      }
+    }
+
+    // Adopt a returning Gamepad pad into a slot that recovered HID-first
+    // (gamepadIndex still null) so one physical controller isn't split
+    // across two slots. effectiveGamepad picks up the buttons next frame.
+    for (const s of this.slots) {
+      if (s.state !== 'claimed' || s.gamepadIndex != null) continue;
+      const gp = this._findReturningPadForSlot(s, pads);
+      if (gp) {
+        s.gamepadIndex = gp.index;
+        console.log(`[manager] ${s.id}: adopted returning Gamepad pad (buttons restored)`);
+      }
     }
 
     // Claim via Gamepad API activity. Uses gamepadHasFreshActivity
@@ -655,6 +751,22 @@ export class ControllerManager {
       empty._emit('claimed');
     }
 
+    // Reconcile late / reconnected HID entries with already-claimed slots.
+    // _attachMatchingPoolEntry only binds at claim time, and the HID-pool
+    // claim loop below is gated on a fresh button press — so a device whose
+    // WebHID handle arrives (or RE-arrives after a reconnect) AFTER the
+    // Gamepad-API claim, and that never emits buttons (IMU-only, e.g.
+    // GameSir-as-DS4), would otherwise be left with working buttons but a
+    // dead gyro toggle after a reconnect (GameSir Super Nova auto-re-pairs
+    // off its charger, so this path gets hit constantly). Binding-only — it
+    // never creates a
+    // slot — so it's safe to run every frame regardless of button activity.
+    // Snapshot the pool values: _attachEntryToSlot mutates the pool map.
+    for (const entry of [...this._hidPool.values()]) {
+      const slot = this._findClaimedUnboundSlotForEntry(entry);
+      if (slot) this._attachEntryToSlot(slot, entry);
+    }
+
     // Claim via WebHID synthetic activity (covers BT-silent DualSense):
     // iterate the HID pool, not slots. Any pool entry showing activity
     // promotes into an empty slot.
@@ -670,15 +782,10 @@ export class ControllerManager {
       // Gamepad API path (same vid:pid), attach the HID entry to that slot
       // for gyro/touchpad rather than spawning a second slot. Fixes pads
       // that expose both Gamepad API and WebHID interfaces (e.g. GameSir
-      // Super Nova presenting as DS4 + raw HID).
-      const existing = this.slots.find((s) => {
-        if (s.state !== 'claimed' || s._hidEntry) return false;
-        const vp = ControllerRegistry.parseGamepadVendorProduct(s.controllerLabel);
-        if (vp && vp.vendorId === entry.device.vendorId && vp.productId === entry.device.productId) return true;
-        const name = (entry.device.productName || '').trim().toLowerCase();
-        if (name && s.controllerLabel && s.controllerLabel.toLowerCase().includes(name)) return true;
-        return false;
-      });
+      // Super Nova presenting as DS4 + raw HID). (The reconciliation pass
+      // above already covers IMU-only devices; this catches a device that
+      // emits buttons AND matches an already-claimed slot.)
+      const existing = this._findClaimedUnboundSlotForEntry(entry);
       if (existing) {
         this._attachEntryToSlot(existing, entry);
         continue;


### PR DESCRIPTION
Refreshes vendored `shared/` from `tandemonium-controller-lab` tag **core-v0.2.0** (drift check passes; byte-identical to the lab).

## What this brings to the in-game WebHID path
- **Steam Controller** — `parseReport` now gates on the STATE report id (`0x45`/`0x42`), not length alone. Fixes the spurious button/stick presses + gyro recalibration dropouts on the Puck (`1304`) and the occasional spurious Options press on USB-C (`1302`). (lab #28)
- **GameSir Super Nova reconnect** — full dual-path recovery in `ControllerManager`:
  - reconciliation pass binds a late/hot-plugged HID gyro entry to an already-claimed slot (fixes "thinks it has gyro but data isn't used" when the controller is picked up *after* launch);
  - sticky orphan re-claim + returning-pad adoption recover the controller after a Bluetooth dock/undock (the Super Nova auto-re-pairs off its charger). (lab #30)
- `SensorFusion` is loaded lazily in `poolDevice` — `three` still resolves via the importmap/CDN on web and locally in Electron; runtime behavior unchanged.

## Notes
- `shared/` is vendored, so the build/deploy stays self-contained (no lab dependency at build time).
- `npm run check:controller-core` passes (stamp 0.2.0, sourceRef core-v0.2.0).
- **The running game caches `shared/` at launch — restart `npm run start` after merging/pulling to exercise the new core.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)