### PR TITLE
Debounce reconnect UI/freeze so brief partner phone-locks don't flash (fixes #320)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -36,6 +36,12 @@ import { ControllerManager } from '../shared/manager.js';
 // Demo checkpoint limit removed — demo users play the tutorial instead
 const TUNING_KEY_PREFIX = 'tandemonium_motion_tuning';
 
+// Grace period before surfacing the "reconnecting" badge / freezing the race.
+// A brief partner phone-lock self-heals within ~1-2s (relay close → fast
+// reconnect + the partner force-reconnects on unlock), so debouncing the
+// presentation avoids a jarring freeze-flash for blips. See #320.
+const RECONNECT_GRACE_MS = 2000;
+
 // Tutorial phase boundaries — sequential layout so all phases are visible ahead
 const TUTORIAL_PHASES = {
   1: { runwayStart: 0,   contentStart: 30,  contentEnd: 80  },
@@ -207,6 +213,7 @@ class Game {
     this._stokerWasFallen = false;
     this._stokerTimeoutShown = false;
     this._reconnecting = false;
+    this._reconnectGraceTimer = null; // debounce timer for _showReconnecting (#320)
 
     // Recording partner pedal flash tracking
     this._recLastTapTime = 0;
@@ -743,7 +750,7 @@ class Game {
 
     this.net.onReconnecting = (attempt, max) => {
       if (this.state !== 'lobby') {
-        this._showReconnecting();
+        this._armReconnectGrace();
       }
     };
 
@@ -1810,12 +1817,28 @@ class Game {
     }
   }
 
+  // Debounce: arm a grace timer that surfaces the reconnecting UI only if the
+  // drop hasn't self-healed by then. Brief partner phone-locks recover within
+  // the window, so the captain never sees a freeze-flash for them (#320).
+  _armReconnectGrace() {
+    if (this._reconnecting) return;        // already shown
+    if (this._reconnectGraceTimer) return; // already pending
+    this._reconnectGraceTimer = setTimeout(() => {
+      this._reconnectGraceTimer = null;
+      this._showReconnecting();
+    }, RECONNECT_GRACE_MS);
+  }
+
   _showReconnecting() {
     this._reconnecting = true;
     document.getElementById('conn-badge').classList.add('reconnecting');
   }
 
   _hideReconnecting() {
+    if (this._reconnectGraceTimer) {
+      clearTimeout(this._reconnectGraceTimer);
+      this._reconnectGraceTimer = null;
+    }
     this._reconnecting = false;
     document.getElementById('conn-badge').classList.remove('reconnecting');
   }


### PR DESCRIPTION
Split out of #314 (the reconnect-on-lock remainder). Implements the recommended debounce.

## Problem
When the stoker's phone briefly locks/backgrounds, the captain **instantly** flashes a "reconnecting" badge and **freezes the race** (`_reconnecting`), even though it self-heals in ~1-2s. False-positive churn, not slow recovery.

## Fix
Debounce the *presentation*:
- `onReconnecting` now calls `_armReconnectGrace()` — starts a **2s** timer (`RECONNECT_GRACE_MS`).
- `_showReconnecting()` (badge + race freeze) only fires if still disconnected when the timer expires.
- `_hideReconnecting()` (called by `onConnected` and terminal `onDisconnected`) cancels the pending timer, so brief locks never surface anything.
- The underlying reconnect/backoff logic is unchanged; a genuine long drop just shows ~2s later.

## Behavior reference (from the investigation)
- Detection is usually immediate: relay `webSocketClose` → `{type:'disconnect'}` → `_handleDisconnect()` (`network-manager.js:203`). Fallback: 8s heartbeat timeout.
- Recovery is already fast: backoff 1s/2s/4s + the stoker force-reconnects on unlock (`_maybeRecoverFromIdle`).

## Tradeoff
During the grace, the race keeps running with the partner's last-known lean/pedal for ~2s instead of freezing instantly — mild (steering is averaged), and far less jarring than a freeze-flash for a 2s blip.

## Scope
- Online MP reconnect only. The local-co-op gamepad-unplug freeze (`game.js:3749`, sets `_reconnecting` directly) is intentionally immediate and untouched.
- `node --check` passes.

## Testing
Captain (desktop) + stoker (phone): briefly lock/unlock the phone mid-ride → captain should **not** flash "reconnecting" or freeze for a quick lock; a sustained disconnect (>2s) still shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)