### PR TITLE
Don't disable clip recording on auto low-quality classification

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -172,10 +172,12 @@ class Game {
     this.archIndicator = new ArchIndicator(this.scene);
     this._partnerBikeColor = null;
     this.recorder = new GameRecorder(this.renderer.domElement, this.input);
-    if (this._lowQuality) {
-      this.recorder.supported = false;
-      if (this.recorder.shareBtn) this.recorder.shareBtn.style.display = 'none';
-    }
+    // NOTE: clip recording is NOT gated on the general _lowQuality render flag.
+    // The recorder runs its own GPU-readback probe (_detectLowEndDevice) to
+    // decide if recording is viable. A coarse/stale hardware-tier
+    // classification was wrongly disabling clips on capable desktops even when
+    // that probe passed (issue: sup=true at construction, then overridden).
+    // Manual "Low" in Options still disables recording (see _setQuality).
 
     // Mode
     this.mode = 'solo'; // 'solo' | 'captain' | 'stoker' | 'local'
@@ -239,8 +241,9 @@ class Game {
           this._lowQuality = true;
           this.renderer.setPixelRatio(0.5);
           this.renderer.shadowMap.enabled = false;
-          this.recorder.supported = false;
-          if (this.recorder.shareBtn) this.recorder.shareBtn.style.display = 'none';
+          // Don't disable clip recording here — the recorder's own GPU-readback
+          // probe is authoritative; auto low-end render quality shouldn't kill
+          // clips on a machine that can actually record. (Manual Low still does.)
           this._updateOptionsQualityUI();
         }
       });


### PR DESCRIPTION
## Problem
On a **capable desktop**, the in-game 🎬 clip button never appeared and no clip could be captured. Root cause traced live with `?debug`:

- The recorder constructs with **`supported = true`** (its own GPU-readback probe passes — `0.07ms`, `lowEnd=false`).
- Then `game.js` immediately **overrode `recorder.supported = false`** and hid the button because the general **`_lowQuality`** render flag was set — auto-classified from a coarse/stale hardware tier, even though the machine is fast.
- So `startBuffer` bailed at its `if (!this.supported …) return` guard → `buffering` stayed false → no in-game button, no clip, no way to reach the preview.

Two different "is this machine slow?" detectors disagreed, and recording lost to the coarser one.

## Fix
Clip-recording viability is the recorder's **own** GPU-readback probe's job (`_detectLowEndDevice`). Stop letting the auto render-quality flag second-guess it:
- Removed the `recorder.supported = false` override at construction (`game.js:175`).
- Removed it from the async `detectHardware()` low-tier path (`game.js:242`), keeping the render-quality changes (pixelRatio/shadows).
- **Kept** the manual `_setQuality('low')` disable (`game.js:3150`) — an explicit user perf choice.

A genuinely slow machine still self-disables recording via the recorder's probe, so this doesn't regress low-end devices — it only stops a mis-classification from killing a feature the purpose-built probe says is fine.

## Notes
- Pre-existing bug (on `main`), unrelated to #324.
- Separate, larger concern (not fixed here): the hardware-detect heuristic itself mis-classifying capable desktops as low-tier (affects *render* quality too). Worth a follow-up.
- `node --check` passes.

## Testing
Desktop where clips were absent: with this change the 🎬 button appears during a ride without forcing `?quality=high`; capture → SAVE/DISCARD preview works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)