### PR TITLE
Migrate game.js overlay nav to FocusController (#318 Step 1, 2nd migration)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -11,6 +11,7 @@ import { CollectibleManager } from './collectibles.js';
 import { ObstacleManager } from './obstacles.js';
 import { AchievementManager, showAchievementToast, updateBadgeDisplay } from './achievements.js';
 import { InputManager, readDualSenseSourcePref, readGyroRollMode } from './input-manager.js';
+import { FocusController } from './nav/focus-controller.js';
 import { PedalController } from './pedal-controller.js';
 import { SharedPedalController } from './shared-pedal-controller.js';
 import { BalanceController } from './balance-controller.js';
@@ -485,12 +486,16 @@ class Game {
       this._returnToLobby();
     });
 
-    // Overlay gamepad navigation (game-over & victory)
-    this._overlayButtons = [];
-    this._overlayFocusIdx = 0;
-    this._olPrevUp = false;
-    this._olPrevDown = false;
-    this._olPrevA = false;
+    // Overlay gamepad navigation (game-over, victory, disconnect, tutorial-end,
+    // options, input-choice) — driven by the shared nav-core FocusController
+    // (#318). Vertical button stack + an optional slider (steering-feel), with
+    // a confirm cooldown (_overlayCooldownUntil) so a held A / a just-opened
+    // victory screen can't be dismissed instantly.
+    this._overlayFocus = new FocusController({
+      input: this.input,
+      orientation: 'vertical',
+      canConfirm: () => performance.now() >= this._overlayCooldownUntil,
+    });
 
     // Game state
     this.state = 'lobby'; // 'lobby' | 'instructions' | 'countdown' | 'playing' | 'finishCinematic' | 'gameover' | 'victory'
