### PR TITLE
Add front-facing PiP "selfie cam" of the bike

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 | # | Domain | Key Concern | Key Files |
 |---|--------|-------------|-----------|
-| 1 | Bike Physics & Balance | Tilt, lean, gravity, pedaling, crank, camera | `bike-model.js`, `balance-controller.js`, `pedal-controller.js`, `chase-camera.js` |
+| 1 | Bike Physics & Balance | Tilt, lean, gravity, pedaling, crank, camera | `bike-model.js`, `balance-controller.js`, `pedal-controller.js`, `chase-camera.js`, `front-view-camera.js` |
 | 2 | Race Management | Checkpoints, timers, scoring, finish | `race-manager.js` |
 | 3 | Levels & Routes | Road generation, level configs, terrain | `race-config.js`, `road-path.js`, `road-chunks.js` |
 | 4 | World Content | Obstacles, collectibles, billboards, scenery, trees, particles, audio | `world.js`, `obstacles.js`, `collectibles.js`, `grass-particles.js`, `assets/*.mp3` |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ npx serve -l 8888
 Open `http://localhost:8888` in your browser.
 
 - **Solo**: Click SOLO RIDE — pedal with Up/Down arrows, lean with A/D (or tilt on mobile)
+- **Front view**: A small window in the lower-right shows a front-facing "selfie cam" of the bike as you ride. Toggle it with `V`.
 - **Multiplayer**: Click RIDE TOGETHER — one player creates a room, the other joins with the room code
 
 ## Multiplayer

