### PR TITLE
Show Riders: goose riders with balance-driven lean + front camera (opt-in, default off)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 | # | Domain | Key Concern | Key Files |
 |---|--------|-------------|-----------|
-| 1 | Bike Physics & Balance | Tilt, lean, gravity, pedaling, crank, camera | `bike-model.js`, `balance-controller.js`, `pedal-controller.js`, `chase-camera.js` |
+| 1 | Bike Physics & Balance | Tilt, lean, gravity, pedaling, crank, camera | `bike-model.js`, `balance-controller.js`, `pedal-controller.js`, `chase-camera.js`, `front-view-camera.js` |
 | 2 | Race Management | Checkpoints, timers, scoring, finish | `race-manager.js` |
 | 3 | Levels & Routes | Road generation, level configs, terrain | `race-config.js`, `road-path.js`, `road-chunks.js` |
 | 4 | World Content | Obstacles, collectibles, billboards, scenery, trees, particles, audio | `world.js`, `obstacles.js`, `collectibles.js`, `grass-particles.js`, `assets/*.mp3` |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ npx serve -l 8888
 Open `http://localhost:8888` in your browser.
 
 - **Solo**: Click SOLO RIDE — pedal with Up/Down arrows, lean with A/D (or tilt on mobile)
+- **Front view**: A small window in the lower-right shows a front-facing "selfie cam" of the bike as you ride. Toggle it with `V`.
 - **Multiplayer**: Click RIDE TOGETHER — one player creates a room, the other joins with the room code
 
 ## Multiplayer

--- a/index.html
+++ b/index.html
@@ -4696,6 +4696,12 @@ ON</button>
       <button class="opt-btn" id="opt-gyro-gravity">Gravity</button>
     </div>
     <div class="options-note">Controller gyro only — applies immediately</div>
+    <div class="label" id="opt-riders-label">Show Riders</div>
+    <div class="options-row" id="opt-riders-row">
+      <button class="opt-btn" id="opt-riders-on">On</button>
+      <button class="opt-btn" id="opt-riders-off">Off</button>
+    </div>
+    <div class="options-note">Canadian-goose riders + front camera — applied on next launch</div>
     <button id="options-perf-btn">Run Perf Test</button>
     <div id="options-perf-result"></div>
     <button id="options-devtools-btn">Tools</button>

--- a/index.html
+++ b/index.html
@@ -2928,6 +2928,14 @@
     min-width: 300px;
     max-width: 400px;
     text-align: center;
+    /* Cap to the viewport and scroll internally so tall content (e.g. the
+       Show Riders row) is reachable on short/mobile screens by touch. dvh
+       tracks the mobile URL bar; vh is the fallback. */
+    max-height: 85vh;
+    max-height: 90dvh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
   }
   .options-card h2 { font-size: 20px; margin-bottom: 20px; }
   .options-card .label { font-size: 12px; color: rgba(255,255,255,0.5); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px; }

--- a/index.html
+++ b/index.html
@@ -4374,7 +4374,7 @@ ON</button>
     <div id="gamepad-back-hint" class="gamepad-back-hint" style="visibility:hidden;">
       <span id="gamepad-back-icon"></span> Back
     </div>
-    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.3476abd | 04-12-2026 09:18</span> <button class="lobby-credits-btn" id="ctrl-test-btn" title="Steam Input live diagnostic">🎮 Test</button></p>
+    <p class="lobby-credits"><a href="https://games.usersfirst.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;">Users First (Games)</a> <button class="lobby-credits-btn" id="credits-btn">&copy;</button> <span id="lobby-license-icon"></span> <span class="lobby-version" id="lobby-version">v.3476abd | 04-12-2026 09:18</span> <button class="lobby-credits-btn" id="ctrl-test-btn" title="Controller test — Steam Input live diagnostic">🎮</button> <button class="lobby-credits-btn" id="ctrl-settings-btn" title="Settings">⚙️</button></p>
   </div>
   <img id="lobby-banner-bottom" src="images/tandemonium_three_actions.png" alt="Tandemonium Actions">
   <img id="lobby-img-left" class="lobby-desktop-img" src="images/large_action_behind.png" alt="">

--- a/js/bike-model.js
+++ b/js/bike-model.js
@@ -4,7 +4,21 @@
 
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
 import { BIKE_MODEL_PATH, TUNE } from './config.js';
