### PR TITLE
nav-core: built-in confirm latch + clip-preview singleton + dead-code cleanup

### DIFF
--- a/js/game-recorder.js
+++ b/js/game-recorder.js
@@ -1440,6 +1440,9 @@ export class GameRecorder {
       [this.previewShareBtn, this.previewSaveBtn, this.previewDiscardBtn]
         .filter(el => el && el.style.display !== 'none')
     );
+    // Singleton RAF loop: cancel any prior poll before starting a new one so
+    // re-showing the preview can't stack loops that double-process input. (#318)
+    if (this._previewPollId) cancelAnimationFrame(this._previewPollId);
     this._pollPreviewGamepad();
   }
 

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -207,28 +207,21 @@ export class Lobby {
     this._updateVolumeUI();
 
     // Gamepad navigation state
-    this._focusIndex = 0;
     this._currentStep = null;
     this._pollRafId = null;
     // Step navigation (mode/level/role/host/join/room) now uses the shared
     // nav-core FocusController in spatial mode (#318): directions move to the
     // nearest on-screen focusable, dissolving the old _modeColumns/_moveColumn/
     // _modeColIndex column math and the difficulty-sibling special-casing.
-    // Global "one confirm per physical A press" gate, shared by the step and
-    // modal controllers (set each frame in _pollGamepadNav). Per-controller edge
-    // detection alone wasn't enough: when an A press opens a popup, the handoff
-    // from the step scope to the modal scope (setItems re-priming, occasional
-    // null pad reads, reprime()) could let the SAME held press fire a second
-    // confirm that immediately closed the popup — the "flash". A gate computed
-    // once per frame from the raw pad is immune to those per-controller resets. (#332)
-    this._confirmEdgeThisFrame = false;
-    this._confirmPrevA = false;
-    const confirmGate = () => this._confirmEdgeThisFrame;
+    // The "one confirm per physical A press" gate that kills the popup flash
+    // (a held press bleeding a second confirm into the scope it just opened)
+    // now lives inside FocusController itself — armed on scope entry + after
+    // each confirm, cleared only on an observed A release — so every call site
+    // inherits it; no shared lobby-level gate needed. (#318)
     this._stepFocus = new FocusController({
       input: this.input,
       onConfirm: (el) => { if (el.tagName === 'INPUT') el.focus(); else el.click(); },
       onBack: () => this._goBack(),
-      canConfirm: confirmGate,
     });
     this._stepNavRanLastFrame = false; // for reprime() on modal→step transitions
     // Shared controller for the linear modal lists (profile popup, rejoin
@@ -239,7 +232,6 @@ export class Lobby {
       input: this.input,
       orientation: 'vertical',
       onBack: () => { if (this._modalBack) this._modalBack(); },
-      canConfirm: confirmGate,
     });
     this._activeModal = null; // 'profile' | 'rejoin' | null
     this._modalBack = null;
@@ -267,7 +259,6 @@ export class Lobby {
       [this.toggleJoystick, this.toggleMotion, this.toggleMusic],
     ];
     this._modeCol = 1;
-    this._modeColIndex = [0, 0, 0, 0];
 
     // Per-step focusable items and back buttons
     this._stepItems = new Map();
@@ -332,8 +323,6 @@ export class Lobby {
     this._isSteam = false;
     this.license = new LicenseManager(this.auth);
     this._steamReady = this._initSteamLicense().then(() => this._setupAuth());
-    this._lbFocusRow = 0;   // 0 = main tabs, 1 = sub tabs, 2 = close button
-    this._lbFocusCol = 0;   // index within the current row
 
     this._setup();
     this._buildLeaderboardTabs();
@@ -708,7 +697,6 @@ export class Lobby {
 
     // Always reset to center column and update its items
     this._modeCol = 1;
-    this._modeColIndex = [0, 0, 0, 0];
     const centerItems = this._stepCenterItems.get(step) || [];
     this._modeColumns[1] = centerItems;
     this._stepItems.set(step, centerItems);
@@ -1450,8 +1438,6 @@ export class Lobby {
       });
     });
 
