### PR TITLE
Keep the race timer running during a partner reconnect (fixes #316)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -3669,12 +3669,13 @@ class Game {
 
     this._recordBalanceCrashIfNew(wasFallen);
 
-    // Race progress + contribution tracking (captain is authoritative)
-    // Freeze race timer while reconnecting
+    // Race progress + contribution tracking (captain is authoritative).
+    // The race clock keeps running during a partner reconnect (#316): a brief
+    // phone-lock shouldn't pause the timer for both players. (#321 already
+    // debounces the reconnect UI so quick blips don't even show.)
     if (this.raceManager) {
-      const raceDt = this._reconnecting ? 0 : dt;
-      const raceEvent = this.raceManager.update(this.bike.distanceTraveled, raceDt);
-      if (raceEvent && !this._reconnecting) {
+      const raceEvent = this.raceManager.update(this.bike.distanceTraveled, dt);
+      if (raceEvent) {
         if (raceEvent.event === 'timeout') { this._onTimerExpired(); return; }
         this._handleRaceEvent(raceEvent);
       }
@@ -3746,7 +3747,7 @@ class Game {
     if (this._localP2Type === 'gamepad' && !this.inputP2.gamepadConnected) {
       if (!this._localP2Disconnected) {
         this._localP2Disconnected = true;
-        this._reconnecting = true; // shared flag with online MP freezes raceManager
+        this._reconnecting = true; // pauses local co-op (this fn early-returns below)
         this._showDisconnect('Player 2 controller disconnected');
       }
       // Render a still frame so the world doesn't look crashed, but skip
@@ -3895,7 +3896,9 @@ class Game {
     // Timer value is synced from captain via onStateReceived; stoker only
     // decrements locally between network updates to keep display smooth.
     if (this.raceManager) {
-      const raceDt = this._reconnecting ? 0 : dt;
+      // Keep the displayed clock ticking during reconnect (#316); captain's
+      // authoritative timer resyncs it on the next state update.
+      const raceDt = dt;
       // Local decrement for smooth display between 20Hz state updates
       if (raceDt > 0 && this.raceManager.segmentTimeRemaining > 0) {
         this.raceManager.segmentTimeRemaining -= raceDt;


### PR DESCRIPTION
## What #316 reported
"Timer countdown looks like it stops in multiplayer if the invited mobile screen is locked… started again once unlocked."

## Why
That was the intended **freeze-during-reconnect**: when the partner drops, `_reconnecting` zeroed the captain's `raceDt` (and suppressed race events), and the stoker mirrors the captain's authoritative timer — so both stopped and resumed on unlock.

## Change (per the chosen behavior: keep the clock running)
- **Captain (authoritative):** `raceManager.update()` now always uses `dt` (no `_reconnecting ? 0 : dt`) and race events fire normally — the clock runs and the race proceeds during a partner drop.
- **Stoker:** the displayed countdown keeps ticking during reconnect; the captain resyncs the authoritative value on the next state update. The **"TOO SLOW" flash stays deferred** to the captain (kept the `_reconnecting` guard) so a brief reconnect can't false-flash it.

## Unchanged
- The "reconnecting" badge still appears (now debounced by #321, so quick locks don't even show it) — it just no longer pauses the timer.
- **Local co-op** gamepad-unplug pause is a separate early-return path (`_updateLocal`) and still freezes as before. Updated its stale comment.

## Tradeoff (accepted)
The clock is now "real" during a disconnect — if the captain's segment times out while the partner is mid-lock, it times out rather than waiting. That's the point of keep-running, and #321 means only sustained drops are even flagged.

## Testing
Captain (desktop) + stoker (phone), mid-ride: lock the phone for several seconds → the captain's timer should **keep counting down** (with at most a small "reconnecting" badge), and resync the stoker on unlock — no full stop/restart.

`node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)