### PR TITLE
docs: add public launch plan

### DIFF
--- a/docs/launch-plan.md
+++ b/docs/launch-plan.md
@@ -1,0 +1,166 @@
+# Tandemonium: Public Launch Plan
+
+*Royal House of Geese Chaos · Field Marshal's Almanac*
+
+A route from a silent Steam playtest list to two back-to-back public moments in Columbus this October — grounded in what already exists, built for one person to execute.
+
+> As of 2026-07-05: 15 weeks out. The primary growth bet is section 2 (Reach & Velocity): other people losing control of a bike on camera, cut into shorts, spreads faster than anything written by hand. No paid GDEX booth this round — COGG is the spine of the in-person work instead: two rounds of live 2v2 playtests at Columbus Code & Coffee, two COGG talks, a guerrilla presence at GDEX, feeding straight into Steam Next Fest four days later.
+
+## Timeline
+
+| When | What |
+|---|---|
+| Now | Foundation & re-engagement |
+| **Jul 19** | Code & Coffee 2v2 playtest |
+| **Jul (TBD)** | COGG talk + prototype night |
+| Sep 21 | Demo submitted for Press Preview |
+| **Sep (TBD)** | Code & Coffee #2 + COGG talk #2 |
+| **Oct 15–18** | GDEX, guerrilla via COGG |
+| **Oct 19–26** | Steam Next Fest |
+| Nov+ | Sustain & scope paid release |
+
+**The landing spot for every link, caption, and QR code from here on is one place:** [store.steampowered.com/app/4482940/Tandemonium](https://store.steampowered.com/app/4482940/Tandemonium/). It's already live (Coming Soon, wishlist-enabled), the tagline is already "Two riders. One bike. Total chaos." — but the store page currently only reflects the base co-op game (captain/stoker, seven bikes, two courses); it doesn't show versus mode, the Royal House of Geese Chaos, or Tourist Mode yet. Refresh its screenshots/description with those before the Reach & Velocity push in section 2, so the clip and the click-through actually match.
+
+## 1 / Positioning — where Tandemonium sits in the market
+
+Physics couch co-op has a real lineage — *Gang Beasts*, *Human: Fall Flat*, *Moving Out*, *Overcooked*, *It Takes Two*, *Party Animals*, *Ultimate Chicken Horse*. Every one of them sells a single clean promise: bodies (or vehicles) that don't cooperate, and friends who have to. The wedge inside that lineage is specific and defensible:
+
+- **Mechanic** — One vehicle, two independent riders who each lean and pedal on their own input — the chaos comes from your own teammate, not just physics noise. Versus mode (1v1/1v2/2v2) turns that into a real head-to-head.
+- **Lore** — Sir Winston Chaos III and Lady Victoria Chaos give the absurdity a face and a name — "Royal House of Geese Chaos" is a hook a press blurb or a booth sign can use verbatim.
+- **Place** — Tourist Mode rides the tandem through real, photogrammetric Columbus. At a Columbus convention, "that's the Short North, that's our skyline" is a line no competitor in the genre can say.
+
+Every piece of copy between now and October — store page, trailer, playtest flyers, talk slides — should lead with one of these three, not with feature lists. "Two riders, one bike, total chaos — starring the Royal House of Geese Chaos, riding through real Columbus" is closer to the actual pitch than anything longer.
+
+## 2 / Reach & velocity — bet on strangers losing control on camera, not on your own posts
+
+Every game in this lineage — *Gang Beasts*, *Human: Fall Flat*, *Fall Guys* — built its audience on other people's clips of other people's chaos, not on developer posts. A devlog earns trust with people who already found you; it doesn't find anyone. A 15-second clip of two strangers losing a bike fight does. Everything else in this document is organized around getting that clip made, then getting it in front of people twice — once by you, again by whoever else picks it up.
+
+### Capture: you don't need anyone else's permission to start
+
+Every live human-vs-human session between now and GDEX is a capture opportunity, and none of them depend on convincing a streamer first:
+
+- Jul 19 Code & Coffee, both COGG talks/prototype nights, the September Code & Coffee, and GDEX hallway demoing — put a phone on a small tripod, shoot vertical, and record continuously. Achievable solo, starting in two weeks.
+- The two moments most worth isolating: the winner fly-around cinematic already built into versus mode, and any bike-to-bike collision pileup. Both read as a complete "watch this" beat in 10–15 seconds with zero context needed.
+- Catch a reaction, not just the screen — a player's laugh or yell sells a clip harder than the physics alone. Ask whoever's playing if you can get their face too.
+
+### Cut & post: one clip, three feeds
+
+- One vertical short a week cut from that footage, posted identically to YouTube Shorts, TikTok, and Instagram Reels — same file, three uploads, roughly 10 minutes of extra work once it's edited.
+- Caption leads with the lore, not the mechanics: "Sir Winston just took Lady Victoria into a wall" beats "versus mode collision test" — see section 1's positioning.
+- Native-post the same clip into the couch-co-op and controller subreddits from section 3 wherever their rules allow video rather than just a link — clips consistently outperform links in those communities.
+- Every bio link, caption link, and QR code — TikTok/Shorts/Reels profile, subreddit posts, GDEX cards, Code & Coffee flyers — points at the [Steam page](https://store.steampowered.com/app/4482940/Tandemonium/) and nowhere else. One destination, one wishlist click, no detour through the blog first.
+
+### Amplify: seed it, don't wait on it
+
+- Give the controller-overlay streamer, and any co-op-focused creators surfaced via Co-Optimus or the co-op subreddits, early access framed specifically around versus mode — before GDEX/Next Fest, not during. A streamer playing generates their own clips for their own audience, multiplying reach past what one person can personally cut.
+- This is the part that depends on someone else's choice — de-risk it by not waiting on it. Self-recorded shorts from Code & Coffee and COGG start the flywheel in July regardless of whether any streamer bites; streamer amplification stacks on top, it isn't the precondition.
+
+The blog, Twitter/X, and subreddit seeding in section 3 below are home-base infrastructure — they give someone who saw a clip somewhere else a place to land and a reason to trust what they find. They were never going to be the thing that finds them.
+
+## 3 / Foundation — July–September: work the channels you already own
+
+Not starting from zero — starting from **eight dormant or under-used assets**. None of them need a budget, all of them need five minutes of upkeep on a schedule. This is the highest-leverage work available and it costs nothing but consistency.
+
+| Asset | Current state | Action between now and Sept |
+|---|---|---|
+| 250 Steam playtesters | Silent, no feedback loop | Direct email/Steam announcement: "here's what changed since you played, 3 questions, and you're invited to the Next Fest demo + a chance to playtest live at Code & Coffee if you're local." A named ask beats a general update. |
+| GDG Columbus Discord | Weekly one-way posts (organizer/admin access) | Use the standing already there to turn posts into asks: "who's coming to the Jul 19 Code & Coffee 2v2 test" and "who wants a demo slot at the COGG talk" — recruit playtesters and talk attendance directly, not just announce. |
+| r/Tandemonium | Registered, empty | Seed with 3–4 devlog posts (Royal House reveal, versus mode clip, Tourist Mode clip) before cross-posting to r/IndieGaming. |
+| Couch co-op communities (new) | Not yet contacted | Cross-post devlogs to r/localmultiplayergames, r/couchcoop, and r/PartyGames — a much sharper-fit audience than general indie subs. Separately, pitch [Co-Optimus](https://co-optimus.com/) directly and submit to their [Steam curator](https://store.steampowered.com/curator/588052-Co-Optimus/) — they cover couch/split-screen co-op specifically. |
+| Twitter/X | Registered, unused | Weekly clip tied to #ScreenshotSaturday / #IndieGameDev — the goose-lean and versus-mode footage is inherently shareable, don't save it all for October. |
+| UsersFirst.games blog | Planned, no posts | One devlog every 2 weeks becomes the press kit and the GDEX/Next Fest landing page by October — write it as you go, not in a scramble in September. |
+| Controller-overlay streamer | 1 streamer, gyro-aiming niche | Direct outreach: ask them to try Tandemonium on stream using the overlay they already use. A warm, specific ask to one real contact outperforms a cold pitch to ten. |
+| Controller-overlay subreddits (new) | Overlay never announced beyond one streamer | Post the overlay itself — genuinely useful on its own — to r/SteamController, r/GameSir, r/GyroGaming, r/DualSense, and r/dualshock4 (confirm current names/self-promo rules on each before posting). Lead with the tool, close with one honest line on Tandemonium being what it was built for. Sequence this *after* the in-game integration below ships, so the post can say "now built into the game too, or grab it standalone." |
+
+This phase is also when the Chaos Coin loop and store page get built and tested — see below — so they're boring and stable by the time strangers are playing at Code & Coffee or GDEX.
+
+### Fold the overlay into the game itself
+
+Right now the WebHID controller overlay only exists as an independent download. Add a way to launch it **from inside Tandemonium** (an Options entry, or an offer at controller-setup time) — the standalone download stays available for the gyro-aiming crowd who want just the tool. Worth doing before the subreddit push above: it turns "here's a cool controller overlay" into "here's a cool controller overlay, also look what it's built for," and gives overlay users a one-click path into the game instead of a second download.
+
+## 4 / Community playtests & talks — COGG and Code & Coffee do the job a booth would have
+
+Cutting the GDEX booth doesn't cut the in-person work — it moves earlier, into rooms where the feedback is cheaper and easier to act on.
+
+- **Columbus Code & Coffee, Jul 19** — first live 2v2 test in front of people who aren't already invested in the project. Bring two working controller pairs, a 3-question feedback card, and film reactions for the blog/socials. This is the realest read on whether versus mode reads clearly to strangers before it's in front of a GDEX or Next Fest crowd.
+- **Second Code & Coffee session, September** — pin the date now for 1–2 weeks *before* the Sep 21 demo submission, so anything it surfaces can still land in the build instead of arriving too late to fix.
+- **COGG prototype/playtest nights + a talk, July and September** — COGG (the Central Ohio GameDev Group) is exactly the room to introduce the Royal House of Geese Chaos and run versus mode live. Membership here, and friendship with the organizers, doesn't make the talk slot a given — it's still an ask. Aim the July talk at "here's the game, come playtest," and the September talk at "we're live in two weeks" as the direct lead-in to GDEX and Next Fest.
+- **Why this matters for GDEX** — COGG doesn't organize GDEX; Multivarious Games does, and Multivarious also runs COGG. So COGG isn't insider access to the show, but it is real, warm proximity to the people who run it. Two rounds of talks and playtest nights build a known, friendly face in that circle rather than a stranger — which is what makes showing up at GDEX without a booth worth doing (see section 7).
+
+## 5 / Chaos Coin — keep the first version small and cosmetic-only
+
+The risk with a currency system three months from a public demo isn't the concept, it's scope: an economy is easy to over-build and hard to re-balance live. Recommendation: **ship the smallest version that gives players a reason to play one more match**, nothing that requires real-money handling or Steam's microtransaction review.
+
+- **Earn** — Flat Chaos Coin per match played, plus small bonuses for match-specific beats (won a versus round, finished a Tourist Mode route, first fall of the match — something that already fires as an event).
+- **Spend** — Cosmetics only, on the two named geese specifically — hats, capes, medals for Sir Winston and Lady Victoria, maybe a bike livery. No stat effects, so versus mode stays fair and balance is never touched.
+- **Scope for October** — 6–10 cosmetic pieces is plenty. A one-off item unlocked for attending a Code & Coffee session, a COGG talk, or the GDEX/Next Fest window gives each event a reason to be "there," and gives attendees something to post about.
+
+Real-money purchases, trading, or anything beyond cosmetics can wait for a post-launch decision once it's clear players actually want more — that's a distinct, later product decision, not a prerequisite for October.
+
+## 6 / Octalysis — a quick read, not the full pass
+
+A fast gut-check against the 8 core drives as the game stands today, rather than the full framework:
+
+| Drive | Score |
+|---|---|
+| Epic Meaning & Calling | 8/10 |
+| Development & Accomplishment | 5/10 |
+| Empowerment of Creativity | 6/10 |
+| Ownership & Possession | 4/10 |
+| Social Influence & Relatedness | 9/10 |
+| Scarcity & Impatience | 2/10 |
+| Unpredictability & Curiosity | 8/10 |
+| Avoidance | 1/10 |
+
+Reads as a strong **White Hat** game (social, curiosity, meaning are the best drives, which is exactly right for a couch party game — a party game shouldn't lean on Black Hat pressure like scarcity/avoidance). Development & Accomplishment and Ownership are the lowest scores, and Chaos Coin + cosmetics is precisely what raises both — a sign the feature is well-targeted rather than a distraction. Treat a full Octalysis pass as a post-October exercise once there's real playtest data to score against, not guesses.
+
+## 7 / GDEX — October 15–18, guerrilla, not a booth
+
+No exhibitor application this round, and no booth fee — that budget and effort is better spent on the two COGG/Code & Coffee rounds above, which do the same relationship-building for free. GDEX becomes a presence, not a purchase — and a capture opportunity per section 2.
+
+- **Lean on the COGG relationship, not the show floor.** GDEX is organized primarily by Multivarious Games, who also run COGG — so COGG membership isn't a backstage pass, but showing up as a known, friendly face after two talks and two playtest sessions goes further in hallway conversations and any COGG-adjacent social/mixer moments than a first-time stranger would get.
+- **Check GDEX's attendee/exhibitor policy before demoing anywhere** — ask COGG organizer friends directly what's fair game for a non-exhibitor. Hallway tracks, COGG-hosted side gatherings, and public common areas are the safe guerrilla ground; soliciting on the paid exhibit floor without a booth is not.
+- **Bring a portable rig and the same "exclusive cosmetic" idea** from section 5, just redeemed via a card/QR code handed out in person instead of at a booth.
+- **Collect Next Fest wishlists the same way** — every hallway conversation ends with "the demo goes live in 4 days, here's the link" pointing at the Steam page above.
+
+## 8 / Steam Next Fest — October 19–26
+
+Next Fest *is* a staged, low-risk release mechanism — it's a free demo funnel by design, so it fits the "itch/demo now, paid Steam later" path already planned without inventing anything new.
+
+| Date | Deadline |
+|---|---|
+| Sep 21 | Submit demo build + store page for review, to be live for Press Preview |
+| Oct 5 | Hard deadline — all required items must be in for the event |
+| Oct 8 | Press Preview opens; deadline to opt out of trailer-use permissions |
+| Oct 19–26 | Steam Next Fest live |
+
+- The demo build should showcase versus mode (1v1/1v2/2v2) front and center — it's the most legible, most streamable, most "watch two people fight on a bike" content available.
+- Sequence the content push so the GDEX footage (hallway crowds, in-person reactions) becomes the Next Fest launch-day post — one story that spans both events instead of two disconnected ones.
+- The seeded streamers and creators from section 2 should specifically target the festival window when playing — Steam's own discovery algorithm is paying attention to activity spikes, so their clips and wishlists land with more force here than any other week.
+
+## 9 / After October — sustaining into a paid release
+
+Whatever wishlist count and Discord/Reddit growth remain after October is the real asset going into next year — the paid Steam release should wait until that number and the feedback loop justify it, not until a fixed date.
+
+- Keep the shorts cadence from section 2 going — it's the growth engine, not just an October push. Keep the blog cadence going too; momentum posts ("what GDEX taught us," "what's next for the Royal House") retain the people the clips send over.
+- Re-run the same "direct, specific ask" that reactivated the 250 playtesters on the new Next Fest wishlisters — don't let this list go silent the way the first one did.
+- Treat the full Octalysis pass, and any real-money monetization decision, as Q1-next-year work — informed by actual October playtest and wishlist data instead of assumptions.
+
+## 10 / Watch-outs
+
+- **Solo bandwidth is the real constraint, not ideas.** Section 2's short-form video channel (one handle, cross-posted to YouTube Shorts/TikTok/Reels) is the deliberate exception to "no new platforms" — it's the primary growth lever, not scope creep. Resist adding anything beyond it (a Kickstarter, a Discord community of your own, long-form YouTube) between now and October.
+- **Capture only works if it's boring to do.** A tripod and a phone recording at every Code & Coffee/COGG session is the whole capture pipeline — don't let "better footage" (a second camera, a capture card, a dedicated editor) become a prerequisite that keeps it from happening at all.
+- **Don't let Chaos Coin balance work compete with build stability.** Freeze the economy at least two weeks before Sept 21 so the demo build is boring and crash-free at Code & Coffee, COGG, and GDEX — not being tuned the week of submission.
+- **Pin the September dates now, not in August.** Both the second Code & Coffee session and the second COGG talk need real dates on the calendar this month — "September" isn't a plan, and both need to land before the Sep 21 freeze to be useful.
+- **Guerrilla at GDEX still has a line.** Being a known COGG face buys goodwill, not blanket permission — confirm what GDEX/COGG consider fair game for non-exhibitors before assuming hallway demoing is fine everywhere.
+
+## Sources
+
+- [Tandemonium — Steam store page](https://store.steampowered.com/app/4482940/Tandemonium/)
+- [Steam Next Fest: October 2026 — Steamworks Documentation](https://partner.steamgames.com/doc/marketing/upcoming_events/nextfest/2026october)
+- [GDEX 2026 — Midwest's Premier Gaming Expo & Conference](https://www.thegdex.com/)
+- [The Central Ohio GameDev Group (COGG)](https://thecogg.com/)
+- [Columbus Code & Coffee — Meetup](https://www.meetup.com/columbus-code-and-coffee/)
+- [Co-Optimus — co-op gaming coverage](https://co-optimus.com/)
+
+*Rendered version with visual timeline/scoring: [artifact](https://claude.ai/code/artifact/5f056221-d634-4ae9-a2d1-709d7b8b0899)*


### PR DESCRIPTION
## Summary
- Adds `docs/launch-plan.md`: the Oct 2026 go-to-market plan worked out with Claude — COGG/Code & Coffee playtests, guerrilla GDEX presence (no booth), Steam Next Fest, a lean cosmetic-only Chaos Coin scope, and a capture/cut/amplify shorts strategy funneling every link to the Steam store page.
- No code changes.

## Test plan
- N/A (docs only)