### PR TITLE
Genericize inbound dispatch — transport no longer knows game messages (#318 Step 2, increment 2)

### DIFF
--- a/js/net/bike-codec.js
+++ b/js/net/bike-codec.js
@@ -125,4 +125,37 @@ export class BikeCodec {
     const json = new TextDecoder().decode(bytes.slice(1));
     return JSON.parse(json);
   }
+
+  /**
+   * Route an opaque inbound frame to the matching game handler. This is the
+   * inbound half of the protocol — it keeps the transport free of any
+   * `MSG_*` knowledge (the transport hands over any non-keepalive bytes and
+   * this decides what they mean). Returns true if the frame was a known game
+   * message, false otherwise (so the transport can ignore unknown frames).
+   *
+   * @param {Uint8Array} bytes
+   * @param {{onState?:Function,onPedal?:Function,onEvent?:Function,onLean?:Function,onProfile?:Function}} h
+   */
+  dispatch(bytes, h) {
+    if (!bytes || bytes.length === 0) return false;
+    switch (bytes[0]) {
+      case MSG_PEDAL:
+        if (h.onPedal) h.onPedal(this.decodePedal(bytes));
+        return true;
+      case MSG_STATE:
+        if (h.onState) h.onState(this.decodeState(bytes));
+        return true;
+      case MSG_EVENT:
+        if (bytes.length >= 2 && h.onEvent) h.onEvent(bytes[1]);
+        return true;
+      case MSG_LEAN:
+        if (bytes.length >= 5 && h.onLean) h.onLean(this.decodeLean(bytes));
+        return true;
+      case MSG_PROFILE:
+        try { if (h.onProfile) h.onProfile(this.decodeProfile(bytes)); } catch (e) { /* malformed */ }
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/js/network-manager.js
+++ b/js/network-manager.js
@@ -3,7 +3,7 @@
 // ============================================================
 
 import {
-  MSG_PEDAL, MSG_STATE, MSG_EVENT, MSG_HEARTBEAT, MSG_LEAN, MSG_PROFILE,
+  MSG_HEARTBEAT,
   TURN_CREDENTIALS_URL, PEERJS_HOST, PEERJS_PORT, PEERJS_PATH, PEERJS_SECURE
 } from './config.js';
 import { BikeCodec } from './net/bike-codec.js';
@@ -64,9 +64,20 @@ export class NetworkManager {
     this._statsSamples = []; // { rtt, packetsLost, packetsSent, bytesReceived, bytesSent, timestamp }
 
     // Game-specific message codec (bike state/lean/pedal/event/profile). The
-    // transport below sends/receives opaque bytes; the codec owns the schema
-    // and the pre-allocated 60Hz send buffers. (#318 Step 2)
+    // transport below sends/receives opaque bytes; the codec owns the schema,
+    // the pre-allocated 60Hz send buffers, AND the inbound dispatch. (#318 Step 2)
     this._codec = new BikeCodec();
+    // Inbound routing table handed to the codec — maps decoded game messages
+    // back to this adapter's public callbacks. Built once; reads the (possibly
+    // reassigned) on*Received fields at call time. Role-flip for pedal lives
+    // here (session state), not in the codec.
+    this._msgHandlers = {
+      onState:   (s) => { if (this.onStateReceived) this.onStateReceived(s); },
+      onPedal:   (foot) => { if (this.onPedalReceived) this.onPedalReceived(this.role === 'captain' ? 'stoker' : 'captain', foot); },
+      onEvent:   (b) => { if (this.onEventReceived) this.onEventReceived(b); },
+      onLean:    (v) => { if (this.onLeanReceived) this.onLeanReceived(v); },
+      onProfile: (p) => { if (this.onProfileReceived) this.onProfileReceived(p); },
+    };
 
     // Pending retries for sendEventReliable (eventByte → setTimeout id list)
     this._reliableEventTimers = [];
@@ -207,24 +218,10 @@ export class NetworkManager {
     }
 
     if (bytes.length === 0) return;
-    const type = bytes[0];
 
-    if (type === MSG_PEDAL) {
-      const foot = this._codec.decodePedal(bytes);
-      if (this.onPedalReceived) this.onPedalReceived(this.role === 'captain' ? 'stoker' : 'captain', foot);
-    } else if (type === MSG_STATE) {
-      const state = this._codec.decodeState(bytes);
-      if (this.onStateReceived) this.onStateReceived(state);
-    } else if (type === MSG_EVENT) {
-      if (bytes.length >= 2 && this.onEventReceived) {
-        this.onEventReceived(bytes[1]);
-      }
-    } else if (type === MSG_LEAN) {
-      if (bytes.length >= 5) {
-        const leanValue = this._codec.decodeLean(bytes);
-        if (this.onLeanReceived) this.onLeanReceived(leanValue);
-      }
-    } else if (type === MSG_HEARTBEAT) {
+    // HEARTBEAT is the transport's own keepalive (connection health + reconnect
+    // reset + ping echo) — handle it here and don't surface it as game data.
+    if (bytes[0] === MSG_HEARTBEAT) {
       this._lastRemoteHeartbeat = performance.now();
       // Verified data exchange — safe to reset reconnect counter
       this._reconnectAttempts = 0;
@@ -233,12 +230,11 @@ export class NetworkManager {
       } else {
         this._send(new Uint8Array([MSG_HEARTBEAT, 0x01]));
       }
-    } else if (type === MSG_PROFILE) {
-      try {
-        const profile = this._codec.decodeProfile(bytes);
-        if (this.onProfileReceived) this.onProfileReceived(profile);
-      } catch (e) { /* ignore malformed profile */ }
+      return;
     }
+
+    // Everything else is opaque game payload — the codec owns what it means.
+    this._codec.dispatch(bytes, this._msgHandlers);
   }
 
   sendPedal(foot) {


### PR DESCRIPTION
Increment 2 of **Step 2 (`@usersfirst/room`)**, building on the codec split (#338).

## What
The transport's `_handleMessage` used to `switch` on every game `MSG_*` type. Now it intercepts **only its own `HEARTBEAT` keepalive** and hands any other frame to the codec as **opaque bytes**.

- **`BikeCodec.dispatch(bytes, handlers)`** — the inbound half of the protocol: decodes by type tag and routes to `onState`/`onPedal`/`onEvent`/`onLean`/`onProfile`; returns `false` for unknown/empty frames so the transport ignores them. The codec module is now the single home of the game wire protocol (encode + decode + dispatch).
- **`network-manager.js`** drops all five game `MSG_*` imports (only `MSG_HEARTBEAT`, a transport keepalive, remains) and routes inbound frames via `this._codec.dispatch(bytes, this._msgHandlers)`. The pedal **role-flip** stays in the adapter (session state, not codec).

## Risk: none to the wire / consumers
- **Wire format unchanged.**
- **Public `NetworkManager` API unchanged** (`sendState`, `onStateReceived`, …) — no `lobby.js`/`game.js` edits.

## Verification
- Transport now has **zero** game `MSG_*` references (grep: PEDAL/STATE/EVENT/LEAN/PROFILE = 0; HEARTBEAT = 5).
- `dispatch` unit test: all 5 message types route to the right handler; unknown byte + empty frame return `false`.

Still wants a **two-client smoke test** before merge (steering/lean sync, pedal, finish/gameover, reconnect) since it's the netcode receive path.

## Next (increment 3)
Physically extract the generic transport into a `RoomTransport` class/file so `network-manager.js` becomes a pure consumer of the room — the seam that lifts to a `@usersfirst/room` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)