### PR TITLE
Invert the achievements→auth dependency (#318 Step 4, increment 1)

### DIFF
--- a/js/achievements.js
+++ b/js/achievements.js
@@ -2,6 +2,8 @@
 // ACHIEVEMENTS — unlock conditions, persistence, toast display
 // ============================================================
 
+import { API_BASE } from './config.js';
+
 const ACHIEVEMENTS = [
   // Distance milestones (cumulative across completed rides)
   { id: 'first_500m',   name: 'First 500m',      icon: '\uD83D\uDC5F', condition: s => s.cumulativeDistance >= 500 },  // 👟
@@ -48,8 +50,42 @@ export class AchievementManager {
     this._newThisSession = []; // newly earned this session
     this._syncHighScore = 0; // consecutive seconds with offsetScore > 0.9
     this._cumulativeDistance = 0;
+    // Injected identity ({ getToken() }) — lets achievements push to the
+    // backend without knowing about auth. Set via setIdentity(). (#318 Step 4)
+    this._identity = null;
     this._load();
     this._loadStats();
+  }
+
+  /** Inject the identity provider used to authorize server sync. */
+  setIdentity(identity) {
+    this._identity = identity;
+    return this;
+  }
+
+  /**
+   * Push earned achievement IDs to the backend (D1). Uses the injected
+   * identity's token; no-op if not logged in or nothing earned. This is the
+   * achievements→server glue that used to live in auth.syncAchievements —
+   * inverted so identity doesn't know achievements exist. (#318 Step 4)
+   */
+  async syncToServer() {
+    const ids = this.getEarnedIds();
+    const token = this._identity && this._identity.getToken && this._identity.getToken();
+    if (!token || !ids || ids.length === 0) return null;
+    try {
+      const res = await fetch(`${API_BASE}/achievements/sync`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({ achievements: ids }),
+      });
+      return res.ok ? res.json() : null;
+    } catch (e) {
+      return null;
+    }
   }
 
   _load() {

--- a/js/auth.js
+++ b/js/auth.js
@@ -2,10 +2,11 @@
 // AUTH — Google Identity Services (GSI) client-side auth
 // ============================================================
 
+import { API_BASE } from './config.js';
+
 const STORAGE_USER = 'tandemonium_auth_user';
 const STORAGE_TOKEN = 'tandemonium_auth_token';
 const GOOGLE_CLIENT_ID = '640682648249-dp1dou0mmpkm6m697oakbe9odabt1dui.apps.googleusercontent.com';
-const API_BASE = 'https://tandemonium-api.pete-872.workers.dev';
 
 export class AuthManager {
   constructor() {
@@ -37,6 +38,12 @@ export class AuthManager {
 
   getUser() {
     return this.user;
+  }
+
+  /** Current server JWT (or null). The injected-identity surface other modules
+   *  depend on, so they can make authed requests without knowing about auth. */
+  getToken() {
+    return this.token;
   }
 
   onLogin(callback) {
@@ -264,19 +271,6 @@ export class AuthManager {
         'Authorization': `Bearer ${this.token}`,
       },
       body: JSON.stringify(data),
-    });
-    return res.ok ? res.json() : null;
-  }
-
-  async syncAchievements(ids) {
-    if (!this.token || !ids || ids.length === 0) return null;
-    const res = await fetch(`${API_BASE}/achievements/sync`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.token}`,
-      },
-      body: JSON.stringify({ achievements: ids }),
     });
     return res.ok ? res.json() : null;
   }

--- a/js/config.js
+++ b/js/config.js
@@ -33,6 +33,10 @@ export const MSG_PROFILE     = 0x07;
 
 export const RELAY_URL = 'wss://tandemonium-relay.pete-872.workers.dev';
 
+// Backend API (auth, scores, achievements, leaderboard, /me). Shared by the
+// identity client and the achievements sync glue. (#318 Step 4)
+export const API_BASE = 'https://tandemonium-api.pete-872.workers.dev';
+
 // Production web URL — used for QR codes in Electron, share links, etc.
 // Update this when the domain changes.
 export const SITE_URL = 'https://tandemonium.jimandi.love';

--- a/js/game.js
+++ b/js/game.js
@@ -2612,7 +2612,10 @@ class Game {
 
     try {
       await auth.submitScore(data);
-      const syncResult = await auth.syncAchievements(this.achievements.getEarnedIds());
+      // Achievements own their server sync now; inject the identity (token
+      // provider) so they can authorize it. (#318 Step 4)
+      this.achievements.setIdentity(auth);
+      const syncResult = await this.achievements.syncToServer();
       if (syncResult && syncResult.achievements) {
         this.achievements.mergeFromServer(
           syncResult.achievements.map(a => ({ id: a.achievement_id, earnedAt: a.earned_at }))

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -316,6 +316,9 @@ export class Lobby {
 
     // Auth (after _avatarCache — _setupAuth triggers updateUI which reads the cache)
     this.auth = new AuthManager();
+    // Achievements push to the backend via the identity (token provider), so
+    // auth no longer reaches into achievements. (#318 Step 4)
+    this._achievements.setIdentity(this.auth);
 
     // Steam: bypass LicenseManager when Steam ownership is confirmed
     // Initialize with a default license so code that reads this.license.isLicensed
@@ -1403,11 +1406,8 @@ export class Lobby {
 
     // Logout: sync achievements to server, then clear local state
     logoutBtn.addEventListener('click', async () => {
-      // Push local achievements to server before clearing
-      const ids = this._achievements.getEarnedIds();
-      if (ids.length > 0) {
-        try { await this.auth.syncAchievements(ids); } catch (e) {}
-      }
+      // Push local achievements to server before clearing (no-op if none/anon)
+      await this._achievements.syncToServer();
       this._achievements.clear();
       this.license.clear();
       this.auth.logout();


### PR DESCRIPTION
First increment of **Step 4 (identity)** from #318 — the dependency inversion that decouples achievements from auth.

## Problem
`auth.js` had `syncAchievements(ids)` — it POSTed earned achievement IDs to `/achievements/sync`, i.e. **identity reaching into the achievements domain**. #318: *"identity must not know achievements exist."*

## Fix — invert it
- **`auth.js`**: drop `syncAchievements()`; add **`getToken()`** (the token-provider surface other modules depend on). Auth now has **zero** achievements references.
- **`achievements.js`**: own the server sync — **`setIdentity({ getToken() })`** + **`syncToServer()`**, which pushes earned IDs using the injected token. No-op when not logged in or nothing earned.
- **`config.js`**: `API_BASE` moved here from `auth.js` (it's shared infra config, alongside `RELAY_URL`/`SITE_URL`).
- **`lobby.js`**: inject identity once (`achievements.setIdentity(auth)`); the logout glue is now a single `achievements.syncToServer()` instead of `getEarnedIds()` + `auth.syncAchievements()`.
- **`game.js` `_submitScore`**: route through `achievements.syncToServer()` (injecting the lobby's `auth` as identity) instead of `auth.syncAchievements()`.

## Risk
Low — pure dependency reshape, **behavior unchanged**. Verified with a unit test: `syncToServer` no-ops without identity / when logged out, and otherwise POSTs `{achievements:[...]}` to `/achievements/sync` with the `Bearer` token, byte-identical to the old `auth.syncAchievements` path. The achievements **server round-trip** happens at end-of-ride (`_submitScore`) and on logout, so a quick check: finish a ride while logged in (achievements persist server-side), and log out/in.

## Step 4 next
- Extract `@usersfirst/identity` (package `auth.js` + the worker auth routes) — now that auth is achievements-free, it's a clean lift.
- Isolate the Steam achievement mirror behind the same injected interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)