--- a/js/front-view-camera.js
+++ b/js/front-view-camera.js
@@ -1,0 +1,215 @@
+// ============================================================
+// FRONT-VIEW CAMERA (picture-in-picture "selfie cam")
+// ============================================================
+//
+// A small window in the lower-right corner that shows a front-facing
+// view of the bike as you ride — the camera sits ahead of the bike on
+// its heading and looks back at the riders, so you watch the tandem (and
+// both riders) coming toward you. Inspired by the r/Unity3D trick of
+// parenting a camera to a character's face and dropping a render texture
+// in the corner.
+//
+// Rendering reuses the main WebGLRenderer via a scissored viewport — no
+// second renderer, no render target — so the cost is one extra scene
+// draw confined to a small rectangle. A DOM frame is layered on top to
+// give it the rounded, bordered "screen" look.
+
+import * as THREE from 'three';
+
+export class FrontViewCamera {
+  constructor(mainCamera) {
+    this.enabled = true;
+
+    // Dedicated camera for the PiP. Square aspect (set in render()).
+    this.camera = new THREE.PerspectiveCamera(50, 1, 0.1, 500);
+
+    // Rig: how the camera sits relative to the bike. Sits just ahead of the
+    // front wheel at roughly rider eye level, looking back so the tandem and
+    // both riders fill the frame as they come toward you.
+    this.frontDist = 4.6;   // units ahead of bike center, along heading
+    this.height = 1.95;     // camera eye height above the bike origin
+    this.lookHeight = 1.45; // height of the point we aim at (riders)
+
+    // Smoothed position/target so the view glides instead of snapping.
+    this._pos = new THREE.Vector3();
+    this._look = new THREE.Vector3();
+    this._desiredPos = new THREE.Vector3();
+    this._desiredLook = new THREE.Vector3();
+    this._fwd = new THREE.Vector3();
+    this._initialized = false;
+
+    this._buildFrame();
+    this._onResize();
+    window.addEventListener('resize', () => this._onResize());
+  }
+
+  // ----- DOM frame --------------------------------------------------
+
+  _buildFrame() {
+    const frame = document.createElement('div');
+    frame.id = 'front-view-frame';
+    frame.style.cssText = [
+      'position:fixed',
+      'pointer-events:none',
+      'z-index:40',
+      'border:3px solid rgba(255,255,255,0.92)',
+      'border-radius:14px',
+      'box-shadow:0 6px 22px rgba(0,0,0,0.45)',
+      'overflow:hidden',
+      'box-sizing:border-box',
+    ].join(';');
+
+    const label = document.createElement('div');
+    label.textContent = 'FRONT VIEW';
+    label.style.cssText = [
+      'position:absolute',
+      'left:8px',
+      'top:6px',
+      'font:600 11px/1 system-ui,sans-serif',
+      'letter-spacing:0.08em',
+      'color:rgba(255,255,255,0.95)',
+      'text-shadow:0 1px 3px rgba(0,0,0,0.8)',
+    ].join(';');
+    frame.appendChild(label);
+
+    document.body.appendChild(frame);
+    this.frame = frame;
+  }
+
+  /** Lower-right square sized relative to the smaller screen dimension.
+   *  Lifts above the on-screen pedal controls (touch layout) so the PiP
+   *  is never occluded by them. */
+  _computeRect() {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const size = Math.round(Math.min(w, h) * 0.28);
+    const margin = Math.round(Math.min(w, h) * 0.035);
+
+    // Clear the bottom pedal bar if it's visible (touch / portrait layout).
+    let bottomClear = margin;
+    const bar = document.getElementById('pedal-bar');
+    if (bar) {
+      const r = bar.getBoundingClientRect();
+      const visible = r.height > 0 && getComputedStyle(bar).display !== 'none';
+      if (visible) bottomClear = Math.max(margin, h - r.top + margin);
+    }
+
+    return {
+      size,
+      marginRight: margin,
+      marginBottom: bottomClear,
+      cssLeft: w - size - margin,
+      cssTop: h - size - bottomClear,
+    };
+  }
+
+  _onResize() {
+    const r = this._computeRect();
+    this._rect = r;
+    if (this.frame) {
+      this.frame.style.width = r.size + 'px';
+      this.frame.style.height = r.size + 'px';
+      this.frame.style.left = r.cssLeft + 'px';
+      this.frame.style.top = r.cssTop + 'px';
+    }
+  }
+
+  /** Master on/off (user toggle). When off, nothing renders and the
+   *  frame is hidden until re-enabled. */
+  setVisible(on) {
+    this.enabled = on;
+    if (!on) this._showFrame(false);
+  }
+
+  toggle() {
+    this.setVisible(!this.enabled);
+    return this.enabled;
+  }
+
+  /** Show/hide just the DOM frame (without touching the master toggle).
+   *  Driven each frame so the frame only appears when we actually draw
+   *  into the corner. */
+  _showFrame(on) {
+    if (!this.frame) return;
+    const display = on ? 'block' : 'none';
+    if (this.frame.style.display !== display) {
+      // Re-measure on show — the HUD pedal bar isn't laid out until gameplay.
+      if (on) this._onResize();
+      this.frame.style.display = display;
+    }
+  }
+
+  /** Hide the PiP for this frame (e.g. menus/cinematic) without disabling. */
+  hide() {
+    this._showFrame(false);
+  }
+
+  // ----- Per-frame --------------------------------------------------
+
+  update(bike, dt) {
+    if (!this.enabled) return;
+
+    const fwd = this._fwd;
+    fwd.set(Math.sin(bike.heading), 0, Math.cos(bike.heading));
+
+    // In front of the bike, looking back at it.
+    this._desiredPos.copy(bike.position);
+    this._desiredPos.x += fwd.x * this.frontDist;
+    this._desiredPos.z += fwd.z * this.frontDist;
+    this._desiredPos.y += this.height;
+
+    this._desiredLook.copy(bike.position);
+    this._desiredLook.y += this.lookHeight;
+
+    if (!this._initialized) {
+      this._pos.copy(this._desiredPos);
+      this._look.copy(this._desiredLook);
+      this._initialized = true;
+    } else {
+      const k = Math.min(1, 8 * (dt || 0.016));
+      this._pos.lerp(this._desiredPos, k);
+      this._look.lerp(this._desiredLook, k);
+    }
+
+    this.camera.position.copy(this._pos);
+    this.camera.up.set(0, 1, 0);
+    this.camera.lookAt(this._look);
+  }
+
+  /** Re-seat the camera instantly (e.g. after a reset/teleport). */
+  reset() {
+    this._initialized = false;
+  }
+
+  /**
+   * Draw the front view into the corner. Call AFTER the main scene
+   * render so it composites on top. Uses a scissored viewport on the
+   * shared renderer.
+   */
+  render(renderer, scene) {
+    if (!this.enabled || !this._rect) return;
+
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const r = this._rect;
+
+    // WebGL viewport origin is bottom-left.
+    const x = w - r.size - r.marginRight;
+    const y = r.marginBottom;
+
+    this.camera.aspect = 1;
+    this.camera.updateProjectionMatrix();
+
+    renderer.setScissorTest(true);
+    renderer.setScissor(x, y, r.size, r.size);
+    renderer.setViewport(x, y, r.size, r.size);
+    renderer.render(scene, this.camera);
+
+    // Restore full-screen viewport for the next main render.
+    renderer.setScissorTest(false);
+    renderer.setViewport(0, 0, w, h);
+    renderer.setScissor(0, 0, w, h);
+
+    this._showFrame(true);
+  }
+}

