### PR TITLE
nav-core FocusController + clip-preview migration (#318 Step 1 PoC)

### DIFF
--- a/js/game-recorder.js
+++ b/js/game-recorder.js
@@ -5,6 +5,7 @@
 // iOS Safari: canvas.captureStream() produces blank video (WebKit bugs 229611, 181663).
 // Detect iOS and use WebCodecs VideoEncoder + mp4-muxer instead.
 import * as analytics from './analytics.js';
+import { FocusController } from './nav/focus-controller.js';
 
 const _isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
   (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
@@ -268,14 +269,14 @@ export class GameRecorder {
       this.shareBtn.style.display = 'none';
     }
 
-    // Gamepad navigation for clip preview modal
-    this._previewItems = [this.previewShareBtn, this.previewSaveBtn, this.previewDiscardBtn].filter(Boolean);
-    this._previewFocusIndex = 0;
+    // Gamepad navigation for clip preview modal — driven by the shared
+    // FocusController (nav-core, #318). B discards the clip; A clicks the
+    // focused button (the controller's default).
     this._previewPollId = null;
-    this._gpPrevLeft = false;
-    this._gpPrevRight = false;
-    this._gpPrevA = false;
-    this._gpPrevB = false;
+    this._previewFocus = new FocusController({
+      input: this.input,
+      onBack: () => this._discardClip(),
+    });
 
     // Resize listener to keep compositing canvas in sync
     window.addEventListener('resize', () => this._syncCanvasSize());
@@ -1433,33 +1434,12 @@ export class GameRecorder {
   // ── Clip preview gamepad navigation ──
 
   _startPreviewGamepadNav() {
-    // Build visible items list (SHARE may be hidden)
-    this._previewItems = [this.previewShareBtn, this.previewSaveBtn, this.previewDiscardBtn]
-      .filter(el => el && el.style.display !== 'none');
-    this._previewFocusIndex = 0;
-    this._gpPrevUp = false;
-    this._gpPrevDown = false;
-    this._gpPrevLeft = false;
-    this._gpPrevRight = false;
-    this._gpPrevA = false;
-    this._gpPrevB = false;
-
-    // Prime edge-detect from current gamepad state
-    if (this.input && this.input.gamepadConnected) {
-      const gp = this.input.getGamepadState();
-      if (gp) {
-        this._gpPrevUp = (gp.buttons[12] && gp.buttons[12].pressed) || gp.axes[1] < -0.5;
-        this._gpPrevDown = (gp.buttons[13] && gp.buttons[13].pressed) || gp.axes[1] > 0.5;
-        this._gpPrevLeft = (gp.buttons[14] && gp.buttons[14].pressed) || gp.axes[0] < -0.5;
-        this._gpPrevRight = (gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5;
-        const aIdx = this.input._gpSwapAB ? 1 : 0;
-        const bIdx = this.input._gpSwapAB ? 0 : 1;
-        this._gpPrevA = gp.buttons[aIdx] && gp.buttons[aIdx].pressed;
-        this._gpPrevB = gp.buttons[bIdx] && gp.buttons[bIdx].pressed;
-      }
-    }
-
-    this._applyPreviewFocus();
+    // Visible items only (SHARE may be hidden on desktop). The controller
+    // primes edge-state so a button held when the modal opens doesn't fire.
+    this._previewFocus.setItems(
+      [this.previewShareBtn, this.previewSaveBtn, this.previewDiscardBtn]
+        .filter(el => el && el.style.display !== 'none')
+    );
     this._pollPreviewGamepad();
   }
 
@@ -1468,60 +1448,12 @@ export class GameRecorder {
       cancelAnimationFrame(this._previewPollId);
       this._previewPollId = null;
     }
-    this._clearPreviewFocus();
+    this._previewFocus.clear();
   }
 
   _pollPreviewGamepad() {
     this._previewPollId = requestAnimationFrame(() => this._pollPreviewGamepad());
-
-    if (!this.input || !this.input.gamepadConnected) return;
-    const gp = this.input.getGamepadState();
-    if (!gp) return;
-
-    const up = (gp.buttons[12] && gp.buttons[12].pressed) || gp.axes[1] < -0.5;
-    const down = (gp.buttons[13] && gp.buttons[13].pressed) || gp.axes[1] > 0.5;
-    const left = (gp.buttons[14] && gp.buttons[14].pressed) || gp.axes[0] < -0.5;
-    const right = (gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5;
-    const aIdx = this.input._gpSwapAB ? 1 : 0;
-    const bIdx = this.input._gpSwapAB ? 0 : 1;
-    const a = gp.buttons[aIdx] && gp.buttons[aIdx].pressed;
-    const b = gp.buttons[bIdx] && gp.buttons[bIdx].pressed;
-
-    // Both axes navigate the button list (buttons wrap vertically on narrow screens)
-    if ((up && !this._gpPrevUp) || (left && !this._gpPrevLeft)) this._movePreviewFocus(-1);
-    if ((down && !this._gpPrevDown) || (right && !this._gpPrevRight)) this._movePreviewFocus(1);
-    if (a && !this._gpPrevA) this._confirmPreviewFocus();
-    if (b && !this._gpPrevB) this._discardClip();
-
-    this._gpPrevUp = up;
-    this._gpPrevDown = down;
-    this._gpPrevLeft = left;
-    this._gpPrevRight = right;
-    this._gpPrevA = a;
-    this._gpPrevB = b;
-  }
-
-  _movePreviewFocus(dir) {
-    if (!this._previewItems.length) return;
-    this._clearPreviewFocus();
-    this._previewFocusIndex = Math.max(0, Math.min(this._previewItems.length - 1, this._previewFocusIndex + dir));
-    this._applyPreviewFocus();
-  }
-
-  _confirmPreviewFocus() {
-    const el = this._previewItems[this._previewFocusIndex];
-    if (el) el.click();
-  }
-
-  _applyPreviewFocus() {
-    const el = this._previewItems[this._previewFocusIndex];
-    if (el) el.classList.add('gamepad-focus');
-  }
-
-  _clearPreviewFocus() {
-    for (const el of this._previewItems) {
-      if (el) el.classList.remove('gamepad-focus');
-    }
+    this._previewFocus.poll();
   }
 
   // ── Canvas drawing helpers ──

--- a/js/nav/focus-controller.js
+++ b/js/nav/focus-controller.js
@@ -1,0 +1,144 @@
+// ============================================================
+// FocusController — controller-driven focus engine (nav-core)
+// ============================================================
+//
+// A single, framework-agnostic abstraction for "poll gamepad → edge-detect →
+// move a focus index → toggle .gamepad-focus", replacing the copy-pasted
+// polling loops across the lobby, in-game overlays, and the clip preview.
+// See issue #318 (Step 1, @usersfirst/nav-core). In-repo first; this is the
+// seam that later lifts to its own package.
+//
+// Design notes:
+//  - Fed by an InputManager (getGamepadState() + the _gpSwapAB A/B-swap
+//    quirk), NOT a per-call-site navigator.getGamepads(). One input owner.
+//  - Caller-driven: it exposes poll() and the caller decides scheduling (a
+//    self-scheduling RAF loop, or the game loop) — RAF ownership varies across
+//    the existing call sites, so the controller never owns it.
+//  - Linear list semantics (up/left = previous, down/right = next, clamped) —
+//    this matches every flat-list call site. Richer geometries (2D grids,
+//    multi-column, sliders) layer on top in later migrations.
+// ============================================================
+
+const NO_EDGES = { up: false, down: false, left: false, right: false, a: false, b: false };
+
+export class FocusController {
+  /**
+   * @param {Object} opts
+   * @param {Object} opts.input — InputManager: needs `gamepadConnected`,
+   *   `getGamepadState()`, and the `_gpSwapAB` quirk flag.
+   * @param {string} [opts.focusClass='gamepad-focus'] — CSS class toggled on
+   *   the focused element.
+   * @param {(el:Element, index:number)=>void} [opts.onConfirm] — A-button
+   *   action. Defaults to `el.click()`.
+   * @param {()=>void} [opts.onBack] — B-button action. No-op if omitted.
+   * @param {(el:Element, index:number)=>void} [opts.onChange] — fired after
+   *   focus moves to a new item.
+   */
+  constructor({ input, focusClass = 'gamepad-focus', onConfirm = null, onBack = null, onChange = null } = {}) {
+    this.input = input;
+    this.focusClass = focusClass;
+    this._onConfirm = onConfirm;
+    this._onBack = onBack;
+    this._onChange = onChange;
+    this.items = [];
+    this.index = 0;
+    this._edge = { ...NO_EDGES };
+  }
+
+  /**
+   * Set the focusable list and highlight `initialIndex`. Falsy entries are
+   * dropped (callers can pass a sparse list of maybe-hidden buttons). Primes
+   * edge-state from the current pad so a button already held when the scope
+   * opens doesn't immediately fire.
+   */
+  setItems(items, initialIndex = 0) {
+    this._clearFocus();
+    this.items = (items || []).filter(Boolean);
+    this.index = this._clamp(initialIndex);
+    this._edge = this._readEdges() || { ...NO_EDGES };
+    this._applyFocus();
+    return this;
+  }
+
+  /** Remove focus styling and drop the item list. */
+  clear() {
+    this._clearFocus();
+    this.items = [];
+    this.index = 0;
+  }
+
+  /**
+   * Read the pad once and dispatch nav / confirm / back via edge detection.
+   * The caller drives this each frame; the controller does not schedule.
+   */
+  poll() {
+    const e = this._readEdges();
+    if (!e) return;
+    if ((e.up && !this._edge.up) || (e.left && !this._edge.left)) this.move(-1);
+    if ((e.down && !this._edge.down) || (e.right && !this._edge.right)) this.move(1);
+    if (e.a && !this._edge.a) this.confirm();
+    if (e.b && !this._edge.b) this.back();
+    this._edge = e;
+  }
+
+  /** Move focus by `dir` (clamped — no wrap, matching the existing loops). */
+  move(dir) {
+    if (!this.items.length) return;
+    this._clearFocus();
+    this.index = this._clamp(this.index + dir);
+    this._applyFocus();
+    if (this._onChange) this._onChange(this.items[this.index], this.index);
+  }
+
+  /** Trigger the focused item's action (onConfirm, else `el.click()`). */
+  confirm() {
+    const el = this.items[this.index];
+    if (!el) return;
+    if (this._onConfirm) this._onConfirm(el, this.index);
+    else el.click();
+  }
+
+  /** Trigger the back action, if any. */
+  back() {
+    if (this._onBack) this._onBack();
+  }
+
+  /** Currently focused element, or null. */
+  get focused() {
+    return this.items[this.index] || null;
+  }
+
+  // ── internals ──
+
+  _clamp(i) {
+    return Math.max(0, Math.min(this.items.length - 1, i));
+  }
+
+  /** Read the current pad into a normalized edge snapshot, honoring A/B swap. */
+  _readEdges() {
+    if (!this.input || !this.input.gamepadConnected) return null;
+    const gp = this.input.getGamepadState();
+    if (!gp) return null;
+    const aIdx = this.input._gpSwapAB ? 1 : 0;
+    const bIdx = this.input._gpSwapAB ? 0 : 1;
+    return {
+      up:    !!((gp.buttons[12] && gp.buttons[12].pressed) || gp.axes[1] < -0.5),
+      down:  !!((gp.buttons[13] && gp.buttons[13].pressed) || gp.axes[1] > 0.5),
+      left:  !!((gp.buttons[14] && gp.buttons[14].pressed) || gp.axes[0] < -0.5),
+      right: !!((gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5),
+      a: !!(gp.buttons[aIdx] && gp.buttons[aIdx].pressed),
+      b: !!(gp.buttons[bIdx] && gp.buttons[bIdx].pressed),
+    };
+  }
+
+  _applyFocus() {
+    const el = this.items[this.index];
+    if (el) el.classList.add(this.focusClass);
+  }
+
+  _clearFocus() {
+    for (const el of this.items) {
+      if (el) el.classList.remove(this.focusClass);
+    }
+  }
+}


### PR DESCRIPTION
First increment of the #318 modularization plan — **Step 1 (`@usersfirst/nav-core`)**, starting with the prescribed proof-of-concept (the clip-preview modal, the smallest self-contained nav call site).

## What
Extracts the copy-pasted *"poll gamepad → edge-detect → move focus index → toggle `.gamepad-focus`"* loop (duplicated 4× across lobby/game/recorder) into one framework-agnostic **`FocusController`** (`js/nav/focus-controller.js` — the in-repo seam that later lifts to `@usersfirst/nav-core`).

- Fed by `InputManager` (`getGamepadState()` + the `_gpSwapAB` A/B-swap quirk) — one input owner, no per-call-site `navigator.getGamepads()`.
- **Caller-driven `poll()`** — it does not own the RAF, because scheduling varies across the existing call sites (preview & lobby self-schedule; the game-over/victory overlay is driven by the game loop).
- Linear list semantics (up/left = prev, down/right = next, clamped) — matches every flat-list site. `onConfirm` / `onBack` / `onChange` hooks; `setItems()` primes edge-state so a button held when a scope opens doesn't immediately fire.

## Proof-of-concept migration
The `game-recorder.js` clip-preview modal now uses it: ~75 lines of bespoke `_movePreviewFocus`/`_confirmPreviewFocus`/`_applyPreviewFocus`/`_clearPreviewFocus` + the inline poll, plus ~8 `_gpPrev*`/index fields, collapse to **one `FocusController` + thin RAF start/stop wrappers**. Behavior preserved exactly (A = click focused button, B = discard, visible-buttons-only, clamped).

## Why this scope
Per the issue's sequencing, Step 1 is the prerequisite and migrates **smallest → largest, each independently shippable**. This PR lands the foundation + proves it against the simplest site. Follow-up PRs:
1. `game.js` game-over/victory/disconnect overlays (needs a slider extension for the steering-feel range).
2. `lobby.js` modals (profile/leaderboard/help/rejoin/spinner).
3. `lobby.js` main steps — retire `_moveFocus`/`_moveColumn`/`_modeColIndex` via a `data-nav` neighbor model.

## No-build constraint
Raw ESM, imported relatively (`./nav/focus-controller.js`) — survives the `node_modules`-excluded gh-pages rsync and Electron `file://`. No bundler, no import-map change needed yet.

## Testing
`node --check` passes on both files. Manual: with a gamepad, open a clip preview → D-pad/stick moves focus across SHARE/SAVE/DISCARD, A activates, B discards — unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)