@@ -3289,99 +3294,18 @@ class Game {
   // OVERLAY GAMEPAD NAVIGATION (game-over & victory)
   // ============================================================
 
+  // Overlay gamepad nav now delegates to the shared FocusController (#318).
+  // These wrappers keep the existing call sites unchanged.
   _setOverlayButtons(buttons, initialFocus = 0) {
-    this._overlayButtons = buttons.filter(Boolean);
-    this._overlayFocusIdx = Math.min(initialFocus, this._overlayButtons.length - 1);
-    this._olPrevUp = false;
-    this._olPrevDown = false;
-    this._olPrevLeft = false;
-    this._olPrevRight = false;
-    this._olPrevA = false;
-    if (this._overlayButtons.length > 0) {
-      this._overlayButtons[this._overlayFocusIdx].classList.add('gamepad-focus');
-    }
+    this._overlayFocus.setItems(buttons, initialFocus);
   }
 
   _clearOverlayButtons() {
-    for (const btn of this._overlayButtons) btn.classList.remove('gamepad-focus');
-    this._overlayButtons = [];
-    this._overlaySlider = null;
+    this._overlayFocus.clear();
   }
 
   _pollOverlayGamepad() {
-    if (this._overlayButtons.length === 0) return;
-    if (!this.input.gamepadConnected) return;
-    const gp = this.input.getGamepadState();
-    if (!gp) return;
-
-    const up = (gp.buttons[12] && gp.buttons[12].pressed) || gp.axes[1] < -0.5;
-    const down = (gp.buttons[13] && gp.buttons[13].pressed) || gp.axes[1] > 0.5;
-    const left = (gp.buttons[14] && gp.buttons[14].pressed) || gp.axes[0] < -0.5;
-    const right = (gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5;
-    const aIdx = this.input._gpSwapAB ? 1 : 0;
-    const a = gp.buttons[aIdx] && gp.buttons[aIdx].pressed;
-
-    if (up && !this._olPrevUp) {
-      this._overlayButtons[this._overlayFocusIdx].classList.remove('gamepad-focus');
-      this._overlayFocusIdx = Math.max(0, this._overlayFocusIdx - 1);
-      this._overlayButtons[this._overlayFocusIdx].classList.add('gamepad-focus');
-    }
-    if (down && !this._olPrevDown) {
-      this._overlayButtons[this._overlayFocusIdx].classList.remove('gamepad-focus');
-      this._overlayFocusIdx = Math.min(this._overlayButtons.length - 1, this._overlayFocusIdx + 1);
-      this._overlayButtons[this._overlayFocusIdx].classList.add('gamepad-focus');
-    }
-
-    // Left/right: always drive the overlay slider if one is registered
-    const slider = this._overlaySlider;
-    if (slider) {
-      const rawX = gp.axes[0] || 0;
-      const deadzone = 0.12;
-      let changed = false;
-
-      // Analog stick: continuous proportional movement
-      if (Math.abs(rawX) > deadzone) {
-        const speed = rawX * 1.5; // ~1.5 units/frame at full deflection (60fps = full sweep in ~1s)
-        slider.value = Math.min(Number(slider.max), Math.max(Number(slider.min), Number(slider.value) + speed));
-        changed = true;
-      }
-
-      // D-pad: repeating discrete steps (fires on press, then repeats while held)
-      if (left) {
-        if (!this._olPrevLeft) {
-          slider.value = Math.max(Number(slider.min), Number(slider.value) - 3);
-          changed = true;
-          this._olDpadRepeatTime = performance.now() + 400; // initial delay
-        } else if (performance.now() > this._olDpadRepeatTime) {
-          slider.value = Math.max(Number(slider.min), Number(slider.value) - 2);
-          changed = true;
-          this._olDpadRepeatTime = performance.now() + 80; // repeat rate
-        }
-      }
-      if (right) {
-        if (!this._olPrevRight) {
-          slider.value = Math.min(Number(slider.max), Number(slider.value) + 3);
-          changed = true;
-          this._olDpadRepeatTime = performance.now() + 400;
-        } else if (performance.now() > this._olDpadRepeatTime) {
-          slider.value = Math.min(Number(slider.max), Number(slider.value) + 2);
-          changed = true;
-          this._olDpadRepeatTime = performance.now() + 80;
-        }
-      }
-
-      if (changed) slider.dispatchEvent(new Event('input'));
-    }
-
-    if (a && !this._olPrevA && performance.now() >= this._overlayCooldownUntil) {
-      this._overlayButtons[this._overlayFocusIdx].click();
-    }
-
-    this._olPrevUp = up;
-    this._olPrevDown = down;
-    this._olPrevLeft = left;
-    this._olPrevRight = right;
-    this._olPrevA = a;
+    this._overlayFocus.poll();
   }
 
   // ============================================================
@@ -5027,7 +4951,7 @@ class Game {
     if (steamStoreBtn) overlayBtns.push(steamStoreBtn);
     overlayBtns.push(continueBtn);
     this._setOverlayButtons(overlayBtns, overlayBtns.length - 1);
-    this._overlaySlider = slider;
+    this._overlayFocus.setSlider(slider);
 
     if (isMobile) {
       this._overlayCooldownUntil = performance.now() + 3000;
@@ -5070,7 +4994,7 @@ class Game {
 
     const overlayBtns = [continueBtn];
     this._setOverlayButtons(overlayBtns, 0);
-    this._overlaySlider = slider;
+    this._overlayFocus.setSlider(slider);
 
     if (isMobile) {
       this._overlayCooldownUntil = performance.now() + 3000;

--- a/js/nav/focus-controller.js
+++ b/js/nav/focus-controller.js
@@ -33,16 +33,38 @@ export class FocusController {
    * @param {()=>void} [opts.onBack] — B-button action. No-op if omitted.
    * @param {(el:Element, index:number)=>void} [opts.onChange] — fired after
    *   focus moves to a new item.
+   * @param {'both'|'vertical'} [opts.orientation='both'] — which axes move
+   *   focus. 'both' (default): up/down AND left/right step the flat list (for
+   *   narrow button stacks). 'vertical': only up/down move focus, leaving
+   *   left/right for a registered slider.
+   * @param {()=>boolean} [opts.canConfirm] — optional gate; confirm is ignored
+   *   while it returns false (e.g. an overlay's "can't dismiss yet" cooldown).
    */
-  constructor({ input, focusClass = 'gamepad-focus', onConfirm = null, onBack = null, onChange = null } = {}) {
+  constructor({ input, focusClass = 'gamepad-focus', onConfirm = null, onBack = null, onChange = null, orientation = 'both', canConfirm = null } = {}) {
     this.input = input;
     this.focusClass = focusClass;
     this._onConfirm = onConfirm;
     this._onBack = onBack;
     this._onChange = onChange;
+    this._orientation = orientation;
+    this._canConfirm = canConfirm;
     this.items = [];
     this.index = 0;
     this._edge = { ...NO_EDGES };
+    // Optional range <input> driven by left/right (analog + d-pad repeat).
+    this._slider = null;
+    this._sliderRepeatAt = 0;
+  }
+
+  /**
+   * Register (or clear) a range <input> that left/right drives instead of
+   * moving focus — analog stick is continuous/proportional, d-pad steps with a
+   * press-then-repeat cadence. Pass null to detach.
+   */
+  setSlider(el) {
+    this._slider = el || null;
+    this._sliderRepeatAt = 0;
+    return this;
   }
 
   /**
@@ -60,25 +82,63 @@ export class FocusController {
     return this;
   }
 
-  /** Remove focus styling and drop the item list. */
+  /** Remove focus styling, drop the item list, and detach any slider. */
   clear() {
     this._clearFocus();
     this.items = [];
     this.index = 0;
+    this._slider = null;
   }
 
   /**
-   * Read the pad once and dispatch nav / confirm / back via edge detection.
-   * The caller drives this each frame; the controller does not schedule.
+   * Read the pad once and dispatch nav / slider / confirm / back via edge
+   * detection. The caller drives this each frame; the controller does not
+   * schedule.
    */
   poll() {
     const e = this._readEdges();
     if (!e) return;
-    if ((e.up && !this._edge.up) || (e.left && !this._edge.left)) this.move(-1);
-    if ((e.down && !this._edge.down) || (e.right && !this._edge.right)) this.move(1);
-    if (e.a && !this._edge.a) this.confirm();
-    if (e.b && !this._edge.b) this.back();
+    const prev = this._edge;
+
+    if (this._slider) {
+      // Slider consumes the horizontal axis; focus moves on up/down only.
+      this._driveSlider(e, prev);
+    } else if (this._orientation === 'both') {
+      if (e.left && !prev.left) this.move(-1);
+      if (e.right && !prev.right) this.move(1);
+    }
+    if (e.up && !prev.up) this.move(-1);
+    if (e.down && !prev.down) this.move(1);
+    if (e.a && !prev.a && (!this._canConfirm || this._canConfirm())) this.confirm();
+    if (e.b && !prev.b) this.back();
+
     this._edge = e;
+  }
+
+  /** Drive the registered slider from the horizontal axis (analog + d-pad). */
+  _driveSlider(e, prev) {
+    const s = this._slider;
+    const min = Number(s.min), max = Number(s.max);
+    const clampS = (v) => Math.min(max, Math.max(min, v));
+    let changed = false;
+
+    // Analog stick: continuous proportional movement (~full sweep in ~1s @60Hz).
+    if (Math.abs(e.axisX) > 0.12) {
+      s.value = clampS(Number(s.value) + e.axisX * 1.5);
+      changed = true;
+    }
+    // D-pad: discrete step on press, then repeat while held (400ms → 80ms).
+    const now = performance.now();
+    const step = (dir, firstMag, repMag) => {
+      if (!(dir === -1 ? e.left : e.right)) return;
+      const held = dir === -1 ? prev.left : prev.right;
+      if (!held) { s.value = clampS(Number(s.value) + dir * firstMag); changed = true; this._sliderRepeatAt = now + 400; }
+      else if (now > this._sliderRepeatAt) { s.value = clampS(Number(s.value) + dir * repMag); changed = true; this._sliderRepeatAt = now + 80; }
+    };
+    step(-1, 3, 2);
+    step(1, 3, 2);
+
+    if (changed) s.dispatchEvent(new Event('input'));
   }
 
   /** Move focus by `dir` (clamped — no wrap, matching the existing loops). */
@@ -128,6 +188,7 @@ export class FocusController {
       right: !!((gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5),
       a: !!(gp.buttons[aIdx] && gp.buttons[aIdx].pressed),
       b: !!(gp.buttons[bIdx] && gp.buttons[bIdx].pressed),
+      axisX: gp.axes[0] || 0, // raw, for slider control
     };
   }
 


### PR DESCRIPTION
Second nav-core migration (after #324's clip-preview PoC). Moves the in-game **overlay** gamepad navigation onto the shared `FocusController`, and extends it with the only features the overlays needed beyond a flat button list.

## What moved
`game.js`'s `_pollOverlayGamepad` / `_setOverlayButtons` / `_clearOverlayButtons` (the loop behind **game-over, victory, disconnect, tutorial-complete, options, and the input-choice** overlays) now **delegate** to one `FocusController`. The ~12 call sites are unchanged. Removed `_overlayButtons` / `_overlayFocusIdx` / `_olPrev*` / `_overlaySlider` / `_olDpadRepeatTime`.

## FocusController extensions (backward-compatible — preview still default)
- **`orientation: 'vertical'`** — up/down move focus; left/right reserved for a slider. (Default stays `'both'`, so #324's preview is unaffected.)
- **`setSlider(el)`** — a range `<input>` driven by left/right: analog stick continuous/proportional (deadzone 0.12, ×1.5), d-pad press-then-repeat (400ms → 80ms, ±3 then ±2). Ported verbatim from the old loop (the steering-feel slider on tutorial-complete).
- **`canConfirm` hook** — gates the A press on the existing `_overlayCooldownUntil`, preserving the "can't dismiss the victory screen for N seconds / ignore a held A" behavior.

## Faithfulness
- Vertical button nav, slider feel, and confirm cooldown all preserved.
- Edge-state is now *primed* on open (held button won't fire) in addition to the cooldown — strictly safer, same net behavior.
- `node --check` passes on both files.

## Please validate with a gamepad before merge (critical UI)
- **Game Over / Victory:** D-pad up/down moves the highlight, A activates, and you can't instantly dismiss victory (cooldown).
- **Tutorial-complete:** left/right (stick + d-pad) adjusts the **steering-feel slider**; up/down moves between it and Continue.
- **Options & disconnect overlays:** D-pad + A still navigate.

Next in the sequence: the lobby menus + 5 modals (which also resolves the #325 nav bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)