### PR TITLE
Lobby step nav → spatial FocusController (#318 Step 1, lobby)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -11,6 +11,7 @@ import { CollectibleManager } from './collectibles.js';
 import { ObstacleManager } from './obstacles.js';
 import { AchievementManager, showAchievementToast, updateBadgeDisplay } from './achievements.js';
 import { InputManager, readDualSenseSourcePref, readGyroRollMode } from './input-manager.js';
+import { FocusController } from './nav/focus-controller.js';
 import { PedalController } from './pedal-controller.js';
 import { SharedPedalController } from './shared-pedal-controller.js';
 import { BalanceController } from './balance-controller.js';
@@ -485,12 +486,16 @@ class Game {
       this._returnToLobby();
     });
 
-    // Overlay gamepad navigation (game-over & victory)
-    this._overlayButtons = [];
-    this._overlayFocusIdx = 0;
-    this._olPrevUp = false;
-    this._olPrevDown = false;
-    this._olPrevA = false;
+    // Overlay gamepad navigation (game-over, victory, disconnect, tutorial-end,
+    // options, input-choice) — driven by the shared nav-core FocusController
+    // (#318). Vertical button stack + an optional slider (steering-feel), with
+    // a confirm cooldown (_overlayCooldownUntil) so a held A / a just-opened
+    // victory screen can't be dismissed instantly.
+    this._overlayFocus = new FocusController({
+      input: this.input,
+      orientation: 'vertical',
+      canConfirm: () => performance.now() >= this._overlayCooldownUntil,
+    });
 
     // Game state
     this.state = 'lobby'; // 'lobby' | 'instructions' | 'countdown' | 'playing' | 'finishCinematic' | 'gameover' | 'victory'