-    // Profile popup gamepad focus index (0 = logout/sign-in, 1 = back)
-    this._profileFocusIndex = 0;
 
     // Close popup when clicking outside
     document.addEventListener('click', (e) => {
@@ -2106,22 +2092,8 @@ export class Lobby {
     document.getElementById('leaderboard-modal').style.display = 'none';
   }
 
-  _lbGetRowItems(row) {
-    if (row === 0) return [...document.getElementById('lb-main-tabs').querySelectorAll('.lb-tab')];
-    if (row === 1) return [...document.getElementById('lb-sub-tabs').querySelectorAll('.lb-tab')];
-    if (row === 2) return [document.getElementById('leaderboard-close')];
-    return [];
-  }
-
   _lbClearFocus() {
     document.querySelectorAll('#leaderboard-modal .gamepad-focus').forEach(el => el.classList.remove('gamepad-focus'));
-  }
-
-  _lbApplyFocus() {
-    this._lbClearFocus();
-    const items = this._lbGetRowItems(this._lbFocusRow);
-    const idx = Math.min(this._lbFocusCol, items.length - 1);
-    if (items[idx]) items[idx].classList.add('gamepad-focus');
   }
 
   // Tabs (main + sub) + close button — the leaderboard's spatial focusable set.
@@ -2162,7 +2134,6 @@ export class Lobby {
     // action (sign-in proxy / log out) so opening with A then a stray A press
     // can't immediately dismiss the popup via the only focusable item. (#325)
     if (this.profilePopup.classList.contains('visible')) {
-      this._profileFocusIndex = 0;
       // Apply initial highlight (skip the logout button when it's hidden — e.g.
       // Electron/Steam — so focus never lands on an invisible control). (#332)
       const items = (this.auth.isLoggedIn()
@@ -3081,7 +3052,6 @@ export class Lobby {
     document.body.appendChild(overlay);
 
     // Default gamepad focus on first card
-    this._rejoinFocus = 0;
     const cards = overlay.querySelectorAll('.rejoin-room-card');
     if (cards.length > 0) cards[0].classList.add('gamepad-focus');
 
@@ -4515,13 +4485,6 @@ export class Lobby {
     const btns = this._gpButtons(gp);
     const a = btns.a;
     const b = btns.b;
-
-    // Global confirm gate: A only counts as a confirm on the frame it goes
-    // down, and that single edge is shared by every scope (step + modals) via
-    // canConfirm. Computed here — before any branch's early return — so a held
-    // A press can never fire a second confirm in another scope (the flash). (#332)
-    this._confirmEdgeThisFrame = a && !this._confirmPrevA;
-    this._confirmPrevA = a;
 
     // D-pad left/right (buttons 14/15 or left stick axis 0)
     const left = (gp.buttons[14] && gp.buttons[14].pressed) || gp.axes[0] < -0.5;

--- a/js/nav/focus-controller.js
+++ b/js/nav/focus-controller.js
@@ -59,6 +59,13 @@ export class FocusController {
     // overrides) instead of index math. Used for 2-D screens like the lobby.
     this._spatial = false;
     this.focusedEl = null;
+    // One-confirm-per-press latch (#318): when true, confirm is suppressed
+    // until the A button is observed released. Armed on scope entry
+    // (setItems/setSpatial) and after every confirm, so a single held press
+    // can neither auto-repeat a confirm nor bleed a confirm into a scope it
+    // just opened (the lobby popup "flash"). Null-safe: only an observed
+    // release clears it, so a missed/null pad read never opens the gate.
+    this._awaitConfirmRelease = false;
   }
 
   /**
@@ -76,6 +83,7 @@ export class FocusController {
       (initialEl && this.items.indexOf(initialEl) >= 0 && this._visible(initialEl)) ? initialEl :
       (this.items.find((el) => this._visible(el)) || null);
     this._edge = this._readEdges() || { ...NO_EDGES };
+    this._awaitConfirmRelease = true; // require A release before first confirm
     if (this.focusedEl) this.focusedEl.classList.add(this.focusClass);
     return this;
   }
@@ -104,6 +112,7 @@ export class FocusController {
     this.items = (items || []).filter(Boolean);
     this.index = this._clamp(initialIndex);
     this._edge = this._readEdges() || { ...NO_EDGES };
+    this._awaitConfirmRelease = true; // require A release before first confirm
     this._applyFocus();
     return this;
   }
@@ -133,6 +142,7 @@ export class FocusController {
     this.index = 0;
     this._slider = null;
     this._spatial = false;
+    this._awaitConfirmRelease = false;
   }
 
   /**
@@ -145,12 +155,19 @@ export class FocusController {
     if (!e) return;
     const prev = this._edge;
 
+    // One-confirm-per-press latch: clear only on an observed A release, then
+    // a fresh A-down edge confirms. `_confirmReady` is the single source of
+    // truth for "may fire a confirm this frame". (#318)
+    if (this._awaitConfirmRelease && !e.a) this._awaitConfirmRelease = false;
+    const confirmReady = e.a && !prev.a && !this._awaitConfirmRelease
+      && (!this._canConfirm || this._canConfirm());
+
     if (this._spatial) {
       if (e.up && !prev.up) this._moveDir('up');
       if (e.down && !prev.down) this._moveDir('down');
       if (e.left && !prev.left) this._moveDir('left');
       if (e.right && !prev.right) this._moveDir('right');
-      if (e.a && !prev.a && (!this._canConfirm || this._canConfirm())) this._confirmSpatial();
+      if (confirmReady) { this._confirmSpatial(); this._awaitConfirmRelease = true; }
       if (e.b && !prev.b) this.back();
       this._edge = e;
       return;
@@ -165,7 +182,7 @@ export class FocusController {
     }
     if (e.up && !prev.up) this.move(-1);
     if (e.down && !prev.down) this.move(1);
-    if (e.a && !prev.a && (!this._canConfirm || this._canConfirm())) this.confirm();
+    if (confirmReady) { this.confirm(); this._awaitConfirmRelease = true; }
     if (e.b && !prev.b) this.back();
 
     this._edge = e;
@@ -227,6 +244,7 @@ export class FocusController {
    */
   reprime() {
     this._edge = this._readEdges() || { ...NO_EDGES };
+    this._awaitConfirmRelease = true; // require A release after a scope handoff
   }
 
   /** Currently focused element, or null. */


### PR DESCRIPTION
Finishing items for nav-core (#318 Step 1), from the post-merge audit.

## 1. Lift the confirm gate into `FocusController` (the refactor)
The "one confirm per physical A press" gate that fixed the lobby popup flash lived as ad-hoc lobby code. It's now a **built-in latch** (`_awaitConfirmRelease`) inside `FocusController`, so **every call site inherits it** (lobby step, lobby modals, in-game overlay, clip-preview).

- **Armed** on scope entry (`setItems`/`setSpatial`), after every confirm, and on `reprime()`.
- **Cleared** only on an *observed* A release → null-safe (a missed/null pad read never opens the gate).

This replicates — per controller — the global gate's two effects:
- armed-on-entry → a held press can't bleed a confirm into the scope it just opened (profile / leaderboard / rejoin modals);
- armed-after-confirm → a held press can't re-fire (the keyboard-only notice was being dismissed by a step re-confirm's synthetic click).

The lobby's `_confirmEdgeThisFrame` / `_confirmPrevA` / `canConfirm: confirmGate` wiring is removed. `canConfirm` stays available for its original cooldown use (in-game overlay "can't dismiss yet").

## 2. Clip-preview poll loop → singleton
`_startPreviewGamepadNav()` now cancels any prior `_previewPollId` before starting, matching the lobby loop fix — prevents stacked RAF loops from double-processing input.

## 3. Dead-code cleanup (lobby.js)
Removed orphaned pre-migration nav code: `_lbApplyFocus`, `_lbGetRowItems`, `_lbFocusRow`, `_lbFocusCol`, `_rejoinFocus`, `_profileFocusIndex`, `_focusIndex`, `_modeColIndex` (all write-only / superseded by `FocusController`).

## Risk / validation
This **replaces the validated popup-flash fix mechanism** (global gate → built-in latch), so it needs a gamepad re-validation pass:
- Profile + keyboard-only popups stay open (no flash); B / RETURN TO LOBBY closes profile.
- SOLO RIDE → select → back → profile: opens without jumping screens; held A doesn't multi-advance steps.
- In-game overlay (Start → options) + clip-preview Save/Discard still confirm normally.

If anything regresses, the prior global-gate approach is one revert away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)