### PR TITLE
Fix gyro steering fusion: gravity-vector roll (default) + Euler fallback toggle (#314)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -37,7 +37,8 @@ jobs:
           HASH=$(git rev-parse --short HEAD)
           DATE=$(TZ='America/New_York' date '+%m-%d-%Y %H:%M')
           VERSION="v.$HASH | $DATE (PR #${{ github.event.number }})"
-          sed -i -E "s#id=\"lobby-version\">[^<]*#id=\"lobby-version\">${VERSION}#" _site/index.html
+          # Delimiter '@' (not '#') — the version contains '#' from the PR number.
+          sed -i -E "s@id=\"lobby-version\">[^<]*@id=\"lobby-version\">${VERSION}@" _site/index.html
 
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1

--- a/index.html
+++ b/index.html
@@ -4660,6 +4660,12 @@ ON</button>
       <button class="opt-btn" id="opt-ds-webhid">WebHID</button>
     </div>
     <div class="options-note" id="opt-ds-state">Applied on next launch</div>
+    <div class="label" id="opt-gyro-label">Gyro Steering</div>
+    <div class="options-row" id="opt-gyro-row">
+      <button class="opt-btn" id="opt-gyro-euler">Smoothed</button>
+      <button class="opt-btn" id="opt-gyro-gravity">Gravity</button>
+    </div>
+    <div class="options-note">Controller gyro only — applies immediately</div>
     <button id="options-perf-btn">Run Perf Test</button>
     <div id="options-perf-result"></div>
     <button id="options-devtools-btn">Tools</button>

--- a/js/game.js
+++ b/js/game.js
@@ -10,7 +10,7 @@ import { ContributionTracker } from './contribution-tracker.js';
 import { CollectibleManager } from './collectibles.js';
 import { ObstacleManager } from './obstacles.js';
 import { AchievementManager, showAchievementToast, updateBadgeDisplay } from './achievements.js';
-import { InputManager, readDualSenseSourcePref } from './input-manager.js';
+import { InputManager, readDualSenseSourcePref, readGyroRollMode } from './input-manager.js';
 import { PedalController } from './pedal-controller.js';
 import { SharedPedalController } from './shared-pedal-controller.js';
 import { BalanceController } from './balance-controller.js';
@@ -3006,6 +3006,11 @@ class Game {
     if (dsSteamBtn)  dsSteamBtn.addEventListener('click',  () => this._setDualSenseSource('steam-input'));
     if (dsWebhidBtn) dsWebhidBtn.addEventListener('click', () => this._setDualSenseSource('webhid'));
 
+    const gyroEulerBtn   = document.getElementById('opt-gyro-euler');
+    const gyroGravityBtn = document.getElementById('opt-gyro-gravity');
+    if (gyroEulerBtn)   gyroEulerBtn.addEventListener('click',   () => this._setGyroRollMode('euler'));
+    if (gyroGravityBtn) gyroGravityBtn.addEventListener('click', () => this._setGyroRollMode('gravity'));
+
     if (isElectron) {
       browserDevBtn.addEventListener('click', async () => {
         const opened = await window.electronApp.toggleDevTools();
@@ -3036,6 +3041,7 @@ class Game {
 
     this._updateOptionsQualityUI();
     this._updateOptionsDualSenseSourceUI();
+    this._updateOptionsGyroRollUI();
   }
 
   _updateOptionsDualSenseSourceUI() {
@@ -3068,6 +3074,24 @@ class Game {
   _setDualSenseSource(source) {
     try { localStorage.setItem('tandemonium_dualsense_source', source); } catch(e) {}
     this._updateOptionsDualSenseSourceUI();
+  }
+
+  _setGyroRollMode(mode) {
+    const m = (mode === 'gravity') ? 'gravity' : 'euler';
+    try { localStorage.setItem('tandemonium_gyro_roll_mode', m); } catch(e) {}
+    // Apply live to both players' input managers so it can be felt immediately.
+    if (this.input) this.input.setGyroRollMode(m);
+    if (this.inputP2) this.inputP2.setGyroRollMode(m);
+    this._updateOptionsGyroRollUI();
+  }
+
+  _updateOptionsGyroRollUI() {
+    const mode = readGyroRollMode();
+    const eulerBtn   = document.getElementById('opt-gyro-euler');
+    const gravityBtn = document.getElementById('opt-gyro-gravity');
+    if (!eulerBtn) return;
+    eulerBtn.classList.toggle('active',   mode !== 'gravity');
+    gravityBtn.classList.toggle('active', mode === 'gravity');
   }
 
   _updateOptionsQualityUI() {
@@ -3125,12 +3149,15 @@ class Game {
       document.getElementById('opt-ds-auto'),
       document.getElementById('opt-ds-steam'),
       document.getElementById('opt-ds-webhid'),
+      document.getElementById('opt-gyro-euler'),
+      document.getElementById('opt-gyro-gravity'),
       document.getElementById('options-perf-btn'),
       document.getElementById('options-devtools-btn'),
       document.getElementById('options-browserdev-btn'),
       document.getElementById('options-close-btn'),
     ].filter(Boolean);
     this._updateOptionsDualSenseSourceUI();
+    this._updateOptionsGyroRollUI();
     this._setOverlayButtons(btns, btns.length - 1); // focus Close by default
   }
 

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -22,18 +22,21 @@ export function readDualSenseSourcePref() {
 }
 
 /**
- * Controller-gyro roll source (experimental A/B toggle, Issue #314):
- *   'euler'   — roll from Euler-Z of the integrated orientation (current).
- *   'gravity' — roll from the gravity-corrected down vector (drift-free,
- *               no ±180° wrap). Stored under 'tandemonium_gyro_roll_mode'.
- * Applied live so both can be felt back-to-back. Defaults to 'euler'.
+ * Controller-gyro roll source (Issue #314):
+ *   'gravity' — roll from the gravity-corrected down vector (DEFAULT).
+ *               Drift-free and bounded (no ±180° wrap), so it can't exhibit
+ *               the "fuses to one side then bounces to the other" failure.
+ *   'euler'   — legacy roll from Euler-Z of the integrated orientation; kept
+ *               as a fallback via the Options toggle (relies on the drift-EMA
+ *               compensation in _applyTilt).
+ * Stored under 'tandemonium_gyro_roll_mode'; applied live. Defaults to 'gravity'.
  */
 export function readGyroRollMode() {
   try {
     const v = localStorage.getItem('tandemonium_gyro_roll_mode');
-    if (v === 'gravity') return v;
+    if (v === 'euler') return v;
   } catch (e) {}
-  return 'euler';
+  return 'gravity';
 }
 
 // Controller state (gamepad binding, WebHID, sensor fusion, synthetic

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -21,6 +21,21 @@ export function readDualSenseSourcePref() {
   return 'auto';
 }
 
+/**
+ * Controller-gyro roll source (experimental A/B toggle, Issue #314):
+ *   'euler'   — roll from Euler-Z of the integrated orientation (current).
+ *   'gravity' — roll from the gravity-corrected down vector (drift-free,
+ *               no ±180° wrap). Stored under 'tandemonium_gyro_roll_mode'.
+ * Applied live so both can be felt back-to-back. Defaults to 'euler'.
+ */
+export function readGyroRollMode() {
+  try {
+    const v = localStorage.getItem('tandemonium_gyro_roll_mode');
+    if (v === 'gravity') return v;
+  } catch (e) {}
+  return 'euler';
+}
+
 // Controller state (gamepad binding, WebHID, sensor fusion, synthetic
 // gamepad for BT-silent DualSense) now lives on a ControllerManager slot.
 // See shared/manager.js. InputManager is a thin consumer that
@@ -138,6 +153,9 @@ export class InputManager {
     // User preference (Auto / Steam Input / WebHID) — sampled once at
     // construction; takes effect on next session boot.
     this._dualsenseSource = readDualSenseSourcePref();
+    // Controller-gyro roll source (#314). Read at construction; updated live
+    // via setGyroRollMode() so the Options toggle takes effect immediately.
+    this._gyroRollMode = readGyroRollMode();
 
     if (enableKeyboard) this._setupKeyboard();
     if (isMobile) {
@@ -701,8 +719,39 @@ export class InputManager {
       if (this.onMotionEnabled) this.onMotionEnabled();
     }
     if (!this.motionEnabled) return;
+
+    // Euler-Z roll from the integrated orientation (current default). Prone to
+    // drift ("fuses to one side") and a ±180° wrap / gimbal-lock flip ("bounces
+    // to the other side") — see #314.
     this._tmpEuler.setFromQuaternion(fusion.orientation, 'XYZ');
-    const leanDeg = -this._tmpEuler.z * (180 / Math.PI);
+    const eulerLeanDeg = -this._tmpEuler.z * (180 / Math.PI);
+
+    // Gravity-vector roll: derived from the gravity-corrected down vector, so it
+    // can't drift and is naturally bounded (no ±180° runaway). Experimental
+    // A/B toggle (#314); fusion.gravityRollRadians() documents the convention.
+    const gravLeanDeg = (typeof fusion.gravityRollRadians === 'function')
+      ? fusion.gravityRollRadians() * (180 / Math.PI)
+      : eulerLeanDeg;
+
+    const leanDeg = this._gyroRollMode === 'gravity' ? gravLeanDeg : eulerLeanDeg;
+
+    // Lightweight diagnostic (off unless window.__gyroDebug is set). Lets us
+    // capture the fuse/bounce live and compare Euler vs gravity roll (#314).
+    if (typeof window !== 'undefined' && window.__gyroDebug) {
+      window.__gyroDebugState = {
+        mode: this._gyroRollMode, eulerLeanDeg, gravLeanDeg,
+        motionOffset: this.motionOffset, relative: this.motionRawRelative,
+        lean: this._smoothedLean,
+      };
+      const t = performance.now();
+      if (!this._gyroDbgT || t - this._gyroDbgT > 250) {
+        this._gyroDbgT = t;
+        console.log('[gyro]', this._gyroRollMode,
+          'euler=' + eulerLeanDeg.toFixed(1), 'grav=' + gravLeanDeg.toFixed(1),
+          'rel=' + (this.motionRawRelative || 0).toFixed(1), 'lean=' + this._smoothedLean.toFixed(2));
+      }
+    }
+
     // Do NOT clamp before passing to _applyTilt — clamping the fusion input
     // prevents gravity correction from tracking through extreme angles,
     // causing the "gyro goes wild" feedback loop on noisy BT connections.
@@ -710,6 +759,11 @@ export class InputManager {
     this._gyroRollAccum = -leanDeg;
     this._accelRoll = leanDeg;
     this._applyTilt(leanDeg, true);
+  }
+
+  // Switch the controller-gyro roll source live (Options toggle, #314).
+  setGyroRollMode(mode) {
+    this._gyroRollMode = (mode === 'gravity') ? 'gravity' : 'euler';
   }
 
   /**

--- a/shared/sensor-fusion.js
+++ b/shared/sensor-fusion.js
@@ -139,10 +139,11 @@ export class SensorFusion {
    * fixing the "fuses to one side then bounces to the other" behavior (#314).
    * `_gravityVec` is gravity in the sensor-local frame (≈ (0,-1,0) at rest),
    * so a roll tips it into the local X axis. Returns radians; sign matches the
-   * Euler-Z convention used by the gyro path (positive = lean right).
+   * Euler-Z convention used by the gyro path (positive = lean right) — verified
+   * on a DualSense (the un-negated form steered inverted), see #314.
    */
   gravityRollRadians() {
-    return -Math.atan2(this._gravityVec.x, -this._gravityVec.y);
+    return Math.atan2(this._gravityVec.x, -this._gravityVec.y);
   }
 
   /**

--- a/shared/sensor-fusion.js
+++ b/shared/sensor-fusion.js
@@ -132,6 +132,20 @@ export class SensorFusion {
   get calibrating() { return this._calibrating; }
 
   /**
+   * Roll (left/right lean) about the sensor's forward axis, derived from the
+   * gravity-corrected down vector rather than the integrated orientation's
+   * Euler decomposition. Because gravity is an absolute reference, this does
+   * NOT drift and is naturally bounded to (-π, π] with no degenerate flip —
+   * fixing the "fuses to one side then bounces to the other" behavior (#314).
+   * `_gravityVec` is gravity in the sensor-local frame (≈ (0,-1,0) at rest),
+   * so a roll tips it into the local X axis. Returns radians; sign matches the
+   * Euler-Z convention used by the gyro path (positive = lean right).
+   */
+  gravityRollRadians() {
+    return -Math.atan2(this._gravityVec.x, -this._gravityVec.y);
+  }
+
+  /**
    * Begin initial one-shot bias calibration. Clears any prior samples.
    * @param {string} [connectionType] — 'bluetooth' or 'usb'. BT gets a
    *   longer capture window and relaxed ideal-stddev threshold to match


### PR DESCRIPTION
Experimental, opt-in toggle to A/B test a fix for the DualSense gyro steering that "fused to one side then bounced all the way to the other" ([#314](https://github.com/petegordon/Tandemonium/issues/314#issuecomment-4698780972)).

## Why
The controller-gyro roll is taken from `Euler('XYZ').z` of the *integrated* orientation, which (1) **drifts** → steering fuses to one side, and (2) crosses a **±180° wrap / gimbal-lock** boundary → snaps to the other extreme. The phone-tilt path avoids both by using a **gravity-referenced** roll.

## What this adds (default behavior unchanged)
- **Options → "Gyro Steering"**: `Smoothed` (Euler, current default) | `Gravity`. Applied **immediately** to both players, persisted in `tandemonium_gyro_roll_mode`. Gamepad-navigable like the other options.
- **`SensorFusion.gravityRollRadians()`** — roll from the gravity-corrected down vector: drift-free, naturally bounded, no ±180° runaway.
- Input-manager computes both rolls each frame, steers with the selected one. **Defaults to Euler**, so nothing changes until you toggle.
- **Diagnostic** behind `window.__gyroDebug = true`: throttled console log + `window.__gyroDebugState` showing `euler` vs `grav` roll, `relative`, and `lean` — to confirm the fuse/bounce live on the DualSense.

## How to test
1. Desktop with DualSense gyro. Open Options (Start button) → Gyro Steering.
2. Reproduce the fuse/bounce on **Smoothed**, then switch to **Gravity** and compare. (Optionally set `window.__gyroDebug = true` in the console first to log both rolls.)
3. If **Gravity** steers inverted, that's just a sign — note it and I'll flip `gravityRollRadians()`.

## Notes
- Experimental branch; once we confirm which mode is right (and the gravity sign), the plan is to make gravity the default and retire most of the Euler drift-EMA band-aid.
- `node --check` passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)