+
+// The riders GLB ships Draco-compressed geometry to keep it small; the plain
+// frame GLB isn't compressed, so the decoder is only fetched when a Draco mesh
+// is actually encountered. Version-matched to the CDN three build. Shared across
+// all BikeModel loads.
+let _dracoLoader = null;
+function getDracoLoader() {
+  if (!_dracoLoader) {
+    _dracoLoader = new DRACOLoader();
+    _dracoLoader.setDecoderPath('https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/libs/draco/');
+  }
+  return _dracoLoader;
+}
 
 export class BikeModel {
   constructor(scene, modelPath) {
@@ -85,6 +99,7 @@ export class BikeModel {
 
   _loadModel() {
     const loader = new GLTFLoader();
+    loader.setDRACOLoader(getDracoLoader());
     loader.load(this._modelPath, (gltf) => {
       const model = gltf.scene;
       model.traverse((child) => {

--- a/js/bike-model.js
+++ b/js/bike-model.js
@@ -223,11 +223,15 @@ export class BikeModel {
     const k = Math.min(1, 12 * (dt || 1 / 60));
     this._captainLeanNorm += (this._captainLeanTarget - this._captainLeanNorm) * k;
     this._stokerLeanNorm += (this._stokerLeanTarget - this._stokerLeanNorm) * k;
+    // Map [-1, 1] -> the monotonic clip [0, duration], NEGATED so the riders
+    // lean into the same side the bike tilts. (After the model's RIDER_MODEL_YAW,
+    // the baked torso roll composes with the group's Z-tilt such that matching
+    // signs read as opposite in the full scene, so we flip here.)
     if (this.captainAction) {
-      this.captainAction.time = (this._captainLeanNorm * 0.5 + 0.5) * this.riderClipDuration;
+      this.captainAction.time = (0.5 - this._captainLeanNorm * 0.5) * this.riderClipDuration;
     }
     if (this.stokerAction) {
-      this.stokerAction.time = (this._stokerLeanNorm * 0.5 + 0.5) * this.riderClipDuration;
+      this.stokerAction.time = (0.5 - this._stokerLeanNorm * 0.5) * this.riderClipDuration;
     }
     this.riderMixer.update(0); // apply the posed times without advancing them
   }
@@ -311,8 +315,11 @@ export class BikeModel {
     // both sway with the single aggregate lean (solo). The bike's tilt itself is
     // unaffected — that still comes from this.lean in _applyTransform.
     if (this.riderMixer) {
+      // Coop provides each rider's own lean; solo provides only the aggregate
+      // leanInput, in which case the captain leans with it and the stoker (who
+      // has no second input in solo) stays upright.
       const cap = (balanceResult.captainLean != null) ? balanceResult.captainLean : balanceResult.leanInput;
-      const sto = (balanceResult.stokerLean != null) ? balanceResult.stokerLean : balanceResult.leanInput;
+      const sto = (balanceResult.stokerLean != null) ? balanceResult.stokerLean : 0;
       this.setRiderLeans(cap, sto);
     }
 

--- a/js/bike-model.js
+++ b/js/bike-model.js
@@ -60,8 +60,28 @@ export class BikeModel {
     this._tmpAxisZ = new THREE.Vector3(0, 0, 1);
     this._tmpAxisX = new THREE.Vector3(1, 0, 0);
 
+    // Rider-lean: the captain and stoker sway their torsos INDEPENDENTLY — each
+    // by their own gyro/lean input — while the whole bike still tilts by this.lean
+    // (the aggregate) in _applyTransform. Only set up when the loaded GLB carries
+    // the skinned rider armature + the two lean clips. See _setupRiderLean.
+    this.riderMixer = null;
+    this.captainAction = null;
+    this.stokerAction = null;
+    this.riderClipDuration = 0;
+    this._captainLeanTarget = 0; // [-1, 1] this frame's captain input
+    this._stokerLeanTarget = 0;  // [-1, 1] this frame's stoker input
+    this._captainLeanNorm = 0;   // smoothed
+    this._stokerLeanNorm = 0;    // smoothed
+
     this._loadModel();
   }
+
+  // Torso lean (radians) at the ends of the exported clip — matches LEAN_AMP_DEG
+  // in export_riders_lean_glb.py, so |normalized lean| = 1 maps to the clip peak.
+  static RIDER_LEAN_AMP = 45 * Math.PI / 180;
+  // Yaw applied to the riders GLB so its authored forward (Blender -X) faces the
+  // travel direction. Tuned against the road in _loadModel.
+  static RIDER_MODEL_YAW = Math.PI / 2;
 
   _loadModel() {
     const loader = new GLTFLoader();
@@ -86,6 +106,10 @@ export class BikeModel {
         }
       });
 
+      // The riders GLB ships a skinned armature + a lean clip; the plain frame
+      // GLB ships neither. Detect it here to drive rider lean and orient it.
+      const isRiders = !!(gltf.animations && gltf.animations.length > 0);
+
       // Scale to ~4.4m long
       const targetLength = 4.4;
       const preBox = new THREE.Box3().setFromObject(model);
@@ -93,6 +117,10 @@ export class BikeModel {
       const maxDim = Math.max(preSize.x, preSize.y, preSize.z);
       const scale = targetLength / maxDim;
       model.scale.setScalar(scale);
+
+      // Face the riders model down the road. Applied before the bounds scan so
+      // recentering happens in the final orientation.
+      if (isRiders) model.rotation.y = BikeModel.RIDER_MODEL_YAW;
 
       this.group.add(model);
       this.group.updateMatrixWorld(true);
@@ -126,16 +154,92 @@ export class BikeModel {
       model.position.z -= centerZ;
 
       this.modelLoaded = true;
+      if (isRiders) this._setupRiderLean(model, gltf.animations);
       console.log('Bike loaded. Spokes:', this.spokeMeshes.length,
-        'Pedals:', this.pedalNodes.length);
+        'Pedals:', this.pedalNodes.length, 'Riders:', isRiders);
 
       if (this._pendingPreset) {
         this.applyPreset(this._pendingPreset);
         this._pendingPreset = null;
       }
     }, undefined, (err) => {
-      console.error('Failed to load tandem_bicycle.glb:', err);
+      console.error('Failed to load bike model:', this._modelPath, err);
     });
+  }
+
+  /**
+   * Wire the two exported rider-lean clips for independent scrubbing. Each clip
+   * is a MONOTONIC sweep (frame 1 = full lean one way, last = full lean the
+   * other): CaptainLean moves only the captain's spine/chest (his arm IK baked
+   * so gloves stay on the bars); StokerLean only the stoker's. We don't play
+   * them — each frame we scrub each to the time matching THAT rider's own lean.
+   *
+   * The exporter samples every bone into both clips (constant for the still
+   * rider), so the raw clips would fight over shared bones. We strip each clip
+   * down to just its rider's bones (M_* / F_*) so the two play together without
+   * interfering; the Bike_* bones stay in neither, so the frame keeps its bind
+   * pose and the whole-bike tilt is left to _applyTransform (this.lean).
+   */
+  _setupRiderLean(model, animations) {
+    this.riderMixer = new THREE.AnimationMixer(model);
+    const byName = (n) => animations.find(c => c.name === n);
+    const cap = byName('CaptainLean') || animations[0];
+    const sto = byName('StokerLean') || animations[1];
+    if (cap) {
+      this._keepTracksWithPrefix(cap, 'M_');
+      this.riderClipDuration = cap.duration;
+      this.captainAction = this._makeScrubAction(cap);
+    }
+    if (sto) {
+      this._keepTracksWithPrefix(sto, 'F_');
+      this.riderClipDuration = this.riderClipDuration || sto.duration;
+      this.stokerAction = this._makeScrubAction(sto);
+    }
+  }
+
+  // Drop every track whose target bone isn't this rider's, so two clips that
+  // were each sampled over the full skeleton no longer collide.
+  _keepTracksWithPrefix(clip, prefix) {
+    clip.tracks = clip.tracks.filter(t => t.name.startsWith(prefix));
+  }
+
+  _makeScrubAction(clip) {
+    const action = this.riderMixer.clipAction(clip);
+    action.play();
+    action.paused = true; // we drive .time ourselves, never let it advance
+    return action;
+  }
+
+  /**
+   * Scrub each rider's lean clip to that rider's own input. _captainLeanTarget /
+   * _stokerLeanTarget are the two gyro/lean inputs in [-1, 1] (set from
+   * balanceResult in update()); the bike's own tilt still comes from this.lean
+   * (the aggregate) in _applyTransform. Map [-1, 1] -> the monotonic clip
+   * [0, duration].
+   */
+  _updateRiderLean(dt) {
+    if (!this.riderMixer) return;
+    // Light smoothing so wobble/danger-shake doesn't make the riders twitch.
+    const k = Math.min(1, 12 * (dt || 1 / 60));
+    this._captainLeanNorm += (this._captainLeanTarget - this._captainLeanNorm) * k;
+    this._stokerLeanNorm += (this._stokerLeanTarget - this._stokerLeanNorm) * k;
+    if (this.captainAction) {
+      this.captainAction.time = (this._captainLeanNorm * 0.5 + 0.5) * this.riderClipDuration;
+    }
+    if (this.stokerAction) {
+      this.stokerAction.time = (this._stokerLeanNorm * 0.5 + 0.5) * this.riderClipDuration;
+    }
+    this.riderMixer.update(0); // apply the posed times without advancing them
+  }
+
+  /**
+   * Set this frame's rider lean inputs (each in [-1, 1]). Call before/within
+   * update(). captain = the captain's own lean, stoker = the stoker's own lean.
+   * In solo play pass the single lean for both so the pair sways together.
+   */
+  setRiderLeans(captain, stoker) {
+    this._captainLeanTarget = Math.max(-1, Math.min(1, captain));
+    this._stokerLeanTarget = Math.max(-1, Math.min(1, stoker));
   }
 
   applyPreset(presetData) {
@@ -201,6 +305,16 @@ export class BikeModel {
 
   update(pedalResult, balanceResult, dt, safetyMode, autoSpeed) {
     this.crankAngle = pedalResult.crankAngle;
+
+    // Rider torso lean. Each rider leans by their OWN input when the caller
+    // provides it (coop: captainLean / stokerLean on balanceResult); otherwise
+    // both sway with the single aggregate lean (solo). The bike's tilt itself is
+    // unaffected — that still comes from this.lean in _applyTransform.
+    if (this.riderMixer) {
+      const cap = (balanceResult.captainLean != null) ? balanceResult.captainLean : balanceResult.leanInput;
+      const sto = (balanceResult.stokerLean != null) ? balanceResult.stokerLean : balanceResult.leanInput;
+      this.setRiderLeans(cap, sto);
+    }
 
     if (this.fallen) {
       this.fallTimer -= dt;
@@ -509,6 +623,9 @@ export class BikeModel {
     this._tmpQ.multiplyQuaternions(this._tmpQYaw, this._tmpQPitch);
     this._tmpQ.multiply(this._tmpQLean);
     this.group.quaternion.copy(this._tmpQ);
+
+    // Sway the riders to match the balance (no-op on the rider-less frame GLB).
+    this._updateRiderLean(dt);
   }
 
   _fall() {

--- a/js/config.js
+++ b/js/config.js
@@ -14,6 +14,11 @@ export const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
 // rider-less frame lives at 'tandem-3d/tandem_bicycle.glb'.
 export const BIKE_MODEL_PATH = 'tandem-3d/tandem_riders.glb';
 
+// The bike chooser / lobby preview keeps the original recolorable frame so the
+// color presets still take effect there. The in-game bike uses the riders model
+// above (one fused mesh, so presets no-op on it).
+export const CHOOSER_MODEL_PATH = 'tandem-3d/tandem_bicycle.glb';
+
 // Protocol message types
 export const MSG_PEDAL     = 0x01;
 export const MSG_STATE     = 0x02;

--- a/js/config.js
+++ b/js/config.js
@@ -9,7 +9,10 @@ export const isMobile = !_isElectron && (
 export const isAndroid = /Android/i.test(navigator.userAgent);
 export const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
 
-export const BIKE_MODEL_PATH = 'tandem-3d/tandem_bicycle.glb';
+// Riders model: the fused tandem + Victorian goose captain & stoker, skinned so
+// their torsos lean with the balance. See BikeModel rider-lean wiring. The older
+// rider-less frame lives at 'tandem-3d/tandem_bicycle.glb'.
+export const BIKE_MODEL_PATH = 'tandem-3d/tandem_riders.glb';
 
 // Protocol message types
 export const MSG_PEDAL     = 0x01;

--- a/js/config.js
+++ b/js/config.js
@@ -19,6 +19,17 @@ export const BIKE_MODEL_PATH = 'tandem-3d/tandem_riders.glb';
 // above (one fused mesh, so presets no-op on it).
 export const CHOOSER_MODEL_PATH = 'tandem-3d/tandem_bicycle.glb';
 
+/**
+ * "Show Riders" setting — when on, the in-game bike is the Canadian-goose
+ * riders model (with torso lean + the front-facing selfie cam); when off, the
+ * plain frame. Off by default. Read at boot (see Game constructor); the Options
+ * dialog persists it and it applies on next launch.
+ */
+export function getShowRiders() {
+  try { return localStorage.getItem('tandemonium_show_riders') === 'on'; }
+  catch (e) { return false; }
+}
+
 // Protocol message types
 export const MSG_PEDAL     = 0x01;
 export const MSG_STATE     = 0x02;

--- a/js/front-view-camera.js
+++ b/js/front-view-camera.js
@@ -76,14 +76,26 @@ export class FrontViewCamera {
     this.frame = frame;
   }
 
-  /** Lower-right square sized relative to the smaller screen dimension.
-   *  Lifts above the on-screen pedal controls (touch layout) so the PiP
-   *  is never occluded by them. */
+  /** Square sized relative to the smaller screen dimension. Returns the
+   *  top-left CSS position + size. In multiplayer, if the partner webcam PiP is
+   *  on screen (it shares the front-view's lower-right corner), the front view
+   *  stacks directly ABOVE it, right-aligned and taken live from its rect, so
+   *  the two never overlap. Otherwise it sits lower-right, above the pedal bar. */
   _computeRect() {
     const w = window.innerWidth;
     const h = window.innerHeight;
     const size = Math.round(Math.min(w, h) * 0.28);
     const margin = Math.round(Math.min(w, h) * 0.035);
+
+    const pip = this._partnerPipRect();
+    if (pip) {
+      const gap = Math.round(Math.min(w, h) * 0.02);
+      // Right edges aligned to the PiP (match its own edge margin); only clamp
+      // enough to keep the square fully on-screen.
+      let cssLeft = Math.max(0, Math.min(pip.right - size, w - size));
+      let cssTop = Math.max(0, pip.top - size - gap);  // parked just above the PiP
+      return { size, cssLeft, cssTop };
+    }
 
     // Clear the bottom pedal bar if it's visible (touch / portrait layout).
     let bottomClear = margin;
@@ -94,24 +106,34 @@ export class FrontViewCamera {
       if (visible) bottomClear = Math.max(margin, h - r.top + margin);
     }
 
-    return {
-      size,
-      marginRight: margin,
-      marginBottom: bottomClear,
-      cssLeft: w - size - margin,
-      cssTop: h - size - bottomClear,
-    };
+    return { size, cssLeft: w - size - margin, cssTop: h - size - bottomClear };
+  }
+
+  /** The partner webcam PiP's on-screen rect when it's actually visible with
+   *  content, else null. The recorder toggles its display when the partner has
+   *  a camera/avatar, so this is how we detect "multiplayer has video there". */
+  _partnerPipRect() {
+    const el = document.getElementById('partner-pip-wrap');
+    if (!el) return null;
+    const cs = getComputedStyle(el);
+    if (cs.display === 'none' || cs.visibility === 'hidden' || cs.opacity === '0') return null;
+    const r = el.getBoundingClientRect();
+    if (r.width < 4 || r.height < 4) return null;
+    if (r.bottom <= 0 || r.top >= window.innerHeight) return null; // off-screen
+    return r;
+  }
+
+  _applyRectToFrame(r) {
+    if (!this.frame) return;
+    this.frame.style.width = r.size + 'px';
+    this.frame.style.height = r.size + 'px';
+    this.frame.style.left = r.cssLeft + 'px';
+    this.frame.style.top = r.cssTop + 'px';
   }
 
   _onResize() {
-    const r = this._computeRect();
-    this._rect = r;
-    if (this.frame) {
-      this.frame.style.width = r.size + 'px';
-      this.frame.style.height = r.size + 'px';
-      this.frame.style.left = r.cssLeft + 'px';
-      this.frame.style.top = r.cssTop + 'px';
-    }
+    this._rect = this._computeRect();
+    this._applyRectToFrame(this._rect);
   }
 
   /** Master on/off (user toggle). When off, nothing renders and the
@@ -187,15 +209,18 @@ export class FrontViewCamera {
    * shared renderer.
    */
   render(renderer, scene) {
-    if (!this.enabled || !this._rect) return;
+    if (!this.enabled) return;
 
     const w = window.innerWidth;
     const h = window.innerHeight;
-    const r = this._rect;
+    // Recompute live so the PiP tracks the partner webcam appearing/leaving
+    // (and any resize) mid-ride. Reads happen before the DOM-frame writes below.
+    const r = this._computeRect();
+    this._rect = r;
 
-    // WebGL viewport origin is bottom-left.
-    const x = w - r.size - r.marginRight;
-    const y = r.marginBottom;
+    // WebGL viewport origin is bottom-left; derive from the CSS top-left rect.
+    const x = Math.round(r.cssLeft);
+    const y = Math.round(h - r.cssTop - r.size);
 
     this.camera.aspect = 1;
     this.camera.updateProjectionMatrix();
@@ -210,6 +235,7 @@ export class FrontViewCamera {
     renderer.setViewport(0, 0, w, h);
     renderer.setScissor(0, 0, w, h);
 
+    this._applyRectToFrame(r);
     this._showFrame(true);
   }
 }

--- a/js/front-view-camera.js
+++ b/js/front-view-camera.js
@@ -1,0 +1,215 @@
+// ============================================================
+// FRONT-VIEW CAMERA (picture-in-picture "selfie cam")
+// ============================================================
+//
+// A small window in the lower-right corner that shows a front-facing
+// view of the bike as you ride — the camera sits ahead of the bike on
+// its heading and looks back at the riders, so you watch the tandem (and
+// both riders) coming toward you. Inspired by the r/Unity3D trick of
+// parenting a camera to a character's face and dropping a render texture
+// in the corner.
+//
+// Rendering reuses the main WebGLRenderer via a scissored viewport — no
+// second renderer, no render target — so the cost is one extra scene
+// draw confined to a small rectangle. A DOM frame is layered on top to
+// give it the rounded, bordered "screen" look.
+
+import * as THREE from 'three';
+
+export class FrontViewCamera {
+  constructor(mainCamera) {
+    this.enabled = true;
+
+    // Dedicated camera for the PiP. Square aspect (set in render()).
+    this.camera = new THREE.PerspectiveCamera(50, 1, 0.1, 500);
+
+    // Rig: how the camera sits relative to the bike. Sits just ahead of the
+    // front wheel at roughly rider eye level, looking back so the tandem and
+    // both riders fill the frame as they come toward you.
+    this.frontDist = 4.6;   // units ahead of bike center, along heading
+    this.height = 1.95;     // camera eye height above the bike origin
+    this.lookHeight = 1.45; // height of the point we aim at (riders)
+
+    // Smoothed position/target so the view glides instead of snapping.
+    this._pos = new THREE.Vector3();
+    this._look = new THREE.Vector3();
+    this._desiredPos = new THREE.Vector3();
+    this._desiredLook = new THREE.Vector3();
+    this._fwd = new THREE.Vector3();
+    this._initialized = false;
+
+    this._buildFrame();
+    this._onResize();
+    window.addEventListener('resize', () => this._onResize());
+  }
+
+  // ----- DOM frame --------------------------------------------------
+
+  _buildFrame() {
+    const frame = document.createElement('div');
+    frame.id = 'front-view-frame';
+    frame.style.cssText = [
+      'position:fixed',
+      'pointer-events:none',
+      'z-index:40',
+      'border:3px solid rgba(255,255,255,0.92)',
+      'border-radius:14px',
+      'box-shadow:0 6px 22px rgba(0,0,0,0.45)',
+      'overflow:hidden',
+      'box-sizing:border-box',
+    ].join(';');
+
+    const label = document.createElement('div');
+    label.textContent = 'FRONT VIEW';
+    label.style.cssText = [
+      'position:absolute',
+      'left:8px',
+      'top:6px',
+      'font:600 11px/1 system-ui,sans-serif',
+      'letter-spacing:0.08em',
+      'color:rgba(255,255,255,0.95)',
+      'text-shadow:0 1px 3px rgba(0,0,0,0.8)',
+    ].join(';');
+    frame.appendChild(label);
+
+    document.body.appendChild(frame);
+    this.frame = frame;
+  }
+
+  /** Lower-right square sized relative to the smaller screen dimension.
+   *  Lifts above the on-screen pedal controls (touch layout) so the PiP
+   *  is never occluded by them. */
+  _computeRect() {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const size = Math.round(Math.min(w, h) * 0.28);
+    const margin = Math.round(Math.min(w, h) * 0.035);
+
+    // Clear the bottom pedal bar if it's visible (touch / portrait layout).
+    let bottomClear = margin;
+    const bar = document.getElementById('pedal-bar');
+    if (bar) {
+      const r = bar.getBoundingClientRect();
+      const visible = r.height > 0 && getComputedStyle(bar).display !== 'none';
+      if (visible) bottomClear = Math.max(margin, h - r.top + margin);
+    }
+
+    return {
+      size,
+      marginRight: margin,
+      marginBottom: bottomClear,
+      cssLeft: w - size - margin,
+      cssTop: h - size - bottomClear,
+    };
+  }
+
+  _onResize() {
+    const r = this._computeRect();
+    this._rect = r;
+    if (this.frame) {
+      this.frame.style.width = r.size + 'px';
+      this.frame.style.height = r.size + 'px';
+      this.frame.style.left = r.cssLeft + 'px';
+      this.frame.style.top = r.cssTop + 'px';
+    }
+  }
+
+  /** Master on/off (user toggle). When off, nothing renders and the
+   *  frame is hidden until re-enabled. */
+  setVisible(on) {
+    this.enabled = on;
+    if (!on) this._showFrame(false);
+  }
+
+  toggle() {
+    this.setVisible(!this.enabled);
+    return this.enabled;
+  }
+
+  /** Show/hide just the DOM frame (without touching the master toggle).
+   *  Driven each frame so the frame only appears when we actually draw
+   *  into the corner. */
+  _showFrame(on) {
+    if (!this.frame) return;
+    const display = on ? 'block' : 'none';
+    if (this.frame.style.display !== display) {
+      // Re-measure on show — the HUD pedal bar isn't laid out until gameplay.
+      if (on) this._onResize();
+      this.frame.style.display = display;
+    }
+  }
+
+  /** Hide the PiP for this frame (e.g. menus/cinematic) without disabling. */
+  hide() {
+    this._showFrame(false);
+  }
+
+  // ----- Per-frame --------------------------------------------------
+
+  update(bike, dt) {
+    if (!this.enabled) return;
+
+    const fwd = this._fwd;
+    fwd.set(Math.sin(bike.heading), 0, Math.cos(bike.heading));
+
+    // In front of the bike, looking back at it.
+    this._desiredPos.copy(bike.position);
+    this._desiredPos.x += fwd.x * this.frontDist;
+    this._desiredPos.z += fwd.z * this.frontDist;
+    this._desiredPos.y += this.height;
+
+    this._desiredLook.copy(bike.position);
+    this._desiredLook.y += this.lookHeight;
+
+    if (!this._initialized) {
+      this._pos.copy(this._desiredPos);
+      this._look.copy(this._desiredLook);
+      this._initialized = true;
+    } else {
+      const k = Math.min(1, 8 * (dt || 0.016));
+      this._pos.lerp(this._desiredPos, k);
+      this._look.lerp(this._desiredLook, k);
+    }
+
+    this.camera.position.copy(this._pos);
+    this.camera.up.set(0, 1, 0);
+    this.camera.lookAt(this._look);
+  }
+
+  /** Re-seat the camera instantly (e.g. after a reset/teleport). */
+  reset() {
+    this._initialized = false;
+  }
+
+  /**
+   * Draw the front view into the corner. Call AFTER the main scene
+   * render so it composites on top. Uses a scissored viewport on the
+   * shared renderer.
+   */
+  render(renderer, scene) {
+    if (!this.enabled || !this._rect) return;
+
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const r = this._rect;
+
+    // WebGL viewport origin is bottom-left.
+    const x = w - r.size - r.marginRight;
+    const y = r.marginBottom;
+
+    this.camera.aspect = 1;
+    this.camera.updateProjectionMatrix();
+
+    renderer.setScissorTest(true);
+    renderer.setScissor(x, y, r.size, r.size);
+    renderer.setViewport(x, y, r.size, r.size);
+    renderer.render(scene, this.camera);
+
+    // Restore full-screen viewport for the next main render.
+    renderer.setScissorTest(false);
+    renderer.setViewport(0, 0, w, h);
+    renderer.setScissor(0, 0, w, h);
+
+    this._showFrame(true);
+  }
+}

--- a/js/game.js
+++ b/js/game.js
@@ -3,6 +3,7 @@
 // ============================================================
 
 import * as THREE from 'three';
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 import { isMobile, isAndroid, isIOS, EVT_COUNTDOWN, EVT_START, EVT_RESET, EVT_GAMEOVER, EVT_CHECKPOINT, EVT_FINISH, EVT_RETURN_ROOM, MSG_PROFILE, TUNE, BALANCE_DEFAULTS, GUEST_NAME, applyDifficulty, applySteeringFeel, snapshotTuningBase } from './config.js';
 import { RaceManager } from './race-manager.js';
 import { getLevelById, LEVELS } from './race-config.js';
@@ -113,10 +114,23 @@ class Game {
     this.renderer.setPixelRatio(this._lowQuality ? 0.5 : Math.min(window.devicePixelRatio, 2));
     this.renderer.shadowMap.enabled = !isMobile && !this._lowQuality;
     if (!isMobile && !this._lowQuality) this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    // Filmic tone mapping so PBR colors (the riders' brass/silk/coat, and the
+    // world) read rich instead of the flat raw output. AgX keeps the Victorian
+    // reds/browns true where ACES would desaturate them; exposure is the dial.
+    this.renderer.toneMapping = THREE.AgXToneMapping;
+    this.renderer.toneMappingExposure = 1.3;
     document.body.prepend(this.renderer.domElement);
 
     // Scene
     this.scene = new THREE.Scene();
+
+    // Soft image-based lighting: PBR materials expect an environment to reflect;
+    // without one they read muddy. RoomEnvironment is generated procedurally (no
+    // asset files), so brass, silk, and the coat pick up gentle reflections and
+    // their colors pop. Applies scene-wide.
+    const _pmrem = new THREE.PMREMGenerator(this.renderer);
+    this.scene.environment = _pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+    _pmrem.dispose();
 
     // Sky gradient: rich blue top → soft light blue at horizon
     const skyCanvas = document.createElement('canvas');

--- a/js/game.js
+++ b/js/game.js
@@ -3068,6 +3068,16 @@ class Game {
     autoBtn.addEventListener('click', () => this._setQuality('auto'));
     devToolsBtn.addEventListener('click', () => { window.location.href = 'test/index.html'; });
 
+    // Lobby gear icon → open settings. Works on every platform (click/tap), so
+    // touch and controller users can reach Options without the Start-button combo.
+    const settingsBtn = document.getElementById('ctrl-settings-btn');
+    if (settingsBtn) {
+      settingsBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._openOptions();
+      });
+    }
+
     const dsAutoBtn   = document.getElementById('opt-ds-auto');
     const dsSteamBtn  = document.getElementById('opt-ds-steam');
     const dsWebhidBtn = document.getElementById('opt-ds-webhid');

--- a/js/game.js
+++ b/js/game.js
@@ -604,11 +604,6 @@ class Game {
     window.addEventListener('keydown', (e) => {
       const tag = document.activeElement && document.activeElement.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-      if (e.code === 'KeyV') {
-        // Toggle the front-facing PiP "selfie cam" of the bike.
-        if (this.frontView) this.frontView.toggle();
-        return;
-      }
       if (e.code === 'KeyM') {
         if (e.shiftKey) {
           // Shift+M: toggle volume picker in lobby

--- a/js/game.js
+++ b/js/game.js
@@ -3594,6 +3594,11 @@ class Game {
       (balanceResult.leanInput + this.remoteLean) * 0.5
     ));
 
+    // Independent rider torsos: captain leans by his own gyro, stoker by hers,
+    // while the bike tilts by the merged aggregate above (leanInput).
+    balanceResult.captainLean = captainLean;
+    balanceResult.stokerLean = this.remoteLean;
+
     const wasFallen = this.bike.fallen;
     this.bike.update(pedalResult, balanceResult, dt, this.safetyMode, this.autoSpeed);
     this._checkTreeCollision();
@@ -3879,6 +3884,10 @@ class Game {
     this.hud.update(this.bike, this.input, this.pedalCtrl, dt, remoteData);
     const stokerLean = this.balanceCtrl.update().leanInput;
     this.archIndicator.update(this.bike, stokerLean, this.remoteLean);
+    // Independent rider torsos on the stoker's screen too: captain leans by the
+    // lean he broadcasts (this.remoteLean), the stoker by her own local lean.
+    // applyRemoteState() poses the riders from these targets next frame.
+    this.bike.setRiderLeans(this.remoteLean, stokerLean);
     this.renderer.render(this.scene, this.camera);
     this.recorder.composite(this._buildRecordState(this.pedalCtrl, remoteData));
   }

--- a/js/game.js
+++ b/js/game.js
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
-import { isMobile, isAndroid, isIOS, EVT_COUNTDOWN, EVT_START, EVT_RESET, EVT_GAMEOVER, EVT_CHECKPOINT, EVT_FINISH, EVT_RETURN_ROOM, MSG_PROFILE, TUNE, BALANCE_DEFAULTS, GUEST_NAME, applyDifficulty, applySteeringFeel, snapshotTuningBase } from './config.js';
+import { isMobile, isAndroid, isIOS, EVT_COUNTDOWN, EVT_START, EVT_RESET, EVT_GAMEOVER, EVT_CHECKPOINT, EVT_FINISH, EVT_RETURN_ROOM, MSG_PROFILE, TUNE, BALANCE_DEFAULTS, GUEST_NAME, BIKE_MODEL_PATH, CHOOSER_MODEL_PATH, getShowRiders, applyDifficulty, applySteeringFeel, snapshotTuningBase } from './config.js';
 import { RaceManager } from './race-manager.js';
 import { getLevelById, LEVELS } from './race-config.js';
 import { ContributionTracker } from './contribution-tracker.js';
@@ -109,28 +109,37 @@ class Game {
       this._lowQuality = false;
     }
 
+    // "Show Riders" (Options, default off) gates the whole riders experience:
+    // the goose model + front selfie-cam AND the richer lighting/tone-mapping
+    // tuned for them. Off = the base game exactly as before. Read once at boot.
+    this._showRiders = getShowRiders();
+
     this.renderer = new THREE.WebGLRenderer({ antialias: !isMobile && !this._lowQuality, preserveDrawingBuffer: true });
     this.renderer.setSize(window.innerWidth, window.innerHeight);
     this.renderer.setPixelRatio(this._lowQuality ? 0.5 : Math.min(window.devicePixelRatio, 2));
     this.renderer.shadowMap.enabled = !isMobile && !this._lowQuality;
     if (!isMobile && !this._lowQuality) this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-    // Filmic tone mapping so PBR colors (the riders' brass/silk/coat, and the
-    // world) read rich instead of the flat raw output. AgX keeps the Victorian
-    // reds/browns true where ACES would desaturate them; exposure is the dial.
-    this.renderer.toneMapping = THREE.AgXToneMapping;
-    this.renderer.toneMappingExposure = 1.3;
+    if (this._showRiders) {
+      // Filmic tone mapping so PBR colors (the riders' brass/silk/coat, and the
+      // world) read rich instead of the flat raw output. AgX keeps the Victorian
+      // reds/browns true where ACES would desaturate them; exposure is the dial.
+      this.renderer.toneMapping = THREE.AgXToneMapping;
+      this.renderer.toneMappingExposure = 1.3;
+    }
     document.body.prepend(this.renderer.domElement);
 
     // Scene
     this.scene = new THREE.Scene();
 
-    // Soft image-based lighting: PBR materials expect an environment to reflect;
-    // without one they read muddy. RoomEnvironment is generated procedurally (no
-    // asset files), so brass, silk, and the coat pick up gentle reflections and
-    // their colors pop. Applies scene-wide.
-    const _pmrem = new THREE.PMREMGenerator(this.renderer);
-    this.scene.environment = _pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
-    _pmrem.dispose();
+    if (this._showRiders) {
+      // Soft image-based lighting: PBR materials expect an environment to
+      // reflect; without one they read muddy. RoomEnvironment is generated
+      // procedurally (no asset files), so brass, silk, and the coat pick up
+      // gentle reflections and their colors pop.
+      const _pmrem = new THREE.PMREMGenerator(this.renderer);
+      this.scene.environment = _pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+      _pmrem.dispose();
+    }
 
     // Sky gradient: rich blue top → soft light blue at horizon
     const skyCanvas = document.createElement('canvas');
@@ -180,12 +189,15 @@ class Game {
     setHapticSources([this.input]);
     this.pedalCtrl = new PedalController(this.input);
     this.balanceCtrl = new BalanceController(this.input);
-    this.world = new World(this.scene, { lowEnd: this._lowQuality });
-    this.bike = new BikeModel(this.scene);
+    this.world = new World(this.scene, { lowEnd: this._lowQuality, showRiders: this._showRiders });
+    // Riders model (goose captain + stoker) when Show Riders is on, else the
+    // plain frame. See the flag read above.
+    this.bike = new BikeModel(this.scene, this._showRiders ? BIKE_MODEL_PATH : CHOOSER_MODEL_PATH);
     this.bike.roadPath = this.world.roadPath;
     this.chaseCamera = new ChaseCamera(this.camera);
-    // Picture-in-picture front-facing "selfie cam" of the bike (lower-right).
-    this.frontView = new FrontViewCamera(this.camera);
+    // Picture-in-picture front-facing "selfie cam" — only with the riders model
+    // (it exists to show off their lean).
+    this.frontView = this._showRiders ? new FrontViewCamera(this.camera) : null;
     this.hud = new HUD(this.input);
     this.grassParticles = new GrassParticles(this.scene);
     this.archIndicator = new ArchIndicator(this.scene);
@@ -3068,6 +3080,11 @@ class Game {
     if (gyroEulerBtn)   gyroEulerBtn.addEventListener('click',   () => this._setGyroRollMode('euler'));
     if (gyroGravityBtn) gyroGravityBtn.addEventListener('click', () => this._setGyroRollMode('gravity'));
 
+    const ridersOnBtn  = document.getElementById('opt-riders-on');
+    const ridersOffBtn = document.getElementById('opt-riders-off');
+    if (ridersOnBtn)  ridersOnBtn.addEventListener('click',  () => this._setShowRiders(true));
+    if (ridersOffBtn) ridersOffBtn.addEventListener('click', () => this._setShowRiders(false));
+
     if (isElectron) {
       browserDevBtn.addEventListener('click', async () => {
         const opened = await window.electronApp.toggleDevTools();
@@ -3099,6 +3116,23 @@ class Game {
     this._updateOptionsQualityUI();
     this._updateOptionsDualSenseSourceUI();
     this._updateOptionsGyroRollUI();
+    this._updateOptionsShowRidersUI();
+  }
+
+  _setShowRiders(on) {
+    try { localStorage.setItem('tandemonium_show_riders', on ? 'on' : 'off'); } catch (e) {}
+    this._updateOptionsShowRidersUI();
+    // Bike model + front cam are chosen at boot, so this applies on next launch
+    // (matches the note in the row and the DualSense-source setting).
+  }
+
+  _updateOptionsShowRidersUI() {
+    const on = getShowRiders();
+    const onBtn  = document.getElementById('opt-riders-on');
+    const offBtn = document.getElementById('opt-riders-off');
+    if (!onBtn) return;
+    onBtn.classList.toggle('active', on);
+    offBtn.classList.toggle('active', !on);
   }
 
   _updateOptionsDualSenseSourceUI() {
@@ -3208,6 +3242,8 @@ class Game {
       document.getElementById('opt-ds-webhid'),
       document.getElementById('opt-gyro-euler'),
       document.getElementById('opt-gyro-gravity'),
+      document.getElementById('opt-riders-on'),
+      document.getElementById('opt-riders-off'),
       document.getElementById('options-perf-btn'),
       document.getElementById('options-devtools-btn'),
       document.getElementById('options-browserdev-btn'),
@@ -3215,6 +3251,7 @@ class Game {
     ].filter(Boolean);
     this._updateOptionsDualSenseSourceUI();
     this._updateOptionsGyroRollUI();
+    this._updateOptionsShowRidersUI();
     this._setOverlayButtons(btns, btns.length - 1); // focus Close by default
   }
 

--- a/js/game.js
+++ b/js/game.js
@@ -19,6 +19,7 @@ import { BalanceController } from './balance-controller.js';
 import { BikeModel } from './bike-model.js';
 import { RemoteBikeState } from './remote-bike-state.js';
 import { ChaseCamera } from './chase-camera.js';
+import { FrontViewCamera } from './front-view-camera.js';
 import { FinishCameraAnimation } from './finish-camera-animation.js';
 import { World } from './world.js';
 import { HUD } from './hud.js';
@@ -169,6 +170,8 @@ class Game {
     this.bike = new BikeModel(this.scene);
     this.bike.roadPath = this.world.roadPath;
     this.chaseCamera = new ChaseCamera(this.camera);
+    // Picture-in-picture front-facing "selfie cam" of the bike (lower-right).
+    this.frontView = new FrontViewCamera(this.camera);
     this.hud = new HUD(this.input);
     this.grassParticles = new GrassParticles(this.scene);
     this.archIndicator = new ArchIndicator(this.scene);
@@ -575,6 +578,11 @@ class Game {
     window.addEventListener('keydown', (e) => {
       const tag = document.activeElement && document.activeElement.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (e.code === 'KeyV') {
+        // Toggle the front-facing PiP "selfie cam" of the bike.
+        if (this.frontView) this.frontView.toggle();
+        return;
+      }
       if (e.code === 'KeyM') {
         if (e.shiftKey) {
           // Shift+M: toggle volume picker in lobby
@@ -3414,6 +3422,7 @@ class Game {
       this._pollOverlayGamepad();
       this.input.consumeTaps(); // drain buffered input so it doesn't fire when overlay closes
       this.renderer.render(this.scene, this.camera);
+      if (this.frontView) this.frontView.hide();
       return;
     }
     // Stoker input-choice overlay: allow gamepad selection while it's up.
@@ -3421,6 +3430,7 @@ class Game {
       this._pollOverlayGamepad();
       this.input.consumeTaps();
       this.renderer.render(this.scene, this.camera);
+      if (this.frontView) this.frontView.hide();
       return;
     }
 
@@ -3464,6 +3474,19 @@ class Game {
       if (this.archIndicator._visible) this.archIndicator.update(this.bike, 0, 0);
 
       this.renderer.render(this.scene, this.camera);
+    }
+
+    // Front-view PiP — composite a front-facing "selfie cam" of the bike
+    // into the lower-right corner, on top of whatever was just rendered.
+    // Only while a ride is on screen (not during the cinematic, which runs
+    // its own camera choreography).
+    if (this.frontView && this.frontView.enabled && this.bike &&
+        (this.state === 'playing' || this.state === 'countdown')) {
+      this.frontView.update(this.bike, dt);
+      this.frontView.render(this.renderer, this.scene);
+    } else if (this.frontView) {
+      this.frontView.hide();
+      this.frontView.reset();
     }
 
     // Sp3 — feed bike velocity to the procedural motion loop every frame.

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -40,7 +40,7 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { InputManager } from './input-manager.js';
-import { isMobile, RELAY_URL, BIKE_MODEL_PATH, TUNE, GUEST_NAME, applySteeringFeel, snapshotTuningBase } from './config.js';
+import { isMobile, RELAY_URL, BIKE_MODEL_PATH, CHOOSER_MODEL_PATH, TUNE, GUEST_NAME, applySteeringFeel, snapshotTuningBase } from './config.js';
 import { LEVELS } from './race-config.js';
 import { AuthManager } from './auth.js';
 import { LicenseManager } from './license.js';
@@ -4642,9 +4642,10 @@ export class Lobby {
     ground.receiveShadow = true;
     this._previewScene.add(ground);
 
-    // Load bike model
+    // Load bike model — the chooser shows the original recolorable frame so the
+    // color presets apply here (the in-game bike is the fused riders model).
     const loader = new GLTFLoader();
-    loader.load(BIKE_MODEL_PATH, (gltf) => {
+    loader.load(CHOOSER_MODEL_PATH, (gltf) => {
       this._previewModel = gltf.scene;
 
       // Scale to fit preview

--- a/js/world.js
+++ b/js/world.js
@@ -669,10 +669,10 @@ export class World {
   }
 
   _buildLighting() {
-    const ambient = new THREE.AmbientLight(0x5566aa, 0.5);
+    const ambient = new THREE.AmbientLight(0x5566aa, 0.8);
     this.scene.add(ambient);
 
-    this.sun = new THREE.DirectionalLight(0xffffdd, 1.1);
+    this.sun = new THREE.DirectionalLight(0xffffdd, 1.7);
     this.sun.position.set(30, 40, 20);
     this.sun.castShadow = true;
     this.sun.shadow.mapSize.width = 1024;
@@ -686,8 +686,14 @@ export class World {
     this.scene.add(this.sun);
     this.scene.add(this.sun.target);
 
-    const hemi = new THREE.HemisphereLight(0x99bbff, 0x44aa44, 0.35);
+    const hemi = new THREE.HemisphereLight(0x99bbff, 0x44aa44, 0.6);
     this.scene.add(hemi);
+
+    // Warm fill opposite the sun so the riders' shadowed front (facing the chase
+    // camera) still reads its Victorian colors instead of going murky.
+    const fill = new THREE.DirectionalLight(0xfff2e0, 0.6);
+    fill.position.set(-25, 25, -25);
+    this.scene.add(fill);
   }
 
   checkTreeCollision(bikePos, bikeD, bikeHeading) {

--- a/js/world.js
+++ b/js/world.js
@@ -61,6 +61,9 @@ export class World {
   constructor(scene, options = {}) {
     this.scene = scene;
     this._lowEnd = !!options.lowEnd;
+    // Brighter, warmer lighting is part of the Show Riders experience (so the
+    // riders' Victorian colors read); off = the original world lighting.
+    this._showRiders = !!options.showRiders;
     this.tileSize = 4;
 
     // Road path (deterministic)
@@ -669,10 +672,11 @@ export class World {
   }
 
   _buildLighting() {
-    const ambient = new THREE.AmbientLight(0x5566aa, 0.8);
+    const riders = this._showRiders;
+    const ambient = new THREE.AmbientLight(0x5566aa, riders ? 0.8 : 0.5);
     this.scene.add(ambient);
 
-    this.sun = new THREE.DirectionalLight(0xffffdd, 1.7);
+    this.sun = new THREE.DirectionalLight(0xffffdd, riders ? 1.7 : 1.1);
     this.sun.position.set(30, 40, 20);
     this.sun.castShadow = true;
     this.sun.shadow.mapSize.width = 1024;
@@ -686,14 +690,16 @@ export class World {
     this.scene.add(this.sun);
     this.scene.add(this.sun.target);
 
-    const hemi = new THREE.HemisphereLight(0x99bbff, 0x44aa44, 0.6);
+    const hemi = new THREE.HemisphereLight(0x99bbff, 0x44aa44, riders ? 0.6 : 0.35);
     this.scene.add(hemi);
 
-    // Warm fill opposite the sun so the riders' shadowed front (facing the chase
-    // camera) still reads its Victorian colors instead of going murky.
-    const fill = new THREE.DirectionalLight(0xfff2e0, 0.6);
-    fill.position.set(-25, 25, -25);
-    this.scene.add(fill);
+    if (riders) {
+      // Warm fill opposite the sun so the riders' shadowed front (facing the
+      // chase camera) still reads its Victorian colors instead of going murky.
+      const fill = new THREE.DirectionalLight(0xfff2e0, 0.6);
+      fill.position.set(-25, 25, -25);
+      this.scene.add(fill);
+    }
   }
 
   checkTreeCollision(bikePos, bikeD, bikeHeading) {


### PR DESCRIPTION
Adds an opt-in **Show Riders** experience: the Victorian Canadian-goose captain & stoker ride the tandem and lean their torsos with the balance system, as a visual read on what tilt/balancing is doing. Everything is gated behind a Settings toggle that **defaults off**, so the base game is unchanged unless a player opts in.

## What's in it

**Riders + lean**
- New skinned `tandem_riders.glb` replaces the plain frame when Show Riders is on.
- Captain and stoker lean **independently**, each driven by their own gyro/lean input; the whole bike still tilts by the **aggregate** `(captainLean + stokerLean)/2` exactly as before.
- Two disjoint lean clips (`CaptainLean` / `StokerLean`) stripped to each rider's bones so they don't interfere; captain-arm IK baked in so his gloves stay on the bars.
- Solo: only the captain leans, the stoker stays upright.

**Front-facing selfie-cam** (merges #349 — **Supersedes #349**)
- PiP that looks back at the riders as they come toward you.
- Repositioned to stack **above the partner webcam PiP** in multiplayer (they previously overlapped in the lower-right).
- Removed its stray `V` keyboard toggle — the front view is simply part of Show Riders now.

**Settings + visuals**
- **Show Riders** On/Off row in the Options dialog (persisted, applied on next launch).
- Lobby button split into **🎮** (controller test) + **⚙️** (opens Settings) so Options is reachable on every platform, not just via the gamepad Start combo.
- Richer lighting for the riders: warmer/brighter world lights + fill, AgX tone mapping, and a procedural `RoomEnvironment` IBL — **all gated behind Show Riders**, so off = the original look.
- Bike chooser keeps the original recolorable frame (presets still work there).

**Size**
- `tandem_riders.glb` exported small: WebP textures (base/normal 2048, metallic-roughness 1024) + Draco geometry → **62 MB → 3.3 MB**, visually identical. A shared `DRACOLoader` decodes it (decoder fetched lazily from the CDN).

## Merge note
Please **squash-merge**: an intermediate commit carries the original 62 MB GLB, so a squash keeps `main`'s history to just the final 3.3 MB file.

## Follow-ups (non-blocking)
- Mobile perf pass for the PiP's second scene render.
- Vendor the Draco decoder for offline desktop builds — tracked in #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)