@@ -3289,99 +3294,18 @@ class Game {
   // OVERLAY GAMEPAD NAVIGATION (game-over & victory)
   // ============================================================
 
+  // Overlay gamepad nav now delegates to the shared FocusController (#318).
+  // These wrappers keep the existing call sites unchanged.
   _setOverlayButtons(buttons, initialFocus = 0) {
-    this._overlayButtons = buttons.filter(Boolean);
-    this._overlayFocusIdx = Math.min(initialFocus, this._overlayButtons.length - 1);
-    this._olPrevUp = false;
-    this._olPrevDown = false;
-    this._olPrevLeft = false;
-    this._olPrevRight = false;
-    this._olPrevA = false;
-    if (this._overlayButtons.length > 0) {
-      this._overlayButtons[this._overlayFocusIdx].classList.add('gamepad-focus');
-    }
+    this._overlayFocus.setItems(buttons, initialFocus);
   }
 
   _clearOverlayButtons() {
-    for (const btn of this._overlayButtons) btn.classList.remove('gamepad-focus');
-    this._overlayButtons = [];
-    this._overlaySlider = null;
+    this._overlayFocus.clear();
   }
 
   _pollOverlayGamepad() {
-    if (this._overlayButtons.length === 0) return;
-    if (!this.input.gamepadConnected) return;
-    const gp = this.input.getGamepadState();
-    if (!gp) return;
-
-    const up = (gp.buttons[12] && gp.buttons[12].pressed) || gp.axes[1] < -0.5;
-    const down = (gp.buttons[13] && gp.buttons[13].pressed) || gp.axes[1] > 0.5;
-    const left = (gp.buttons[14] && gp.buttons[14].pressed) || gp.axes[0] < -0.5;
-    const right = (gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5;
-    const aIdx = this.input._gpSwapAB ? 1 : 0;
-    const a = gp.buttons[aIdx] && gp.buttons[aIdx].pressed;
-
-    if (up && !this._olPrevUp) {
-      this._overlayButtons[this._overlayFocusIdx].classList.remove('gamepad-focus');
-      this._overlayFocusIdx = Math.max(0, this._overlayFocusIdx - 1);
-      this._overlayButtons[this._overlayFocusIdx].classList.add('gamepad-focus');
-    }
-    if (down && !this._olPrevDown) {
-      this._overlayButtons[this._overlayFocusIdx].classList.remove('gamepad-focus');
-      this._overlayFocusIdx = Math.min(this._overlayButtons.length - 1, this._overlayFocusIdx + 1);
-      this._overlayButtons[this._overlayFocusIdx].classList.add('gamepad-focus');
-    }
-
-    // Left/right: always drive the overlay slider if one is registered
-    const slider = this._overlaySlider;
-    if (slider) {
-      const rawX = gp.axes[0] || 0;
-      const deadzone = 0.12;
-      let changed = false;
-
-      // Analog stick: continuous proportional movement
-      if (Math.abs(rawX) > deadzone) {
-        const speed = rawX * 1.5; // ~1.5 units/frame at full deflection (60fps = full sweep in ~1s)
-        slider.value = Math.min(Number(slider.max), Math.max(Number(slider.min), Number(slider.value) + speed));
-        changed = true;
-      }
-
-      // D-pad: repeating discrete steps (fires on press, then repeats while held)
-      if (left) {
-        if (!this._olPrevLeft) {
-          slider.value = Math.max(Number(slider.min), Number(slider.value) - 3);
-          changed = true;
-          this._olDpadRepeatTime = performance.now() + 400; // initial delay
-        } else if (performance.now() > this._olDpadRepeatTime) {
-          slider.value = Math.max(Number(slider.min), Number(slider.value) - 2);
-          changed = true;
-          this._olDpadRepeatTime = performance.now() + 80; // repeat rate
-        }
-      }
-      if (right) {
-        if (!this._olPrevRight) {
-          slider.value = Math.min(Number(slider.max), Number(slider.value) + 3);
-          changed = true;
-          this._olDpadRepeatTime = performance.now() + 400;
-        } else if (performance.now() > this._olDpadRepeatTime) {
-          slider.value = Math.min(Number(slider.max), Number(slider.value) + 2);
-          changed = true;
-          this._olDpadRepeatTime = performance.now() + 80;
-        }
-      }
-
-      if (changed) slider.dispatchEvent(new Event('input'));
-    }
-
-    if (a && !this._olPrevA && performance.now() >= this._overlayCooldownUntil) {
-      this._overlayButtons[this._overlayFocusIdx].click();
-    }
-
-    this._olPrevUp = up;
-    this._olPrevDown = down;
-    this._olPrevLeft = left;
-    this._olPrevRight = right;
-    this._olPrevA = a;
+    this._overlayFocus.poll();
   }
 
   // ============================================================
@@ -5027,7 +4951,7 @@ class Game {
     if (steamStoreBtn) overlayBtns.push(steamStoreBtn);
     overlayBtns.push(continueBtn);
     this._setOverlayButtons(overlayBtns, overlayBtns.length - 1);
-    this._overlaySlider = slider;
+    this._overlayFocus.setSlider(slider);
 
     if (isMobile) {
       this._overlayCooldownUntil = performance.now() + 3000;
@@ -5070,7 +4994,7 @@ class Game {
 
     const overlayBtns = [continueBtn];
     this._setOverlayButtons(overlayBtns, 0);
-    this._overlaySlider = slider;
+    this._overlayFocus.setSlider(slider);
 
     if (isMobile) {
       this._overlayCooldownUntil = performance.now() + 3000;

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -4257,6 +4257,10 @@ export class Lobby {
         this._gpPrevRight = (gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5;
       }
     }
+    // Set up the spatial step focus for the current step on (re)start — initial
+    // load and show() set _currentStep directly without going through
+    // _showStep, so the highlight + d-pad/stick nav need seeding here too (#318).
+    this._applyStepSpatialFocus(this._currentStep);
     this._pollGamepadNav();
   }
 
@@ -4615,8 +4619,13 @@ export class Lobby {
     }
 
     // Step navigation: delegated to the spatial FocusController (#318).
-    // Re-prime its edges when returning from a modal (ranLast captured at the
-    // top of this poll) so a held button across the transition isn't read as a
+    // Lazily seed the scope the first time we run with a gamepad — covers
+    // controllers that connect async without a 'gamepadconnected' event (e.g.
+    // a WebHID DualSense), which otherwise left the mode screen un-navigable
+    // until the first _showStep.
+    if (this._stepFocus.items.length === 0) this._applyStepSpatialFocus(this._currentStep);
+    // Re-prime edges when returning from a modal (ranLast captured at the top
+    // of this poll) so a held button across the transition isn't read as a
     // fresh press.
     if (!ranLast) this._stepFocus.reprime();
     this._stepNavRanLastFrame = true;

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -45,6 +45,7 @@ import { LicenseManager } from './license.js';
 import { AchievementManager, updateBadgeDisplay } from './achievements.js';
 import * as analytics from './analytics.js';
 import { ControllerRegistry } from '../shared/drivers/controller-registry.js';
+import { FocusController } from './nav/focus-controller.js';
 
 // Timeout wrapper for permission promises that may hang on iOS stale tabs
 const PERMISSION_TIMEOUT_MS = 8000;
@@ -206,6 +207,18 @@ export class Lobby {
     this._focusIndex = 0;
     this._currentStep = null;
     this._pollRafId = null;
+    // Step navigation (mode/level/role/host/join/room) now uses the shared
+    // nav-core FocusController in spatial mode (#318): directions move to the
+    // nearest on-screen focusable, dissolving the old _modeColumns/_moveColumn/
+    // _modeColIndex column math and the difficulty-sibling special-casing.
+    // (Modals — profile/leaderboard/help/rejoin/spinner — still use the
+    // hand-rolled branches in _pollGamepadNav for now.)
+    this._stepFocus = new FocusController({
+      input: this.input,
+      onConfirm: (el) => { if (el.tagName === 'INPUT') el.focus(); else el.click(); },
+      onBack: () => this._goBack(),
+    });
+    this._stepNavRanLastFrame = false; // for reprime() on modal→step transitions
     this._gpPrevUp = false;
     this._gpPrevDown = false;
     this._gpPrevA = false;
@@ -675,8 +688,7 @@ export class Lobby {
     this._modeColumns[1] = centerItems;
     this._stepItems.set(step, centerItems);
 
-    this._focusIndex = this._stepDefaultFocus.get(step) || 0;
-    this._applyFocusHighlight();
+    this._applyStepSpatialFocus(step);
     this._updateBackHint(step);
     this._updateCardHeader(step);
     if (step === this.levelStep) {
@@ -1160,6 +1172,8 @@ export class Lobby {
       if (this._modeCol === 1) {
         this._stepItems.set(this.levelStep, centerItems);
       }
+      // Refresh the spatial scope so newly-built cards are navigable (#318).
+      this._applyStepSpatialFocus(this.levelStep);
     }
   }
 
@@ -2599,6 +2613,8 @@ export class Lobby {
       }
       // Defer so input-manager's gamepadconnected handler has set gamepadConnected
       setTimeout(() => this._updateBackHint(this._currentStep), 0);
+      // Set up spatial step focus now that a gamepad is present (#318).
+      this._applyStepSpatialFocus(this._currentStep);
       // Switch to spinners if currently on join step
       if (this._currentStep === this.joinStep) {
         if (this._lastFailedCode) {
@@ -4396,6 +4412,12 @@ export class Lobby {
   _pollGamepadNav() {
     this._pollRafId = requestAnimationFrame(() => this._pollGamepadNav());
 
+    // Whether the step-nav section ran last frame. Reset each frame; set true
+    // only when we reach it, so a modal frame (early return) flips it false and
+    // the next step frame re-primes the spatial controller's edges (#318).
+    const ranLast = this._stepNavRanLastFrame;
+    this._stepNavRanLastFrame = false;
+
     if (!this.input || !this.input.gamepadConnected) return;
 
     // Don't process lobby navigation while options overlay is open
@@ -4592,14 +4614,15 @@ export class Lobby {
       return;
     }
 
-    // Edge detection: fire on press, not hold
-    if (up && !this._gpPrevUp) this._moveFocus(-1);
-    if (down && !this._gpPrevDown) this._moveFocus(1);
-    if (left && !this._gpPrevLeft) this._moveColumn(-1);
-    if (right && !this._gpPrevRight) this._moveColumn(1);
-    if (a && !this._gpPrevA) this._confirmFocus();
-    if (b && !this._gpPrevB) this._goBack();
+    // Step navigation: delegated to the spatial FocusController (#318).
+    // Re-prime its edges when returning from a modal (ranLast captured at the
+    // top of this poll) so a held button across the transition isn't read as a
+    // fresh press.
+    if (!ranLast) this._stepFocus.reprime();
+    this._stepNavRanLastFrame = true;
+    this._stepFocus.poll();
 
+    // _gpPrev* are still maintained for the LB/RB bumpers + the modal branches.
     this._gpPrevUp = up;
     this._gpPrevDown = down;
     this._gpPrevLeft = left;
@@ -4742,6 +4765,25 @@ export class Lobby {
   _clearFocusHighlight() {
     const prev = this.lobbyEl.querySelector('.gamepad-focus');
     if (prev) prev.classList.remove('gamepad-focus');
+  }
+
+  /**
+   * Hand the current step's full focusable set (all toggle columns + the
+   * active step's center items) to the spatial FocusController, focusing the
+   * step's default item. Only highlights when a gamepad is connected (matching
+   * the old _applyFocusHighlight gate). Called from _showStep and on gamepad
+   * hot-connect. (#318)
+   */
+  _applyStepSpatialFocus(step) {
+    if (!step) return;
+    if (this.input && this.input.gamepadConnected) {
+      const centerItems = this._stepCenterItems.get(step) || [];
+      this._modeColumns[1] = centerItems;
+      const defaultEl = centerItems[this._stepDefaultFocus.get(step) || 0] || null;
+      this._stepFocus.setSpatial(this._modeColumns.flat(), defaultEl);
+    } else {
+      this._stepFocus.clear();
+    }
   }
 
   // ============================================================

--- a/js/nav/focus-controller.js
+++ b/js/nav/focus-controller.js
@@ -33,16 +33,38 @@ export class FocusController {
    * @param {()=>void} [opts.onBack] — B-button action. No-op if omitted.
    * @param {(el:Element, index:number)=>void} [opts.onChange] — fired after
    *   focus moves to a new item.
+   * @param {'both'|'vertical'} [opts.orientation='both'] — which axes move
+   *   focus. 'both' (default): up/down AND left/right step the flat list (for
+   *   narrow button stacks). 'vertical': only up/down move focus, leaving
+   *   left/right for a registered slider.
+   * @param {()=>boolean} [opts.canConfirm] — optional gate; confirm is ignored
+   *   while it returns false (e.g. an overlay's "can't dismiss yet" cooldown).
    */
-  constructor({ input, focusClass = 'gamepad-focus', onConfirm = null, onBack = null, onChange = null } = {}) {
+  constructor({ input, focusClass = 'gamepad-focus', onConfirm = null, onBack = null, onChange = null, orientation = 'both', canConfirm = null } = {}) {
     this.input = input;
     this.focusClass = focusClass;
     this._onConfirm = onConfirm;
     this._onBack = onBack;
     this._onChange = onChange;
+    this._orientation = orientation;
+    this._canConfirm = canConfirm;
     this.items = [];
     this.index = 0;
     this._edge = { ...NO_EDGES };
+    // Optional range <input> driven by left/right (analog + d-pad repeat).
+    this._slider = null;
+    this._sliderRepeatAt = 0;
+  }
+
+  /**
+   * Register (or clear) a range <input> that left/right drives instead of
+   * moving focus — analog stick is continuous/proportional, d-pad steps with a
+   * press-then-repeat cadence. Pass null to detach.
+   */
+  setSlider(el) {
+    this._slider = el || null;
+    this._sliderRepeatAt = 0;
+    return this;
   }
 
   /**
@@ -60,25 +82,63 @@ export class FocusController {
     return this;
   }
 
-  /** Remove focus styling and drop the item list. */
+  /** Remove focus styling, drop the item list, and detach any slider. */
   clear() {
     this._clearFocus();
     this.items = [];
     this.index = 0;
+    this._slider = null;
   }
 
   /**
-   * Read the pad once and dispatch nav / confirm / back via edge detection.
-   * The caller drives this each frame; the controller does not schedule.
+   * Read the pad once and dispatch nav / slider / confirm / back via edge
+   * detection. The caller drives this each frame; the controller does not
+   * schedule.
    */
   poll() {
     const e = this._readEdges();
     if (!e) return;
-    if ((e.up && !this._edge.up) || (e.left && !this._edge.left)) this.move(-1);
-    if ((e.down && !this._edge.down) || (e.right && !this._edge.right)) this.move(1);
-    if (e.a && !this._edge.a) this.confirm();
-    if (e.b && !this._edge.b) this.back();
+    const prev = this._edge;
+
+    if (this._slider) {
+      // Slider consumes the horizontal axis; focus moves on up/down only.
+      this._driveSlider(e, prev);
+    } else if (this._orientation === 'both') {
+      if (e.left && !prev.left) this.move(-1);
+      if (e.right && !prev.right) this.move(1);
+    }
+    if (e.up && !prev.up) this.move(-1);
+    if (e.down && !prev.down) this.move(1);
+    if (e.a && !prev.a && (!this._canConfirm || this._canConfirm())) this.confirm();
+    if (e.b && !prev.b) this.back();
+
     this._edge = e;
+  }
+
+  /** Drive the registered slider from the horizontal axis (analog + d-pad). */
+  _driveSlider(e, prev) {
+    const s = this._slider;
+    const min = Number(s.min), max = Number(s.max);
+    const clampS = (v) => Math.min(max, Math.max(min, v));
+    let changed = false;
+
+    // Analog stick: continuous proportional movement (~full sweep in ~1s @60Hz).
+    if (Math.abs(e.axisX) > 0.12) {
+      s.value = clampS(Number(s.value) + e.axisX * 1.5);
+      changed = true;
+    }
+    // D-pad: discrete step on press, then repeat while held (400ms → 80ms).
+    const now = performance.now();
+    const step = (dir, firstMag, repMag) => {
+      if (!(dir === -1 ? e.left : e.right)) return;
+      const held = dir === -1 ? prev.left : prev.right;
+      if (!held) { s.value = clampS(Number(s.value) + dir * firstMag); changed = true; this._sliderRepeatAt = now + 400; }
+      else if (now > this._sliderRepeatAt) { s.value = clampS(Number(s.value) + dir * repMag); changed = true; this._sliderRepeatAt = now + 80; }
+    };
+    step(-1, 3, 2);
+    step(1, 3, 2);
+
+    if (changed) s.dispatchEvent(new Event('input'));
   }
 
   /** Move focus by `dir` (clamped — no wrap, matching the existing loops). */
@@ -128,6 +188,7 @@ export class FocusController {
       right: !!((gp.buttons[15] && gp.buttons[15].pressed) || gp.axes[0] > 0.5),
       a: !!(gp.buttons[aIdx] && gp.buttons[aIdx].pressed),
       b: !!(gp.buttons[bIdx] && gp.buttons[bIdx].pressed),
+      axisX: gp.axes[0] || 0, // raw, for slider control
     };
   }
 

--- a/js/nav/focus-controller.js
+++ b/js/nav/focus-controller.js
@@ -54,6 +54,30 @@ export class FocusController {
     // Optional range <input> driven by left/right (analog + d-pad repeat).
     this._slider = null;
     this._sliderRepeatAt = 0;
+    // Spatial (neighbor) mode: focus tracked by element, directions resolve to
+    // the nearest visible focusable on-screen (with optional data-nav-*
+    // overrides) instead of index math. Used for 2-D screens like the lobby.
+    this._spatial = false;
+    this.focusedEl = null;
+  }
+
+  /**
+   * Spatial/neighbor mode (#318): register a flat set of focusables laid out in
+   * 2-D. Directions move to the nearest VISIBLE neighbor by on-screen geometry
+   * — dissolving column/row/sibling special-casing — or follow an explicit
+   * `data-nav-up|down|left|right="targetId"` if present. Hidden items are
+   * skipped automatically at move time. Confirm/back behave as in linear mode.
+   */
+  setSpatial(items, initialEl = null) {
+    this._clearSpatialFocus();
+    this.items = (items || []).filter(Boolean);
+    this._spatial = true;
+    this.focusedEl =
+      (initialEl && this.items.indexOf(initialEl) >= 0 && this._visible(initialEl)) ? initialEl :
+      (this.items.find((el) => this._visible(el)) || null);
+    this._edge = this._readEdges() || { ...NO_EDGES };
+    if (this.focusedEl) this.focusedEl.classList.add(this.focusClass);
+    return this;
   }
 
   /**
@@ -82,12 +106,14 @@ export class FocusController {
     return this;
   }
 
-  /** Remove focus styling, drop the item list, and detach any slider. */
+  /** Remove focus styling, drop the item list, and reset slider/spatial state. */
   clear() {
     this._clearFocus();
+    this._clearSpatialFocus();
     this.items = [];
     this.index = 0;
     this._slider = null;
+    this._spatial = false;
   }
 
   /**
@@ -99,6 +125,17 @@ export class FocusController {
     const e = this._readEdges();
     if (!e) return;
     const prev = this._edge;
+
+    if (this._spatial) {
+      if (e.up && !prev.up) this._moveDir('up');
+      if (e.down && !prev.down) this._moveDir('down');
+      if (e.left && !prev.left) this._moveDir('left');
+      if (e.right && !prev.right) this._moveDir('right');
+      if (e.a && !prev.a && (!this._canConfirm || this._canConfirm())) this._confirmSpatial();
+      if (e.b && !prev.b) this.back();
+      this._edge = e;
+      return;
+    }
 
     if (this._slider) {
       // Slider consumes the horizontal axis; focus moves on up/down only.
@@ -163,9 +200,88 @@ export class FocusController {
     if (this._onBack) this._onBack();
   }
 
+  /**
+   * Re-sync edge state to the pad's current state without moving focus. Call
+   * when control returns to this scope after another scope (e.g. a modal)
+   * consumed input, so a button still held across the transition isn't read as
+   * a fresh press.
+   */
+  reprime() {
+    this._edge = this._readEdges() || { ...NO_EDGES };
+  }
+
   /** Currently focused element, or null. */
   get focused() {
-    return this.items[this.index] || null;
+    return this._spatial ? this.focusedEl : (this.items[this.index] || null);
+  }
+
+  // ── spatial (neighbor) mode ──
+
+  /** Move focus to the nearest visible neighbor in `dir` (or a data-nav override). */
+  _moveDir(dir) {
+    if (!this.focusedEl) {
+      this.focusedEl = this.items.find((el) => this._visible(el)) || null;
+      if (this.focusedEl) this.focusedEl.classList.add(this.focusClass);
+      return;
+    }
+    const target = this._explicitNeighbor(this.focusedEl, dir) || this._spatialNeighbor(this.focusedEl, dir);
+    if (!target || target === this.focusedEl) return;
+    this.focusedEl.classList.remove(this.focusClass);
+    this.focusedEl = target;
+    target.classList.add(this.focusClass);
+    if (this._onChange) this._onChange(target, this.items.indexOf(target));
+  }
+
+  _confirmSpatial() {
+    const el = this.focusedEl;
+    if (!el) return;
+    if (this._onConfirm) this._onConfirm(el, this.items.indexOf(el));
+    else el.click();
+  }
+
+  /** Follow an explicit data-nav-{dir}="targetId" neighbor if it's valid+visible. */
+  _explicitNeighbor(el, dir) {
+    const key = 'nav' + dir.charAt(0).toUpperCase() + dir.slice(1); // navUp/navDown/...
+    const id = el.dataset && el.dataset[key];
+    if (!id) return null;
+    const target = document.getElementById(id);
+    return (target && this.items.indexOf(target) >= 0 && this._visible(target)) ? target : null;
+  }
+
+  /** Nearest visible focusable in `dir` by center-to-center geometry. */
+  _spatialNeighbor(el, dir) {
+    const r = el.getBoundingClientRect();
+    const cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+    let best = null, bestScore = Infinity;
+    for (const other of this.items) {
+      if (other === el || !this._visible(other)) continue;
+      const rr = other.getBoundingClientRect();
+      const ox = rr.left + rr.width / 2, oy = rr.top + rr.height / 2;
+      const dx = ox - cx, dy = oy - cy;
+      // Must lie in the pressed direction (with a small tolerance).
+      if (dir === 'left'  && dx > -1) continue;
+      if (dir === 'right' && dx <  1) continue;
+      if (dir === 'up'    && dy > -1) continue;
+      if (dir === 'down'  && dy <  1) continue;
+      const horizontal = (dir === 'left' || dir === 'right');
+      const primary = horizontal ? Math.abs(dx) : Math.abs(dy);
+      const perp = horizontal ? Math.abs(dy) : Math.abs(dx);
+      // Prefer aligned neighbors: weight the off-axis distance heavily.
+      const score = primary + perp * 3;
+      if (score < bestScore) { bestScore = score; best = other; }
+    }
+    return best;
+  }
+
+  _visible(el) {
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0; // display:none / detached → zero box
+  }
+
+  _clearSpatialFocus() {
+    if (this.focusedEl) this.focusedEl.classList.remove(this.focusClass);
+    this.focusedEl = null;
   }
 
   // ── internals ──


### PR DESCRIPTION
Re-opens #328 (which GitHub auto-closed when the stacked base branch #327 was deleted on merge). Same branch, **already gamepad-validated by the maintainer** ("328 worked well with DualSense" — including the left/right toggle-column crossing). Now rebased onto main (#327 merged), so the diff is lobby-only.

## What it does
Migrates the lobby's hand-rolled column/row/sibling step navigation to the nav-core `FocusController` in **spatial mode**: directions move to the nearest visible focusable by on-screen geometry (with optional `data-nav-*` overrides), dissolving `_modeColumns`/`_moveColumn`/`_modeColIndex` and the difficulty-sibling special-casing.

- `FocusController`: `setSpatial`, geometry `_spatialNeighbor` + `_explicitNeighbor`, `reprime()`.
- `lobby.js`: `_stepFocus` drives all steps; `_showStep` / level-card rebuild / gamepad hot-connect / `_startGamepadNav` / a **lazy poll-time seed** all (re)apply the step's full focusable set (`_modeColumns.flat()`). The lazy seed fixed the reported "no highlight until a mouse click" bug for **WebHID controllers that connect without a `gamepadconnected` event**. Modal branches + LB/RB bumpers unchanged. Old `_moveFocus`/`_moveColumn` left as a fallback (remove in a follow-up).

## Validation
Confirmed on-device with a DualSense: highlight appears on load, d-pad/stick navigation works, and left/right correctly crosses into the left/right toggle columns.

Next: migrate the 5 lobby modal branches (closes #325) and delete the dead column methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)