### PR TITLE
Lobby step nav → spatial FocusController (#318 Step 1, lobby)

### DIFF
--- a/js/lobby.js
+++ b/js/lobby.js
@@ -4257,6 +4257,10 @@ export class Lobby {
         this._gpPrevRight = (gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5;
       }
     }
+    // Set up the spatial step focus for the current step on (re)start — initial
+    // load and show() set _currentStep directly without going through
+    // _showStep, so the highlight + d-pad/stick nav need seeding here too (#318).
+    this._applyStepSpatialFocus(this._currentStep);
     this._pollGamepadNav();
   }
 
@@ -4615,8 +4619,13 @@ export class Lobby {
     }
 
     // Step navigation: delegated to the spatial FocusController (#318).
-    // Re-prime its edges when returning from a modal (ranLast captured at the
-    // top of this poll) so a held button across the transition isn't read as a
+    // Lazily seed the scope the first time we run with a gamepad — covers
+    // controllers that connect async without a 'gamepadconnected' event (e.g.
+    // a WebHID DualSense), which otherwise left the mode screen un-navigable
+    // until the first _showStep.
+    if (this._stepFocus.items.length === 0) this._applyStepSpatialFocus(this._currentStep);
+    // Re-prime edges when returning from a modal (ranLast captured at the top
+    // of this poll) so a held button across the transition isn't read as a
     // fresh press.
     if (!ranLast) this._stepFocus.reprime();
     this._stepNavRanLastFrame = true;

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -45,6 +45,7 @@ import { LicenseManager } from './license.js';
 import { AchievementManager, updateBadgeDisplay } from './achievements.js';
 import * as analytics from './analytics.js';
 import { ControllerRegistry } from '../shared/drivers/controller-registry.js';
+import { FocusController } from './nav/focus-controller.js';
 
 // Timeout wrapper for permission promises that may hang on iOS stale tabs
 const PERMISSION_TIMEOUT_MS = 8000;
