### PR TITLE
Hide logout in the desktop app to prevent an Electron login dead-end

### DIFF
--- a/js/lobby.js
+++ b/js/lobby.js
@@ -1320,6 +1320,12 @@ export class Lobby {
       this.auth.initGSI();
     }
 
+    // Hide LOG OUT in any Electron session, not just verified-Steam. Google
+    // sign-in can't run on the file:// origin, so logging out of a persisted
+    // (Steam) session strands the user with no way back in. Steam identity is
+    // automatic, so there's no meaningful logout in the desktop app. (#332)
+    if (isElectron && logoutBtn) logoutBtn.style.display = 'none';
+
     // Save original SVG to restore on logout
     const profileSvg = this.toggleProfile.innerHTML;
 
@@ -2157,12 +2163,14 @@ export class Lobby {
     // can't immediately dismiss the popup via the only focusable item. (#325)
     if (this.profilePopup.classList.contains('visible')) {
       this._profileFocusIndex = 0;
-      // Apply initial highlight
-      const items = this.auth.isLoggedIn()
+      // Apply initial highlight (skip the logout button when it's hidden — e.g.
+      // Electron/Steam — so focus never lands on an invisible control). (#332)
+      const items = (this.auth.isLoggedIn()
         ? [document.getElementById('profile-popup-logout'), document.getElementById('profile-popup-back')]
-        : [document.getElementById('profile-popup-signin-proxy'), document.getElementById('profile-popup-signin-back')];
+        : [document.getElementById('profile-popup-signin-proxy'), document.getElementById('profile-popup-signin-back')]
+      ).filter(el => el && el.style.display !== 'none');
       items.forEach(el => el.classList.remove('gamepad-focus'));
-      items[0].classList.add('gamepad-focus');
+      if (items[0]) items[0].classList.add('gamepad-focus');
     } else {
       // Clear highlights on close
       this.profilePopup.querySelectorAll('.gamepad-focus').forEach(el => el.classList.remove('gamepad-focus'));
@@ -4533,11 +4541,14 @@ export class Lobby {
     this._gpPrevLB = lb;
     this._gpPrevRB = rb;
 
-    // If profile popup is open, navigate between logout and back
+    // If profile popup is open, navigate between logout and back (skip the
+    // logout button when it's hidden — Electron/Steam — so gamepad focus can't
+    // land on or confirm an invisible control). (#332)
     if (this.profilePopup.classList.contains('visible')) {
-      const items = this.auth.isLoggedIn()
+      const items = (this.auth.isLoggedIn()
         ? [document.getElementById('profile-popup-logout'), document.getElementById('profile-popup-back')]
-        : [document.getElementById('profile-popup-signin-proxy'), document.getElementById('profile-popup-signin-back')];
+        : [document.getElementById('profile-popup-signin-proxy'), document.getElementById('profile-popup-signin-back')]
+      ).filter(el => el && el.style.display !== 'none');
       if (this._activeModal !== 'profile') {
         this._activeModal = 'profile';
         this._modalBack = () => this.profilePopup.classList.remove('visible');


### PR DESCRIPTION
## Problem
In the desktop app (`npm start` / Electron), logging out is a trap. You can be **logged in via a persisted Steam token** while the current session can't verify Steam ownership (`_isSteam` is false), so the **LOG OUT** button stays visible — but once you log out there's no way back in:
- Google Identity Services **can't run on Electron's `file://` origin** (the code already notes this at lobby.js:1316-1318).
- There's no Steam re-login affordance in the popup.

Recovery required closing the app, relaunching through Steam, exiting, and relaunching `npm start`.

## Fix
Steam identity is automatic in the desktop app, so there's no meaningful logout there. **Hide the LOG OUT button in any Electron session** (not just verified-Steam), which makes the dead-end impossible. Also filter the now-hidden logout button out of the gamepad profile-popup item lists so focus/confirm can't land on an invisible control.

Chosen approach: "Hide logout in desktop" (vs. adding a Steam re-login button), per product decision — simplest and demo-safe.

## Scope / not included
- The logged-out Electron state still shows the (non-functional on `file://`) Google sign-in proxy. In the shipped Steam build this isn't reached because Steam auto-login runs; flagged as a separate, pre-existing gap.

## Validation
Desktop: open the profile popup while logged in → no LOG OUT button; RETURN TO LOBBY only. Web (browser) unchanged — logout still shown, Google sign-in still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)