### PR TITLE
Allow anonymous players to join an invite (fixes #312)

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -38,6 +38,10 @@ export const RELAY_URL = 'wss://tandemonium-relay.pete-872.workers.dev';
 export const SITE_URL = 'https://tandemonium.jimandi.love';
 export const TURN_CREDENTIALS_URL = 'https://tandemonium-relay.pete-872.workers.dev/turn-credentials';
 
+// Display name shown to a partner when a player joins an invite without
+// signing in (anonymous play). See Issue #312.
+export const GUEST_NAME = 'Guest';
+
 // Self-hosted PeerJS signaling server (Cloud Run)
 export const PEERJS_HOST = 'peerjs-640682648249.us-central1.run.app';
 export const PEERJS_PORT = 443;

--- a/js/game.js
+++ b/js/game.js
@@ -3,7 +3,7 @@
 // ============================================================
 
 import * as THREE from 'three';
-import { isMobile, isAndroid, isIOS, EVT_COUNTDOWN, EVT_START, EVT_RESET, EVT_GAMEOVER, EVT_CHECKPOINT, EVT_FINISH, EVT_RETURN_ROOM, MSG_PROFILE, TUNE, BALANCE_DEFAULTS, applyDifficulty, applySteeringFeel, snapshotTuningBase } from './config.js';
+import { isMobile, isAndroid, isIOS, EVT_COUNTDOWN, EVT_START, EVT_RESET, EVT_GAMEOVER, EVT_CHECKPOINT, EVT_FINISH, EVT_RETURN_ROOM, MSG_PROFILE, TUNE, BALANCE_DEFAULTS, GUEST_NAME, applyDifficulty, applySteeringFeel, snapshotTuningBase } from './config.js';
 import { RaceManager } from './race-manager.js';
 import { getLevelById, LEVELS } from './race-config.js';
 import { ContributionTracker } from './contribution-tracker.js';
@@ -1899,6 +1899,8 @@ class Game {
         if (user.serverId) profile.serverId = user.serverId;
       }
     }
+    // Anonymous players have no name — show a friendly label to the partner. (#312)
+    if (!profile.name) profile.name = GUEST_NAME;
     profile.bikeColor = this._getFrameColor(this.lobby.selectedPreset);
     this.net.sendProfile(profile);
   }

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -38,7 +38,7 @@ import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { NetworkManager } from './network-manager.js';
 import { InputManager } from './input-manager.js';
-import { isMobile, RELAY_URL, SITE_URL, BIKE_MODEL_PATH, TUNE, applySteeringFeel, snapshotTuningBase } from './config.js';
+import { isMobile, RELAY_URL, SITE_URL, BIKE_MODEL_PATH, TUNE, GUEST_NAME, applySteeringFeel, snapshotTuningBase } from './config.js';
 import { LEVELS } from './race-config.js';
 import { AuthManager } from './auth.js';
 import { LicenseManager } from './license.js';
@@ -2669,13 +2669,11 @@ export class Lobby {
     // Dismiss tap-to-start overlay — user already acted by navigating via URL
     if (this._tapOverlay) this._dismissTapOverlay();
 
-    // If not logged in, prompt sign-in first and join after auth completes
-    if (!this.auth.isLoggedIn()) {
-      this._pendingAutoJoinCode = fullCode;
-      this.auth.login();
-      return;
-    }
-
+    // No login required to join an invite. The relay accepts unauthenticated
+    // connections (worker/relay.js — auth is optional), and the manual join
+    // paths (btn-stoker / btn-join) never gated on login either. Sign-in stays
+    // available via the profile toggle for achievements/leaderboards, but it
+    // must not block joining a room from a QR/shared link. (Issue #312)
     this._showStep(this.joinStep);
     // Put the last 4 chars in the text input and pre-set for spinners
     const suffix = fullCode.slice(-4);
@@ -3530,13 +3528,14 @@ export class Lobby {
   _sendRoomProfile() {
     if (!this.net || !this.net.connected) return;
     const profile = { achievements: this._achievements.getEarned() };
-    if (this.auth && this.auth.isLoggedIn()) {
-      const user = this.auth.getUser();
-      if (user) {
-        if (user.avatar) profile.avatar = user.avatar;
-        if (user.name) profile.name = user.name;
-      }
+    const user = this.auth && this.auth.isLoggedIn() ? this.auth.getUser() : null;
+    if (user) {
+      if (user.avatar) profile.avatar = user.avatar;
+      if (user.name) profile.name = user.name;
     }
+    // Anonymous players (joined via invite without signing in) have no name —
+    // give the partner a friendly label instead of a blank. (Issue #312)
+    if (!profile.name) profile.name = GUEST_NAME;
     this.net.sendProfile(profile);
   }
 


### PR DESCRIPTION
## Problem

Joining a room from a **QR code or shared link** (`?room=CODE`) forced a Google sign-in first. On mobile the Google One Tap prompt frequently never appears (FedCM disabled, exponential cooldown, in-app browsers), and the persistent sign-in button lives in a hidden profile popup — so the user lands on the correct site but **never joins the room**. That's the symptom reported in #312.

## Root cause

The login gate in `_checkAutoJoin` was **obsolete**:

- The relay made auth **optional** in `000f925` ("Make relay auth optional — allow unauthenticated room connections"). A tokenless WebSocket connects fine; only a *valid-but-mismatched* token is rejected.
- The **manual** join paths (`btn-stoker`, `btn-join`) and the captain button never gated on login. Only the QR auto-join path did — an inconsistency, not a real requirement.

## Changes

- **`js/lobby.js`** — remove the sign-in gate in `_checkAutoJoin`; QR/shared-link joins now go straight to `_joinRoom`, identical to manual join. Sign-in remains available via the profile toggle for achievements/leaderboards (now optional, not a wall).
- **Guest fallback** — anonymous players previously sent no `name`, so the partner's label rendered blank. Now they present **"Guest"**, applied at the profile-send sites (`_sendRoomProfile`, game `_sendProfile`) so it propagates to the room label, PiP, and recent-rooms list. `GUEST_NAME` added to `js/config.js`.

## Notes / scope

- No relay or server change required — the server already accepts anonymous connections.
- In-game partner labels use role (STOKER/CAPTAIN), so the Guest name surfaces mainly on the room screen and recent-rooms list.
- Anonymous players have no persistent identity (no achievements/leaderboard) until they choose to sign in.

## Testing

- `node --check` passes on `js/lobby.js`, `js/game.js`, `js/config.js`.
- Manual verification suggested: scan a room QR from a **signed-out** phone → should join directly and show as "Guest" to the captain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)