@@ -206,6 +207,18 @@ export class Lobby {
     this._focusIndex = 0;
     this._currentStep = null;
     this._pollRafId = null;
+    // Step navigation (mode/level/role/host/join/room) now uses the shared
+    // nav-core FocusController in spatial mode (#318): directions move to the
+    // nearest on-screen focusable, dissolving the old _modeColumns/_moveColumn/
+    // _modeColIndex column math and the difficulty-sibling special-casing.
+    // (Modals — profile/leaderboard/help/rejoin/spinner — still use the
+    // hand-rolled branches in _pollGamepadNav for now.)
+    this._stepFocus = new FocusController({
+      input: this.input,
+      onConfirm: (el) => { if (el.tagName === 'INPUT') el.focus(); else el.click(); },
+      onBack: () => this._goBack(),
+    });
+    this._stepNavRanLastFrame = false; // for reprime() on modal→step transitions
     this._gpPrevUp = false;
     this._gpPrevDown = false;
     this._gpPrevA = false;
@@ -675,8 +688,7 @@ export class Lobby {
     this._modeColumns[1] = centerItems;
     this._stepItems.set(step, centerItems);
 
-    this._focusIndex = this._stepDefaultFocus.get(step) || 0;
-    this._applyFocusHighlight();
+    this._applyStepSpatialFocus(step);
     this._updateBackHint(step);
     this._updateCardHeader(step);
     if (step === this.levelStep) {
@@ -1160,6 +1172,8 @@ export class Lobby {
       if (this._modeCol === 1) {
         this._stepItems.set(this.levelStep, centerItems);
       }
+      // Refresh the spatial scope so newly-built cards are navigable (#318).
+      this._applyStepSpatialFocus(this.levelStep);
     }
   }
 
@@ -2599,6 +2613,8 @@ export class Lobby {
       }
       // Defer so input-manager's gamepadconnected handler has set gamepadConnected
       setTimeout(() => this._updateBackHint(this._currentStep), 0);
+      // Set up spatial step focus now that a gamepad is present (#318).
+      this._applyStepSpatialFocus(this._currentStep);
       // Switch to spinners if currently on join step
       if (this._currentStep === this.joinStep) {
         if (this._lastFailedCode) {
@@ -4396,6 +4412,12 @@ export class Lobby {
   _pollGamepadNav() {
     this._pollRafId = requestAnimationFrame(() => this._pollGamepadNav());
 
+    // Whether the step-nav section ran last frame. Reset each frame; set true
+    // only when we reach it, so a modal frame (early return) flips it false and
+    // the next step frame re-primes the spatial controller's edges (#318).
+    const ranLast = this._stepNavRanLastFrame;
+    this._stepNavRanLastFrame = false;
+
     if (!this.input || !this.input.gamepadConnected) return;
 
     // Don't process lobby navigation while options overlay is open
@@ -4592,14 +4614,15 @@ export class Lobby {
       return;
     }
 
-    // Edge detection: fire on press, not hold
-    if (up && !this._gpPrevUp) this._moveFocus(-1);
-    if (down && !this._gpPrevDown) this._moveFocus(1);
-    if (left && !this._gpPrevLeft) this._moveColumn(-1);
-    if (right && !this._gpPrevRight) this._moveColumn(1);
-    if (a && !this._gpPrevA) this._confirmFocus();
-    if (b && !this._gpPrevB) this._goBack();
+    // Step navigation: delegated to the spatial FocusController (#318).
+    // Re-prime its edges when returning from a modal (ranLast captured at the
+    // top of this poll) so a held button across the transition isn't read as a
+    // fresh press.
+    if (!ranLast) this._stepFocus.reprime();
+    this._stepNavRanLastFrame = true;
+    this._stepFocus.poll();
 
+    // _gpPrev* are still maintained for the LB/RB bumpers + the modal branches.
     this._gpPrevUp = up;
     this._gpPrevDown = down;
     this._gpPrevLeft = left;
@@ -4742,6 +4765,25 @@ export class Lobby {
   _clearFocusHighlight() {
     const prev = this.lobbyEl.querySelector('.gamepad-focus');
     if (prev) prev.classList.remove('gamepad-focus');
+  }
+
+  /**
+   * Hand the current step's full focusable set (all toggle columns + the
+   * active step's center items) to the spatial FocusController, focusing the
+   * step's default item. Only highlights when a gamepad is connected (matching
+   * the old _applyFocusHighlight gate). Called from _showStep and on gamepad
+   * hot-connect. (#318)
+   */
+  _applyStepSpatialFocus(step) {
+    if (!step) return;
+    if (this.input && this.input.gamepadConnected) {
+      const centerItems = this._stepCenterItems.get(step) || [];
+      this._modeColumns[1] = centerItems;
+      const defaultEl = centerItems[this._stepDefaultFocus.get(step) || 0] || null;
+      this._stepFocus.setSpatial(this._modeColumns.flat(), defaultEl);
+    } else {
+      this._stepFocus.clear();
+    }
   }
 
   // ============================================================

--- a/js/nav/focus-controller.js
+++ b/js/nav/focus-controller.js
@@ -54,6 +54,30 @@ export class FocusController {
     // Optional range <input> driven by left/right (analog + d-pad repeat).
     this._slider = null;
     this._sliderRepeatAt = 0;
+    // Spatial (neighbor) mode: focus tracked by element, directions resolve to
+    // the nearest visible focusable on-screen (with optional data-nav-*
+    // overrides) instead of index math. Used for 2-D screens like the lobby.
+    this._spatial = false;
+    this.focusedEl = null;
+  }
+
+  /**
+   * Spatial/neighbor mode (#318): register a flat set of focusables laid out in
+   * 2-D. Directions move to the nearest VISIBLE neighbor by on-screen geometry
+   * — dissolving column/row/sibling special-casing — or follow an explicit
+   * `data-nav-up|down|left|right="targetId"` if present. Hidden items are
+   * skipped automatically at move time. Confirm/back behave as in linear mode.
+   */
+  setSpatial(items, initialEl = null) {
+    this._clearSpatialFocus();
+    this.items = (items || []).filter(Boolean);
+    this._spatial = true;
+    this.focusedEl =
+      (initialEl && this.items.indexOf(initialEl) >= 0 && this._visible(initialEl)) ? initialEl :
+      (this.items.find((el) => this._visible(el)) || null);
+    this._edge = this._readEdges() || { ...NO_EDGES };
+    if (this.focusedEl) this.focusedEl.classList.add(this.focusClass);
+    return this;
   }
 
   /**
@@ -82,12 +106,14 @@ export class FocusController {
     return this;
   }
 
-  /** Remove focus styling, drop the item list, and detach any slider. */
+  /** Remove focus styling, drop the item list, and reset slider/spatial state. */
   clear() {
     this._clearFocus();
+    this._clearSpatialFocus();
     this.items = [];
     this.index = 0;
     this._slider = null;
+    this._spatial = false;
   }
 
   /**
@@ -99,6 +125,17 @@ export class FocusController {
     const e = this._readEdges();
     if (!e) return;
     const prev = this._edge;
+
+    if (this._spatial) {
+      if (e.up && !prev.up) this._moveDir('up');
+      if (e.down && !prev.down) this._moveDir('down');
+      if (e.left && !prev.left) this._moveDir('left');
+      if (e.right && !prev.right) this._moveDir('right');
+      if (e.a && !prev.a && (!this._canConfirm || this._canConfirm())) this._confirmSpatial();
+      if (e.b && !prev.b) this.back();
+      this._edge = e;
+      return;
+    }
 
     if (this._slider) {
       // Slider consumes the horizontal axis; focus moves on up/down only.
@@ -163,9 +200,88 @@ export class FocusController {
     if (this._onBack) this._onBack();
   }
 
+  /**
+   * Re-sync edge state to the pad's current state without moving focus. Call
+   * when control returns to this scope after another scope (e.g. a modal)
+   * consumed input, so a button still held across the transition isn't read as
+   * a fresh press.
+   */
+  reprime() {
+    this._edge = this._readEdges() || { ...NO_EDGES };
+  }
+
   /** Currently focused element, or null. */
   get focused() {
-    return this.items[this.index] || null;
+    return this._spatial ? this.focusedEl : (this.items[this.index] || null);
+  }
+
+  // ── spatial (neighbor) mode ──
+
+  /** Move focus to the nearest visible neighbor in `dir` (or a data-nav override). */
+  _moveDir(dir) {
+    if (!this.focusedEl) {
+      this.focusedEl = this.items.find((el) => this._visible(el)) || null;
+      if (this.focusedEl) this.focusedEl.classList.add(this.focusClass);
+      return;
+    }
+    const target = this._explicitNeighbor(this.focusedEl, dir) || this._spatialNeighbor(this.focusedEl, dir);
+    if (!target || target === this.focusedEl) return;
+    this.focusedEl.classList.remove(this.focusClass);
+    this.focusedEl = target;
+    target.classList.add(this.focusClass);
+    if (this._onChange) this._onChange(target, this.items.indexOf(target));
+  }
+
+  _confirmSpatial() {
+    const el = this.focusedEl;
+    if (!el) return;
+    if (this._onConfirm) this._onConfirm(el, this.items.indexOf(el));
+    else el.click();
+  }
+
+  /** Follow an explicit data-nav-{dir}="targetId" neighbor if it's valid+visible. */
+  _explicitNeighbor(el, dir) {
+    const key = 'nav' + dir.charAt(0).toUpperCase() + dir.slice(1); // navUp/navDown/...
+    const id = el.dataset && el.dataset[key];
+    if (!id) return null;
+    const target = document.getElementById(id);
+    return (target && this.items.indexOf(target) >= 0 && this._visible(target)) ? target : null;
+  }
+
+  /** Nearest visible focusable in `dir` by center-to-center geometry. */
+  _spatialNeighbor(el, dir) {
+    const r = el.getBoundingClientRect();
+    const cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+    let best = null, bestScore = Infinity;
+    for (const other of this.items) {
+      if (other === el || !this._visible(other)) continue;
+      const rr = other.getBoundingClientRect();
+      const ox = rr.left + rr.width / 2, oy = rr.top + rr.height / 2;
+      const dx = ox - cx, dy = oy - cy;
+      // Must lie in the pressed direction (with a small tolerance).
+      if (dir === 'left'  && dx > -1) continue;
+      if (dir === 'right' && dx <  1) continue;
+      if (dir === 'up'    && dy > -1) continue;
+      if (dir === 'down'  && dy <  1) continue;
+      const horizontal = (dir === 'left' || dir === 'right');
+      const primary = horizontal ? Math.abs(dx) : Math.abs(dy);
+      const perp = horizontal ? Math.abs(dy) : Math.abs(dx);
+      // Prefer aligned neighbors: weight the off-axis distance heavily.
+      const score = primary + perp * 3;
+      if (score < bestScore) { bestScore = score; best = other; }
+    }
+    return best;
+  }
+
+  _visible(el) {
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0; // display:none / detached → zero box
+  }
+
+  _clearSpatialFocus() {
+    if (this.focusedEl) this.focusedEl.classList.remove(this.focusClass);
+    this.focusedEl = null;
   }
 
   // ── internals ──


### PR DESCRIPTION
**Stacked on #327** (base is the overlays branch, since both extend `FocusController`). The diff here is just the lobby change. Review/merge #327 first.

Implements the **spatial / neighbor model** you chose for the trickiest part — the lobby column toggles.

## The idea
Instead of porting the column math, this **dissolves** it: the controller moves focus to the **nearest visible focusable in the pressed direction by on-screen geometry** (with optional `data-nav-up|down|left|right="id"` overrides). Hidden toggles are auto-skipped (zero box), so left/right "into the toggle columns", up/down through a list, and the difficulty-button row all just work from layout — no `_modeColumns` / `_moveColumn` / `_modeColIndex` / sibling special-casing.

## Changes
- **`FocusController`**: `setSpatial(items, initialEl)`, geometry-based `_spatialNeighbor` (perpendicular-weighted so aligned neighbors win) + `_explicitNeighbor` (data-nav), and `reprime()`.
- **`lobby.js`**: `_stepFocus` drives all steps; `_showStep`, the level-card rebuild, and **gamepad hot-connect** feed it the step's full focusable set (`_modeColumns.flat()`); `_pollGamepadNav`'s step section is now `_stepFocus.poll()` with a `ranLast` reprime on modal→step transitions. Modals (profile/leaderboard/help/rejoin/spinner) and LB/RB bumpers untouched. The old `_moveFocus`/`_moveColumn` are now dead (left as a fallback this PR; remove after validation).

## ⚠️ Please gamepad-validate before merge — this is the main menu
Focus on the column/toggle behavior you flagged:
- **Mode screen:** left/right crosses from the center buttons **into the left toggles (help/star/profile) and the right ones (ALL/camera/music/mic)** and back; up/down moves within a column. Row position feels natural when crossing.
- **Level screen:** up/down through level cards; **left/right across the difficulty buttons**; up/down from the difficulty row back to a card.
- **Role/host/join/room** steps: up/down/left/right land on the right controls; **A** activates, **B** backs out; room-code input gets focus (not click).
- **Modals still work:** open profile/leaderboard/help/rejoin/spinner with A, navigate, close with B — then confirm step nav resumes cleanly (the reprime) with **no stray click/back** from the button you held to close.
- **Hot-connect:** connect the pad while already in the lobby → a highlight appears and nav works.

If anything feels off, tell me which screen/direction and I'll adjust the geometry weighting or add `data-nav` overrides there.

Next (not in this PR): migrate the 5 modal branches themselves, then delete the dead column methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)