### PR TITLE
Fix DualSense touchpad-click closing lobby popups + focus-glow symmetry

### DIFF
--- a/js/lobby.js
+++ b/js/lobby.js
@@ -1407,11 +1407,16 @@ export class Lobby {
     // Profile popup gamepad focus index (0 = logout/sign-in, 1 = back)
     this._profileFocusIndex = 0;
 
-    // Close popup when clicking outside
+    // Close popup when clicking outside.
+    // The DualSense touchpad is mapped to a system mouse (via Steam Input), so
+    // navigating the controller emits stray pointer clicks outside the popup
+    // that would dismiss it the instant it opened — the "flash". When a gamepad
+    // is driving, dismiss via B / RETURN TO LOBBY instead of outside-clicks. (#325)
     document.addEventListener('click', (e) => {
       if (!this.profilePopup.classList.contains('visible')) return;
       if (this.profilePopup.contains(e.target)) return;
       if (this.toggleProfile.contains(e.target)) return;
+      if (this.input && this.input.gamepadConnected) return;
       this.profilePopup.classList.remove('visible');
     });
 
@@ -1894,7 +1899,12 @@ export class Lobby {
     };
     const autoDismiss = () => dismiss();
     const timer = setTimeout(dismiss, 2000);
-    setTimeout(() => document.addEventListener('click', autoDismiss, true), 0);
+    // Only wire dismiss-on-click for mouse users. With a gamepad connected the
+    // DualSense touchpad (Steam Input → system mouse) emits stray clicks that
+    // would dismiss this notice the instant it appears — rely on the 2s timer. (#325)
+    if (!(this.input && this.input.gamepadConnected)) {
+      setTimeout(() => document.addEventListener('click', autoDismiss, true), 0);
+    }
   }
 
   _showRecalPopup() {


### PR DESCRIPTION
## Problem
On desktop with a DualSense controller, the **profile popup** ("LOG OUT" / sign-in) and the **keyboard-only notice** (shown when gyro + joystick are both deselected) *flash* — they open and immediately close, "do not stay open." Reported repeatedly while validating the nav-core work; confirmed to be a **pre-existing bug** (#325), not a nav-core regression.

## Root cause
The DualSense touchpad is exposed as a **system mouse** via Steam Input. Navigating the controller emits stray **real** pointer clicks (`isTrusted=true`) at the cursor position. Those clicks land outside the popup and trip the existing "dismiss on outside click" handlers, closing the popup the instant it opens.

A temporary `MutationObserver` on the popups captured the close path: an `isTrusted=true` click with a target *outside* the popup — i.e. a real pointer event, not a synthetic gamepad `.click()`.

## Fix
When a gamepad is connected, skip the click-to-dismiss paths:
- **Profile popup** — outside-click handler returns early; dismiss via **B** / **RETURN TO LOBBY**.
- **Keyboard-only notice** — don't wire the "dismiss on any click" listener; rely on the existing **2s auto-timer**.

Mouse-only users (no gamepad) keep click-to-dismiss unchanged.

## Still TODO in this PR
- [ ] Focus-glow left/right symmetry fix (pinning the exact clipping with a screenshot before changing CSS).

## Validation
Gamepad validation needed: open the profile popup with the controller → it stays open; B closes it. Deselect gyro + joystick → the keyboard notice stays the full 2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)