### PR TITLE
Preserve PR previews across main deploys (fixes #319)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,12 +40,28 @@ jobs:
           # in UsersFirst/tandemonium-controller-lab and is served at
           # https://lab.usersfirst.games/overlay (the /test card links out to it).
 
+      # Carry the existing PR previews into the publish tree so this deploy
+      # can't drop them. `keep_files: true` alone has proven unreliable at
+      # preserving the pr-preview/ subtree, so we restore it explicitly: the
+      # previews become part of _site and are therefore always re-published.
+      # (#319)
+      - name: Preserve existing PR previews
+        run: |
+          git fetch origin gh-pages --depth=1 || true
+          if git ls-tree -d origin/gh-pages pr-preview 2>/dev/null | grep -q pr-preview; then
+            git archive origin/gh-pages pr-preview | tar -x -C _site
+            echo "Preserved PR previews: $(ls _site/pr-preview 2>/dev/null | tr '\n' ' ')"
+          else
+            echo "No existing PR previews to preserve"
+          fi
+
       - name: Deploy to gh-pages branch
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           publish_branch: gh-pages
+          # No exclude_assets for pr-preview: we now restore it INTO _site (see
+          # the preserve step), so it must be published rather than excluded.
           keep_files: true
-          exclude_assets: 'pr-preview/**'
           cname: tandemonium.jimandi.love

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,8 +49,13 @@ jobs:
         run: |
           git fetch origin gh-pages --depth=1 || true
           if git ls-tree -d origin/gh-pages pr-preview 2>/dev/null | grep -q pr-preview; then
-            git archive origin/gh-pages pr-preview | tar -x -C _site
-            echo "Preserved PR previews: $(ls _site/pr-preview 2>/dev/null | tr '\n' ' ')"
+            # `if` consumes the pipeline status, so a failure here can't abort
+            # the deploy (bash -eo pipefail) — worst case previews aren't kept.
+            if git archive origin/gh-pages pr-preview | tar -x -C _site; then
+              echo "Preserved PR previews: $(ls _site/pr-preview 2>/dev/null | tr '\n' ' ')"
+            else
+              echo "WARNING: failed to preserve pr-preview; continuing deploy"
+            fi
           else
             echo "No existing PR previews to preserve"
           fi


### PR DESCRIPTION
## Problem
A push/merge to `main` runs `deploy.yml`, which **wipes the entire `pr-preview/` tree** on `gh-pages` — `peaceiris/actions-gh-pages` `keep_files: true` did **not** preserve it (proven: `git diff --stat 4004a56 1af28c8` showed `pr-preview/pr-317/** … 63398 deletions`). Every active PR preview 404s until it re-syncs.

## Fix (deterministic — doesn't rely on keep_files)
Before publishing, **restore the existing previews into the publish tree**:
```yaml
- name: Preserve existing PR previews
  run: |
    git fetch origin gh-pages --depth=1 || true
    if git ls-tree -d origin/gh-pages pr-preview 2>/dev/null | grep -q pr-preview; then
      git archive origin/gh-pages pr-preview | tar -x -C _site
    fi
```
Now `pr-preview/` is part of `_site`, so it's always re-published and can't be dropped. Also **removed `exclude_assets: 'pr-preview/**'`** — the previews are now *in* `_site` and must be published, not excluded.

## Validation
- Confirmed the `git archive <ref> <path> | tar -x -C _site` mechanism locally (extracts the subtree into `_site` preserving structure).
- `gh-pages` currently has no `pr-preview/` (already wiped by the recent #317/#321 merges), so the next main deploy will hit the "nothing to preserve" branch; the preservation kicks in for previews created after this lands.

## Notes
- Narrow residual race if a main deploy and a preview deploy run at the exact same time (the snapshot could be momentarily stale) — vastly better than today's "always wipes."
- `keep_files: true` is retained as defense-in-depth for any non-preview files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)