--- a/js/game.js
+++ b/js/game.js
@@ -19,6 +19,7 @@ import { BalanceController } from './balance-controller.js';
 import { BikeModel } from './bike-model.js';
 import { RemoteBikeState } from './remote-bike-state.js';
 import { ChaseCamera } from './chase-camera.js';
+import { FrontViewCamera } from './front-view-camera.js';
 import { FinishCameraAnimation } from './finish-camera-animation.js';
 import { World } from './world.js';
 import { HUD } from './hud.js';
@@ -169,6 +170,8 @@ class Game {
     this.bike = new BikeModel(this.scene);
     this.bike.roadPath = this.world.roadPath;
     this.chaseCamera = new ChaseCamera(this.camera);
+    // Picture-in-picture front-facing "selfie cam" of the bike (lower-right).
+    this.frontView = new FrontViewCamera(this.camera);
     this.hud = new HUD(this.input);
     this.grassParticles = new GrassParticles(this.scene);
     this.archIndicator = new ArchIndicator(this.scene);
@@ -575,6 +578,11 @@ class Game {
     window.addEventListener('keydown', (e) => {
       const tag = document.activeElement && document.activeElement.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (e.code === 'KeyV') {
+        // Toggle the front-facing PiP "selfie cam" of the bike.
+        if (this.frontView) this.frontView.toggle();
+        return;
+      }
       if (e.code === 'KeyM') {
         if (e.shiftKey) {
           // Shift+M: toggle volume picker in lobby
@@ -3414,6 +3422,7 @@ class Game {
       this._pollOverlayGamepad();
       this.input.consumeTaps(); // drain buffered input so it doesn't fire when overlay closes
       this.renderer.render(this.scene, this.camera);
+      if (this.frontView) this.frontView.hide();
       return;
     }
     // Stoker input-choice overlay: allow gamepad selection while it's up.
@@ -3421,6 +3430,7 @@ class Game {
       this._pollOverlayGamepad();
       this.input.consumeTaps();
       this.renderer.render(this.scene, this.camera);
+      if (this.frontView) this.frontView.hide();
       return;
     }
 
@@ -3464,6 +3474,19 @@ class Game {
       if (this.archIndicator._visible) this.archIndicator.update(this.bike, 0, 0);
 
       this.renderer.render(this.scene, this.camera);
+    }
+
+    // Front-view PiP — composite a front-facing "selfie cam" of the bike
+    // into the lower-right corner, on top of whatever was just rendered.
+    // Only while a ride is on screen (not during the cinematic, which runs
+    // its own camera choreography).
+    if (this.frontView && this.frontView.enabled && this.bike &&
+        (this.state === 'playing' || this.state === 'countdown')) {
+      this.frontView.update(this.bike, dt);
+      this.frontView.render(this.renderer, this.scene);
+    } else if (this.frontView) {
+      this.frontView.hide();
+      this.frontView.reset();
     }
 
     // Sp3 — feed bike velocity to the procedural motion loop every frame.


### PR DESCRIPTION
## What

Adds a small window in the **lower-right corner** that shows a **front-facing view of the tandem bike and riders as you ride** — the camera sits just ahead of the bike on its heading and looks back, so the bike comes toward you.

Inspired by the [r/Unity3D "parent a camera to your character's face and slap a render texture in the corner"](https://www.reddit.com/r/Unity3D/s/XEQz5g1mGP) trick referenced in the request.

## How

- **New module `js/front-view-camera.js`** (`FrontViewCamera`):
  - Owns a dedicated `PerspectiveCamera` rigged just ahead of the front wheel at roughly rider eye level, looking back at the bike each frame (with light smoothing so it glides).
  - Renders the scene into a **scissored viewport on the shared `WebGLRenderer`** — no second renderer, no render target. The cost is one extra scene draw confined to a small rectangle, composited on top after the main scene render.
  - A lightweight DOM frame provides the rounded, bordered "screen" look with a `FRONT VIEW` label.
  - The corner square auto-sizes to the screen and **lifts above the on-screen pedal bar** so HUD controls never occlude it.
- **Wired into the main loop** (`js/game.js`) for every ride mode (solo / captain / stoker / local). It's hidden during menus, overlays, and the finish cinematic, and re-seats instantly on reset.
- **Toggle with the `V` key.** On by default.

## Verification

Drove the game into a live solo ride in headless Chrome (SwiftShader) and confirmed:
- `state: playing`, front view enabled, frame displayed, scene rendering correctly.
- The PiP shows the front of the bike + rider coming toward the camera with the road/scenery behind.
- Pressing `V` hides the PiP (frame `display: none`, rendering skipped) and toggles it back on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CipBeC79qV4Jz4MphLHzGf)_