### PR TITLE
Mobile: replace Tap-to-Start gate with an auto-dismissing "Loading…" veil

### DIFF
--- a/index.html
+++ b/index.html
@@ -4017,9 +4017,20 @@ ON</button>
 </div>
 <script>
 (function() {
-  var isDesktop = navigator.userAgent.includes('Electron') || navigator.userAgent.includes('electron');
+  var ua = navigator.userAgent;
+  var isDesktop = ua.includes('Electron') || ua.includes('electron');
+  // Mirror config.js isMobile so the boot veil label agrees with the app.
+  var isMobile = !isDesktop && (/Android|iPhone|iPad|iPod|webOS|BlackBerry|IEMobile|Opera Mini/i.test(ua) || navigator.maxTouchPoints > 1);
+  // Desktop (Electron) and mobile both show a "Loading…" veil instead of the
+  // "Tap to Start" prompt: desktop dismisses on gamepad input (poll below),
+  // mobile auto-dismisses once the Lobby loads (the tap-gate is obsolete — iOS
+  // motion permission is requested from a real gesture at ride start). Desktop
+  // *browsers* keep the click-to-start prompt (they need the click to dismiss).
+  if (isDesktop || isMobile) {
+    var textEl = document.getElementById('tap-to-start-text');
+    if (textEl) textEl.textContent = 'Loading…';
+  }
   if (isDesktop) {
-    document.getElementById('tap-to-start-text').textContent = 'Loading...';
     // Poll for gamepad input to dismiss the overlay
     var overlay = document.getElementById('tap-to-start');
     function pollForButton() {

--- a/js/game.js
+++ b/js/game.js
@@ -579,12 +579,15 @@ class Game {
       this._updateMusicBtnIcon();
     };
 
-    // First-visit: the "Tap to Start" overlay in lobby.js handles autoplay unlock.
-    // Returning visitors (overlay skipped): start music on first user interaction.
+    // Desktop first-visit: the "Tap to Start" overlay in lobby.js supplies the
+    // autoplay-unlock gesture (its dismiss calls onMusicChanged). Everyone else
+    // — returning visitors (overlay skipped) AND mobile (the overlay is now a
+    // passive "Loading…" veil that auto-dismisses, not a tap gate) — must start
+    // music on the first real user interaction instead.
     if (this.lobby.musicActive) {
       this._musicEl.play().catch(() => {});
     }
-    if (!this.lobby._tapOverlay) {
+    if (!this.lobby._tapOverlay || isMobile) {
       const startMusic = () => {
         if (this.lobby.musicActive) {
           this._musicEl.play().catch(() => {});

--- a/js/lobby.js
+++ b/js/lobby.js
@@ -353,7 +353,25 @@ export class Lobby {
     // Only shown once ever; after first dismissal, localStorage flag prevents it.
     this._tapOverlay = document.getElementById('tap-to-start');
     if (this._tapOverlay) {
-      if (localStorage.getItem('tandemonium_started')) {
+      if (isMobile) {
+        // Mobile: the old "Tap to Start" tap-gate is obsolete. iOS motion
+        // permission is now requested from a real gesture at ride start
+        // (game.js doStart) and audio unlocks on the first lobby interaction,
+        // so no boot gesture is needed. The overlay is now purely a "Loading…"
+        // veil (label set by the boot script) that auto-dismisses once the page
+        // finishes loading — no tap. _toggleAll is intentionally NOT called
+        // here: a non-gesture requestPermission() is rejected by iOS anyway.
+        const lift = () => {
+          const o = this._tapOverlay;
+          if (!o) return;
+          this._tapOverlay = null;
+          o.classList.add('fade-out');
+          setTimeout(() => o.remove(), 400);
+        };
+        if (document.readyState === 'complete') requestAnimationFrame(lift);
+        else window.addEventListener('load', () => requestAnimationFrame(lift), { once: true });
+        setTimeout(lift, 4000); // safety: never let the veil dead-end (see #350)
+      } else if (localStorage.getItem('tandemonium_started')) {
         this._tapOverlay.remove();
         this._tapOverlay = null;
         // Subsequent-launch case: the tap overlay was dismissed in a
@@ -364,9 +382,7 @@ export class Lobby {
         // otherwise the user has to power-cycle the controller on
         // every app restart to force it back into Chromium-visible
         // compat mode.
-        if (!isMobile) {
-          this._runDesktopGamepadDetection();
-        }
+        this._runDesktopGamepadDetection();
       } else {
         this._tapOverlay.addEventListener('click', () => this._dismissTapOverlay(), { once: true });
       }


### PR DESCRIPTION
The mobile **"Tap to Start"** gate is obsolete. It originally supplied the user gesture for iOS motion permission + audio autoplay, but:
- **Motion** is now requested from a real gesture at ride start (`game.js` `doStart` → `requestMotionPermission()`).
- **Audio** unlocks on the first lobby interaction (`game.js`'s first-gesture music starter).

So mobile no longer needs a dedicated tap gate. Instead of a "Tap to Start" prompt (which also risks reading as a *silent dead-end* — cf. #350), mobile now shows the dark overlay purely as a pulsing **"Loading…"** veil that **auto-dismisses once the page finishes loading**.

## Changes
- **`index.html`** (boot script): label the veil `Loading…` on mobile too (set immediately — no "Tap to Start" flash). The gamepad-input poll stays desktop-only. Mobile detection mirrors `config.js` `isMobile`.
- **`js/lobby.js`**: mobile takes an auto-dismiss path — fade out on window `load` + `requestAnimationFrame`, with a **4s safety timeout so the veil can never dead-end** (#350). `_toggleAll()` is intentionally *not* called on mobile boot (a non-gesture `requestPermission()` is rejected by iOS anyway).
- **`js/game.js`**: `if (!this.lobby._tapOverlay || isMobile)` — game.js wired its first-gesture music starter only when there was no overlay; the new veil keeps `_tapOverlay` set but never taps, so without this mobile lobby music would stay silent. Now music starts on the first lobby interaction.

## Unchanged
Desktop (Electron "Loading…" + gamepad dismiss; desktop-browser "Tap to Start" + click) is untouched.

## Net mobile behavior
Boot → pulsing "Loading…" veil → clears itself when loaded (no tap). Motion requested at ride start; music starts on first lobby tap; camera requested when the front-view is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNqB4zV3F6aBAg6LUxuvBY