### PR TITLE
Declutter the mobile ride screen: one stat strip, one quick menu

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@
 | 5 | Onboarding & Accessibility | Tutorial phases, DDA | `game.js` (tutorial), `dda-manager.js` |
 | 6 | Input Systems | Keyboard, touch, gyro, gamepad API | `input-manager.js` |
 | 7 | Controller Drivers | WebHID (DualSense, Switch Pro, Xbox), vendor-specific | `controllers/dualsense-driver.js`, `switch-pro-driver.js`, `xbox-driver.js` |
-| 8 | Player Feedback | HUD, haptics, balance gauge, crash overlay | `hud.js`, `haptics.js`, `arch-indicator.js` |
+| 8 | Player Feedback | HUD, quick menu, haptics, balance gauge, crash overlay | `hud.js`, `quick-menu.js`, `haptics.js`, `arch-indicator.js` |
 | 9 | Multiplayer Networking | Rooms, relay, PeerJS, remote state, sync tracking | `network-manager.js`, `remote-bike-state.js`, `contribution-tracker.js`, `shared-pedal-controller.js` |
 | 10 | Video/PiP | Camera streams, recording, partner video | `game-recorder.js` |
 | 11 | Cloudflare Workers API | REST routes, rate limiting, relay tokens | `worker/leaderboard.js`, `worker/relay.js` |

--- a/index.html
+++ b/index.html
@@ -16,11 +16,19 @@
   canvas { display: block; width: 100%; height: 100%; }
 
   /* ── HUD: top bar ── */
+  /* Column: the stat strip, then the quick-menu button tucked under its right
+     end. The button used to sit beside the strip, which cost the strip ~58px of
+     width in the corner where the numbers are widest — a late-ride readout
+     (three-digit speed, km distance, mm:ss elapsed) outgrew it and wrapped. */
   #hud-top {
     position: fixed;
     top: env(safe-area-inset-top, 0px);
     left: 0; right: 0;
     padding: 10px 14px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
     pointer-events: none;
     z-index: 10;
   }
@@ -38,14 +46,18 @@
     border: 1px solid rgba(255,255,255,0.12);
     border-radius: 14px;
     padding: 7px 12px 6px;
-    /* Never grow under the quick-menu button in the opposite corner. */
-    max-width: calc(100% - 58px);
+    /* Full width on a phone so the strip has the whole screen to grow into;
+       back to hugging its content once there is room to spare. */
+    width: 100%;
+  }
+  @media (min-width: 700px) {
+    #hud-dashboard { width: auto; }
   }
   #hud-stats {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 5px 7px;
+    gap: 5px 6px;
   }
   .hud-stat {
     display: none;
@@ -62,10 +74,16 @@
     content: '';
     width: 1px;
     height: 13px;
-    margin-right: 4px;
+    margin-right: 3px;
     background: rgba(255,255,255,0.16);
   }
+  /* Every number gets a reserved slot, wide enough for the digits it usually
+     reaches, so 9 -> 10 -> 100 grows into its own column instead of shoving the
+     rest of the strip sideways. Tabular figures keep the slots honest. */
   #speed-value {
+    display: inline-block;
+    min-width: 2ch;
+    text-align: right;
     font-size: 20px;
     font-weight: 700;
     color: #fff;
@@ -94,32 +112,28 @@
   }
   #distance-display,
   #elapsed-display {
+    display: inline-block;
     font-size: 12px;
     font-weight: 600;
     color: rgba(255,255,255,0.5);
   }
+  #distance-display { min-width: 4.5ch; }
+  #elapsed-display { min-width: 5ch; }
   .hud-stat-icon { font-size: 13px; }
-  /* Narrow phones: trim the strip rather than let it wrap for ordinary
-     values. It still wraps rather than spilling if every stat runs long. */
-  @media (max-width: 400px) {
-    #hud-dashboard { padding: 6px 10px 5px; }
-    #hud-stats { gap: 4px 5px; }
-    #speed-value { font-size: 18px; }
-    #segment-timer { font-size: 15px; }
-    #distance-display,
-    #elapsed-display,
-    #collectible-count,
-    #geese-count { font-size: 11px; }
-  }
   #collectible-count,
   #geese-count {
+    display: inline-block;
     font-size: 12px;
     font-weight: 700;
     color: rgba(255,255,255,0.85);
   }
+  #collectible-count { min-width: 3ch; }
+  #geese-count { min-width: 2ch; }
 
   /* ── Segment timer ── */
   #segment-timer {
+    display: inline-block;
+    min-width: 4ch;
     font-size: 16px;
     font-weight: 700;
     color: #44ff66;
@@ -131,6 +145,35 @@
   #segment-timer.warning { color: #ffd700; }
   #segment-timer.danger { color: #ff4444; animation: timerPulse 0.5s infinite; }
   @keyframes timerPulse { 50% { opacity: 0.5; } }
+
+  /* Narrow phones: trim the strip rather than let it wrap for ordinary
+     values. It still wraps rather than spilling if every stat runs long. */
+  @media (max-width: 400px) {
+    #hud-dashboard { padding: 6px 9px 5px; }
+    #hud-stats { gap: 4px 5px; }
+    .hud-stat.visible ~ .hud-stat.visible::before { margin-right: 2px; }
+    #speed-value { font-size: 18px; }
+    #segment-timer { font-size: 15px; }
+    #distance-display,
+    #elapsed-display,
+    #collectible-count,
+    #geese-count { font-size: 11px; }
+  }
+  /* Second step for the smallest phones, where even the trimmed strip runs out
+     of room once every stat is at full length. */
+  @media (max-width: 385px) {
+    #hud-dashboard { padding: 6px 7px 5px; }
+    #hud-stats { gap: 3px 4px; }
+    .hud-stat.visible ~ .hud-stat.visible::before { margin-right: 2px; height: 11px; }
+    #speed-value { font-size: 16px; }
+    #speed-unit { font-size: 9px; }
+    #segment-timer { font-size: 13px; }
+    .hud-stat-icon { font-size: 11px; }
+    #distance-display,
+    #elapsed-display,
+    #collectible-count,
+    #geese-count { font-size: 10px; }
+  }
 
   /* ── Center countdown overlay ── */
   #countdown-overlay {
@@ -1260,9 +1303,8 @@
      #share-btn / #music-btn elements, which remain the single source of truth
      for both state and behaviour. */
   #quick-menu-btn {
-    position: fixed;
-    top: calc(env(safe-area-inset-top, 0px) + 10px);
-    right: 14px;
+    align-self: flex-end;
+    flex: 0 0 auto;
     width: 44px;
     height: 44px;
     border-radius: 50%;
@@ -1276,7 +1318,6 @@
     justify-content: center;
     cursor: pointer;
     pointer-events: auto;
-    z-index: 12;
     -webkit-tap-highlight-color: transparent;
     -webkit-appearance: none;
     appearance: none;
@@ -4310,6 +4351,18 @@
       <div id="contrib-stoker"></div>
     </div>
   </div>
+  <!-- Quick menu: the one on-screen control during a ride. Sits under the strip's
+       right end and opens the sheet further down, whose entries proxy clicks to
+       the hidden #side-buttons, #share-btn and #music-btn. Wired in
+       js/quick-menu.js. -->
+  <button id="quick-menu-btn" aria-label="Ride controls" aria-haspopup="dialog" aria-expanded="false">
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+      <path d="M3 6h9M15.5 6H17M3 14h3M9.5 14H17M3 10h6M12.5 10H17"/>
+      <circle cx="13.75" cy="6" r="1.75"/>
+      <circle cx="7.75" cy="14" r="1.75"/>
+      <circle cx="10.75" cy="10" r="1.75"/>
+    </svg>
+  </button>
 </div>
 
 <div id="countdown-overlay"><span id="countdown-number"></span></div>
@@ -4366,18 +4419,6 @@ ON</button>
   <button class="side-btn speed-off" id="speed-btn">SPEED</button>
   <button class="side-btn assist-off" id="assist-btn" style="display:none;">ASSIST</button>
 </div>
-
-<!-- Quick menu: the one on-screen control during a ride. Opens the sheet below,
-     whose entries proxy clicks to the hidden buttons above plus #share-btn and
-     #music-btn. Wired in js/quick-menu.js. -->
-<button id="quick-menu-btn" aria-label="Ride controls" aria-haspopup="dialog" aria-expanded="false">
-  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
-    <path d="M3 6h9M15.5 6H17M3 14h3M9.5 14H17M3 10h6M12.5 10H17"/>
-    <circle cx="13.75" cy="6" r="1.75"/>
-    <circle cx="7.75" cy="14" r="1.75"/>
-    <circle cx="10.75" cy="10" r="1.75"/>
-  </svg>
-</button>
 
 <div id="quick-menu-overlay" role="dialog" aria-modal="true" aria-label="Ride controls">
   <div id="quick-menu-sheet">

--- a/index.html
+++ b/index.html
@@ -24,24 +24,49 @@
     pointer-events: none;
     z-index: 10;
   }
+  /* One horizontal strip instead of a stacked card: speed · distance ·
+     elapsed · segment timer · collectibles · geese. Everything the rider
+     reads at a glance lives on one line, so the top of the screen is a single
+     band rather than four separate widgets competing for the same corner. */
   #hud-dashboard {
     display: inline-flex;
     flex-direction: column;
-    gap: 3px;
+    gap: 4px;
     background: rgba(0,0,0,0.45);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
     border: 1px solid rgba(255,255,255,0.12);
-    border-radius: 12px;
-    padding: 8px 14px 7px;
+    border-radius: 14px;
+    padding: 7px 12px 6px;
+    /* Never grow under the quick-menu button in the opposite corner. */
+    max-width: calc(100% - 58px);
   }
-  #speed-row {
+  #hud-stats {
     display: flex;
-    align-items: baseline;
-    gap: 4px;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 5px 7px;
+  }
+  .hud-stat {
+    display: none;
+    align-items: center;
+    gap: 3px;
+    line-height: 1;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .hud-stat.visible { display: flex; }
+  /* Hairline separator, drawn by the stat that follows another visible one.
+     Because it is a child of the stat itself it disappears with it. */
+  .hud-stat.visible ~ .hud-stat.visible::before {
+    content: '';
+    width: 1px;
+    height: 13px;
+    margin-right: 4px;
+    background: rgba(255,255,255,0.16);
   }
   #speed-value {
-    font-size: 28px;
+    font-size: 20px;
     font-weight: 700;
     color: #fff;
     font-variant-numeric: tabular-nums;
@@ -49,13 +74,13 @@
     transition: color 0.2s;
   }
   #speed-unit {
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 600;
     color: rgba(255,255,255,0.5);
   }
   #speed-bar-wrap {
     width: 100%;
-    height: 4px;
+    height: 3px;
     background: rgba(255,255,255,0.1);
     border-radius: 2px;
     overflow: hidden;
@@ -67,32 +92,35 @@
     background: #fff;
     transition: width 0.15s, background 0.2s;
   }
-  #distance-row {
-    display: flex;
-  }
-  #distance-display {
-    font-size: 11px;
-    font-weight: 500;
-    color: rgba(255,255,255,0.45);
-  }
-  #elapsed-row {
-    display: flex;
-  }
+  #distance-display,
   #elapsed-display {
-    font-size: 11px;
-    font-weight: 500;
-    color: rgba(255,255,255,0.45);
+    font-size: 12px;
+    font-weight: 600;
+    color: rgba(255,255,255,0.5);
+  }
+  .hud-stat-icon { font-size: 13px; }
+  /* Narrow phones: trim the strip rather than let it wrap for ordinary
+     values. It still wraps rather than spilling if every stat runs long. */
+  @media (max-width: 400px) {
+    #hud-dashboard { padding: 6px 10px 5px; }
+    #hud-stats { gap: 4px 5px; }
+    #speed-value { font-size: 18px; }
+    #segment-timer { font-size: 15px; }
+    #distance-display,
+    #elapsed-display,
+    #collectible-count,
+    #geese-count { font-size: 11px; }
+  }
+  #collectible-count,
+  #geese-count {
+    font-size: 12px;
+    font-weight: 700;
+    color: rgba(255,255,255,0.85);
   }
 
   /* ── Segment timer ── */
-  #timer-row {
-    display: none;
-  }
-  #timer-row.visible {
-    display: flex;
-  }
   #segment-timer {
-    font-size: 21px;
+    font-size: 16px;
     font-weight: 700;
     color: #44ff66;
     font-variant-numeric: tabular-nums;
@@ -643,23 +671,6 @@
     font-size: 12px;
     filter: drop-shadow(0 1px 2px rgba(0,0,0,0.7));
   }
-  #collectible-counter {
-    position: fixed;
-    top: calc(env(safe-area-inset-top, 0px) + 12px);
-    right: 14px;
-    font-size: 13px;
-    font-weight: 700;
-    color: rgba(255,255,255,0.8);
-    z-index: 11;
-    pointer-events: none;
-    display: none;
-    align-items: center;
-    gap: 4px;
-    text-shadow: 0 1px 3px rgba(0,0,0,0.7);
-  }
-  #collectible-icon { font-size: 16px; }
-  #collectible-count { font-variant-numeric: tabular-nums; }
-
   /* ── Contribution bar (multiplayer) ── */
   #contribution-bar {
     display: none;
@@ -964,7 +975,7 @@
     box-shadow: 0 0 15px rgba(68, 255, 102, 0.4);
   }
 
-  /* ── Bottom HUD: gauge bar + pedal buttons ── */
+  /* ── Bottom HUD: partner pedal indicators + pedal buttons ── */
   #bottom-hud {
     position: fixed;
     bottom: env(safe-area-inset-bottom, 0px);
@@ -981,34 +992,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 6px;
-  }
-
-  /* ── Gauges ── */
-  .gauge-wrap {
-    width: 54px; height: 54px;
-    position: relative;
-  }
-  .gauge-wrap svg { width: 100%; height: 100%; }
-  .gauge-label {
-    position: absolute;
-    bottom: -2px; left: 0; right: 0;
-    text-align: center;
-    font-size: 10px;
-    font-weight: 700;
-    color: #fff;
-    text-shadow: 0 1px 3px rgba(0,0,0,0.7);
-  }
-  .gauge-title {
-    position: absolute;
-    top: -2px; left: 0; right: 0;
-    text-align: center;
-    font-size: 8px;
-    font-weight: 600;
-    color: rgba(255,255,255,0.7);
-    text-shadow: 0 1px 2px rgba(0,0,0,0.5);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
+    gap: 18px;
   }
   .pedal-indicator {
     width: 28px;
@@ -1127,12 +1111,19 @@
     z-index: 10;
   }
 
-  /* ── Top-right D-pad buttons (PS-style) ── */
+  /* ── Top-right D-pad buttons (PS-style) ──
+     Retired from the screen: the disc ate the top-right corner on phones, and
+     its four actions now live in the quick menu. The element stays in the DOM
+     and keeps its handlers — the quick menu and the gamepad D-pad both drive
+     the game by clicking these buttons, and Game still toggles their inline
+     display to signal which actions the current role may use. Note the rule
+     below is `display: none`, so the `style.display = ''` restores in game.js
+     resolve back to hidden rather than re-showing the disc. */
   #side-buttons {
     position: fixed;
     top: calc(env(safe-area-inset-top, 0px) + 10px);
     right: 14px;
-    display: grid;
+    display: none;
     grid-template-areas:
       ".      safety ."
       "lobby  .      reset"
@@ -1260,6 +1251,140 @@
   #assist-btn.assist-off {
     background: linear-gradient(to top, rgba(100,100,100,0.95) 0%, rgba(55,55,55,0.95) 100%);
   }
+
+  /* ── Quick menu ──
+     One button in the corner the D-pad used to fill. Tap it to open a sheet of
+     the ride controls (safety, speed, assist, music, clip, reset, lobby), tap
+     an entry to run it — two taps for anything you rarely need, and nothing on
+     screen while you ride. The sheet drives the hidden #side-buttons /
+     #share-btn / #music-btn elements, which remain the single source of truth
+     for both state and behaviour. */
+  #quick-menu-btn {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 10px);
+    right: 14px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 1.5px solid rgba(255,255,255,0.22);
+    background: rgba(0,0,0,0.45);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    color: rgba(255,255,255,0.9);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    pointer-events: auto;
+    z-index: 12;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-appearance: none;
+    appearance: none;
+    transition: background 0.15s, border-color 0.15s;
+  }
+  #quick-menu-btn.visible { display: flex; }
+  #quick-menu-btn:active {
+    background: rgba(255,255,255,0.2);
+    border-color: rgba(255,255,255,0.5);
+  }
+
+  #quick-menu-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.6);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    z-index: 70;
+  }
+  #quick-menu-overlay.visible { display: flex; }
+  #quick-menu-sheet {
+    position: relative;
+    width: 100%;
+    max-width: 340px;
+    background: rgba(22,22,26,0.92);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 20px;
+    padding: 46px 16px 16px;
+    box-shadow: 0 18px 50px rgba(0,0,0,0.55);
+  }
+  #quick-menu-title {
+    position: absolute;
+    top: 16px; left: 20px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    color: rgba(255,255,255,0.4);
+  }
+  #quick-menu-close {
+    position: absolute;
+    top: 8px; right: 8px;
+    width: 36px;
+    height: 36px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.08);
+    color: rgba(255,255,255,0.75);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+  #quick-menu-close:active { background: rgba(255,255,255,0.2); }
+  #quick-menu-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .qm-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    min-height: 76px;
+    padding: 10px 6px;
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 14px;
+    background: rgba(255,255,255,0.06);
+    color: rgba(255,255,255,0.9);
+    font-family: inherit;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-appearance: none;
+    appearance: none;
+    transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+  }
+  .qm-item:active { background: rgba(255,255,255,0.16); }
+  .qm-item[hidden] { display: none; }
+  .qm-item:disabled {
+    opacity: 0.35;
+    cursor: default;
+  }
+  .qm-icon { font-size: 21px; line-height: 1; }
+  .qm-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+  }
+  .qm-state {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    color: rgba(255,255,255,0.4);
+  }
+  .qm-item.qm-on {
+    background: rgba(65,220,90,0.18);
+    border-color: rgba(65,220,90,0.45);
+  }
+  .qm-item.qm-on .qm-state { color: #6ee88a; }
+  .qm-item.qm-danger { grid-column: span 2; }
+  .qm-item.qm-danger .qm-label { color: #ff8a8a; }
 
   /* ── Pedal touch buttons (bottom) ── */
   #pedal-bar {
@@ -2073,9 +2198,7 @@
   body.mode-versus #bottom-hud,
   body.mode-versus #progress-bar-wrap,
   body.mode-versus #side-buttons,
-  body.mode-versus #bike-gauge,
-  body.mode-versus #phone-gauge,
-  body.mode-versus #partner-gauge,
+  body.mode-versus #quick-menu-btn,
   body.mode-versus #contribution-bar,
   body.mode-versus #gamepad-badge {
     display: none !important;
@@ -3033,7 +3156,13 @@
     background: rgba(255,255,255,0.18);
   }
 
-  /* ── Share / Record button ── */
+  /* ── Share / Record + music buttons ──
+     Both are off-screen now; the quick menu carries them. They keep their
+     geometry below only so nothing else has to change, and are forced hidden
+     here with `!important` because GameRecorder and Game still write
+     `style.display` on them to record availability — that inline value is the
+     signal the quick menu reads, so it must keep being written. */
+  #share-btn, #music-btn { display: none !important; }
   #share-btn {
     position: fixed;
     top: calc(env(safe-area-inset-top, 0px) + 130px);
@@ -4152,20 +4281,30 @@
 <!-- HUD: top bar -->
 <div id="hud-top">
   <div id="hud-dashboard">
-    <div id="speed-row">
-      <span id="speed-value">0</span>
-      <span id="speed-unit">km/h</span>
+    <div id="hud-stats">
+      <div class="hud-stat visible" id="speed-row">
+        <span id="speed-value">0</span>
+        <span id="speed-unit">km/h</span>
+      </div>
+      <div class="hud-stat visible" id="distance-row">
+        <span id="distance-display">0 m</span>
+      </div>
+      <div class="hud-stat" id="elapsed-row">
+        <span id="elapsed-display"></span>
+      </div>
+      <div class="hud-stat" id="timer-row">
+        <span id="segment-timer"></span>
+      </div>
+      <div class="hud-stat" id="collectible-counter">
+        <span class="hud-stat-icon" id="collectible-icon"></span>
+        <span id="collectible-count"></span>
+      </div>
+      <div class="hud-stat" id="geese-counter">
+        <span class="hud-stat-icon">&#x1FABF;</span>
+        <span id="geese-count">0</span>
+      </div>
     </div>
     <div id="speed-bar-wrap"><div id="speed-bar-fill"></div></div>
-    <div id="distance-row">
-      <span id="distance-display">0 m</span>
-    </div>
-    <div id="elapsed-row">
-      <span id="elapsed-display"></span>
-    </div>
-    <div id="timer-row">
-      <span id="segment-timer"></span>
-    </div>
     <div id="contribution-bar">
       <div id="contrib-captain"></div>
       <div id="contrib-stoker"></div>
@@ -4182,8 +4321,11 @@
   <span id="progress-bar-bike">&#x1F6B2;</span>
   <span id="progress-destination"></span>
 </div>
-<div id="collectible-counter"><span id="collectible-icon"></span><span id="collectible-count"></span></div>
 
+<!-- Clip + music toggles. Both moved into the quick menu (#quick-menu-overlay)
+     to clear the left edge; they stay in the DOM because their handlers and
+     their inline display (set by GameRecorder / Game) are what the quick menu
+     reads for availability and proxies clicks to. -->
 <!-- Share button (recording) -->
 <button id="share-btn" aria-label="Share clip">&#x1F3AC;</button>
 
@@ -4225,71 +4367,58 @@ ON</button>
   <button class="side-btn assist-off" id="assist-btn" style="display:none;">ASSIST</button>
 </div>
 
+<!-- Quick menu: the one on-screen control during a ride. Opens the sheet below,
+     whose entries proxy clicks to the hidden buttons above plus #share-btn and
+     #music-btn. Wired in js/quick-menu.js. -->
+<button id="quick-menu-btn" aria-label="Ride controls" aria-haspopup="dialog" aria-expanded="false">
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+    <path d="M3 6h9M15.5 6H17M3 14h3M9.5 14H17M3 10h6M12.5 10H17"/>
+    <circle cx="13.75" cy="6" r="1.75"/>
+    <circle cx="7.75" cy="14" r="1.75"/>
+    <circle cx="10.75" cy="10" r="1.75"/>
+  </svg>
+</button>
+
+<div id="quick-menu-overlay" role="dialog" aria-modal="true" aria-label="Ride controls">
+  <div id="quick-menu-sheet">
+    <span id="quick-menu-title">CONTROLS</span>
+    <button id="quick-menu-close" aria-label="Close">&times;</button>
+    <div id="quick-menu-grid">
+      <button class="qm-item" id="qm-safety">
+        <span class="qm-icon">&#x1F6E1;&#xFE0F;</span><span class="qm-label">SAFETY</span><span class="qm-state"></span>
+      </button>
+      <button class="qm-item" id="qm-speed">
+        <span class="qm-icon">&#x26A1;</span><span class="qm-label">AUTO SPEED</span><span class="qm-state"></span>
+      </button>
+      <button class="qm-item" id="qm-assist">
+        <span class="qm-icon">&#x1F91D;</span><span class="qm-label">ASSIST</span><span class="qm-state"></span>
+      </button>
+      <button class="qm-item" id="qm-music">
+        <span class="qm-icon">&#x1F3B5;</span><span class="qm-label">MUSIC</span><span class="qm-state"></span>
+      </button>
+      <button class="qm-item" id="qm-clip">
+        <span class="qm-icon">&#x1F3AC;</span><span class="qm-label">SAVE CLIP</span><span class="qm-state"></span>
+      </button>
+      <button class="qm-item" id="qm-recenter">
+        <span class="qm-icon">&#x1F3AF;</span><span class="qm-label">RECENTER TILT</span><span class="qm-state"></span>
+      </button>
+      <button class="qm-item" id="qm-reset">
+        <span class="qm-icon">&#x21BA;</span><span class="qm-label">RESET</span><span class="qm-state"></span>
+      </button>
+      <button class="qm-item qm-danger" id="qm-lobby">
+        <span class="qm-icon">&#x1F3E0;</span><span class="qm-label">RETURN TO LOBBY</span>
+      </button>
+    </div>
+  </div>
+</div>
+
 <!-- Bottom HUD: gauge bar + pedal buttons -->
 <div id="bottom-hud">
+  <!-- Partner pedal indicators. The YOU / BIKE / PARTNER lean gauges that used
+       to sit here were removed: they crowded the space directly above the pedal
+       buttons and duplicated what the bike itself already shows on screen. -->
   <div id="gauge-bar">
     <div class="pedal-indicator" id="partner-pedal-up">&#9650;</div>
-    <div class="gauge-wrap" id="phone-gauge">
-      <div class="gauge-title">YOU</div>
-      <svg viewBox="0 0 120 120">
-        <circle cx="60" cy="60" r="52" fill="rgba(0,0,0,0.5)" stroke="rgba(255,255,255,0.3)" stroke-width="2"/>
-        <path d="M 60 60 L 96.8 23.2 A 52 52 0 0 1 96.8 96.8 L 60 60" fill="rgba(0,180,0,0.2)"/>
-        <path d="M 60 60 L 23.2 96.8 A 52 52 0 0 1 23.2 23.2 L 60 60" fill="rgba(0,180,0,0.2)"/>
-        <line x1="60" y1="9" x2="60" y2="18" stroke="rgba(255,255,255,0.5)" stroke-width="1.5"/>
-        <g id="phone-needle" transform="rotate(0, 60, 60)">
-          <line x1="18" y1="60" x2="48" y2="60" stroke="#fa3" stroke-width="3" stroke-linecap="round"/>
-          <line x1="72" y1="60" x2="102" y2="60" stroke="#fa3" stroke-width="3" stroke-linecap="round"/>
-          <circle cx="60" cy="60" r="4" fill="none" stroke="#fa3" stroke-width="2"/>
-          <line x1="56" y1="60" x2="48" y2="60" stroke="#fa3" stroke-width="2"/>
-          <line x1="64" y1="60" x2="72" y2="60" stroke="#fa3" stroke-width="2"/>
-          <line x1="60" y1="56" x2="60" y2="50" stroke="#fa3" stroke-width="2"/>
-        </g>
-        <polygon points="60,10 57,16 63,16" fill="#fff" opacity="0.8"/>
-      </svg>
-      <div class="gauge-label" id="phone-label">0.0&deg;</div>
-    </div>
-    <div class="gauge-wrap" id="bike-gauge">
-      <div class="gauge-title">BIKE</div>
-      <svg viewBox="0 0 120 120">
-        <circle cx="60" cy="60" r="52" fill="rgba(0,0,0,0.5)" stroke="rgba(255,255,255,0.3)" stroke-width="2"/>
-        <path d="M 60 60 L 14.4 79.6 A 52 52 0 0 1 8 60 L 60 60" fill="rgba(255,50,50,0.25)"/>
-        <path d="M 60 60 L 112 60 A 52 52 0 0 1 105.6 79.6 L 60 60" fill="rgba(255,50,50,0.25)"/>
-        <line x1="60" y1="9" x2="60" y2="18" stroke="rgba(255,255,255,0.5)" stroke-width="1.5"/>
-        <line x1="29" y1="20" x2="34" y2="28" stroke="rgba(255,50,50,0.5)" stroke-width="1"/>
-        <line x1="91" y1="20" x2="86" y2="28" stroke="rgba(255,50,50,0.5)" stroke-width="1"/>
-        <line x1="12" y1="44" x2="21" y2="47" stroke="rgba(255,50,50,0.5)" stroke-width="1"/>
-        <line x1="108" y1="44" x2="99" y2="47" stroke="rgba(255,50,50,0.5)" stroke-width="1"/>
-        <g id="bike-needle" transform="rotate(0, 60, 60)">
-          <line x1="18" y1="60" x2="48" y2="60" stroke="#4af" stroke-width="3" stroke-linecap="round"/>
-          <line x1="72" y1="60" x2="102" y2="60" stroke="#4af" stroke-width="3" stroke-linecap="round"/>
-          <circle cx="60" cy="60" r="4" fill="none" stroke="#4af" stroke-width="2"/>
-          <line x1="56" y1="60" x2="48" y2="60" stroke="#4af" stroke-width="2"/>
-          <line x1="64" y1="60" x2="72" y2="60" stroke="#4af" stroke-width="2"/>
-          <line x1="60" y1="56" x2="60" y2="50" stroke="#4af" stroke-width="2"/>
-        </g>
-        <polygon points="60,10 57,16 63,16" fill="#fff" opacity="0.8"/>
-      </svg>
-      <div class="gauge-label" id="bike-label">0.0&deg;</div>
-    </div>
-    <div class="gauge-wrap" id="partner-gauge" style="display:none;">
-      <div class="gauge-title">PARTNER</div>
-      <svg viewBox="0 0 120 120">
-        <circle cx="60" cy="60" r="52" fill="rgba(0,0,0,0.5)" stroke="rgba(255,255,255,0.3)" stroke-width="2"/>
-        <path d="M 60 60 L 96.8 23.2 A 52 52 0 0 1 96.8 96.8 L 60 60" fill="rgba(170,102,255,0.15)"/>
-        <path d="M 60 60 L 23.2 96.8 A 52 52 0 0 1 23.2 23.2 L 60 60" fill="rgba(170,102,255,0.15)"/>
-        <line x1="60" y1="9" x2="60" y2="18" stroke="rgba(255,255,255,0.5)" stroke-width="1.5"/>
-        <g id="partner-needle" transform="rotate(0, 60, 60)">
-          <line x1="18" y1="60" x2="48" y2="60" stroke="#a6f" stroke-width="3" stroke-linecap="round"/>
-          <line x1="72" y1="60" x2="102" y2="60" stroke="#a6f" stroke-width="3" stroke-linecap="round"/>
-          <circle cx="60" cy="60" r="4" fill="none" stroke="#a6f" stroke-width="2"/>
-          <line x1="56" y1="60" x2="48" y2="60" stroke="#a6f" stroke-width="2"/>
-          <line x1="64" y1="60" x2="72" y2="60" stroke="#a6f" stroke-width="2"/>
-          <line x1="60" y1="56" x2="60" y2="50" stroke="#a6f" stroke-width="2"/>
-        </g>
-        <polygon points="60,10 57,16 63,16" fill="#fff" opacity="0.8"/>
-      </svg>
-      <div class="gauge-label" id="partner-label">0.0&deg;</div>
-    </div>
     <div class="pedal-indicator" id="partner-pedal-down">&#9660;</div>
   </div>
   <div id="pedal-bar">

--- a/js/finish-camera-animation.js
+++ b/js/finish-camera-animation.js
@@ -13,6 +13,22 @@ const PHASE = {
   DONE: 3,
 };
 
+// The frontal three-quarter pose the swing lands on and the two later phases
+// hold. theta=0 is directly in front of the bike.
+//
+// Camera and aim both sit higher than the geometry alone would ask for: the
+// riders' heads are the tallest thing on the bike, and a pose framed on the
+// bike centre pushed them into the top ~10% of a portrait screen — straight
+// under the HUD's top strip, which clipped their faces at the moment the shot
+// exists to show them. Lifting the camera and lifting the aim further still
+// drops the heads to roughly a third down the frame and flattens the downward
+// tilt from ~20° to ~9°, which is a kinder angle for a victory frame anyway.
+const END_THETA = -0.35;
+const END_RADIUS = 4.2;
+const END_HEIGHT = 2.0;
+const END_LOOK_FWD = 1.4;
+const END_LOOK_Y = 1.55;
+
 export class FinishCameraAnimation {
   constructor(camera, bike) {
     this.camera = camera;
@@ -114,18 +130,20 @@ export class FinishCameraAnimation {
     const e = this._easeInOut(t);
     const bikePos = this.bike.position;
 
-    const theta = this._lerp(Math.PI, -0.35, e);
-    const radius = this._lerp(11, 4.2, e);
-    const height = this._lerp(4.0, 1.7, e);
+    const theta = this._lerp(Math.PI, END_THETA, e);
+    const radius = this._lerp(11, END_RADIUS, e);
+    const height = this._lerp(4.0, END_HEIGHT, e);
 
     this._orbitOffset(theta, radius, height, this._orbitPos);
     this._desiredPos.copy(bikePos).add(this._orbitPos);
 
-    const lookFwdBias = this._lerp(-0.5, 1.4, e);
+    const lookFwdBias = this._lerp(-0.5, END_LOOK_FWD, e);
     this._desiredLook.copy(bikePos);
     this._desiredLook.x += this._fwd.x * lookFwdBias;
     this._desiredLook.z += this._fwd.z * lookFwdBias;
-    this._desiredLook.y += this._lerp(0.9, 0.65, e);
+    // Rises through the swing, so the riders sit lower in frame the closer the
+    // camera gets rather than climbing towards the top strip.
+    this._desiredLook.y += this._lerp(1.2, END_LOOK_Y, e);
 
     // Ease out of the chase cam's last pose for the first ~40% of swing.
     const blend = Math.min(1, t * 2.5);
@@ -143,24 +161,27 @@ export class FinishCameraAnimation {
     this.camera.updateProjectionMatrix();
   }
 
+  /** Park the camera on the held end pose. Shared by the zoom and hold phases. */
+  _applyEndPose() {
+    const bikePos = this.bike.position;
+    this._orbitOffset(END_THETA, END_RADIUS, END_HEIGHT, this._orbitPos);
+    this._desiredPos.copy(bikePos).add(this._orbitPos);
+    this.camera.position.copy(this._desiredPos);
+
+    this._desiredLook.copy(bikePos);
+    this._desiredLook.x += this._fwd.x * END_LOOK_FWD;
+    this._desiredLook.z += this._fwd.z * END_LOOK_FWD;
+    this._desiredLook.y += END_LOOK_Y;
+    this.camera.lookAt(this._desiredLook);
+  }
+
   // Phase 2: settle on the frontal three-quarter pose the swing landed
   // on — no further dolly-in. FOV eases back from the swing's wide
   // bias to the camera's normal value so the held frame doesn't read
   // as distorted.
   _updateZoom(t) {
     const e = this._easeOutQuint(t);
-    const bikePos = this.bike.position;
-
-    this._orbitOffset(-0.35, 4.2, 1.7, this._orbitPos);
-    this._desiredPos.copy(bikePos).add(this._orbitPos);
-    this.camera.position.copy(this._desiredPos);
-
-    this._desiredLook.copy(bikePos);
-    this._desiredLook.x += this._fwd.x * 1.4;
-    this._desiredLook.z += this._fwd.z * 1.4;
-    this._desiredLook.y += 0.65;
-    this.camera.lookAt(this._desiredLook);
-
+    this._applyEndPose();
     this.camera.fov = this._lerp(this.startFov + 6, this.startFov, e);
     this.camera.updateProjectionMatrix();
   }
@@ -168,17 +189,7 @@ export class FinishCameraAnimation {
   // Phase 3: hold the same frontal three-quarter pose for a beat
   // before the victory overlay reveals — no zoom past the swing.
   _updateHold() {
-    const bikePos = this.bike.position;
-    this._orbitOffset(-0.35, 4.2, 1.7, this._orbitPos);
-    this._desiredPos.copy(bikePos).add(this._orbitPos);
-    this.camera.position.copy(this._desiredPos);
-
-    this._desiredLook.copy(bikePos);
-    this._desiredLook.x += this._fwd.x * 1.4;
-    this._desiredLook.z += this._fwd.z * 1.4;
-    this._desiredLook.y += 0.65;
-    this.camera.lookAt(this._desiredLook);
-
+    this._applyEndPose();
     this.camera.fov = this.startFov;
     this.camera.updateProjectionMatrix();
   }

--- a/js/game-recorder.js
+++ b/js/game-recorder.js
@@ -800,10 +800,7 @@ export class GameRecorder {
     // ── Pedal buttons (bottom, matches .pedal-touch) ──
     this._drawPedalButtons(ctx, w, h, s, state);
 
-    // ── Gauges (YOU + BIKE, centered above pedals) ──
-    this._drawGauges(ctx, w, h, s, state);
-
-    // ── Partner pedal indicators (wider apart, flanking partner label) ──
+    // ── Partner pedal indicators (just above the pedal buttons) ──
     if (state.hasPartner) {
       this._drawPartnerIndicators(ctx, w, h, s, state);
     }
@@ -878,81 +875,104 @@ export class GameRecorder {
     if (kmh > 35) { speedColor = '#00e040'; barColor = '#00e040'; }
     else if (kmh > 15) { speedColor = '#88ff88'; barColor = '#88ff88'; }
 
-    // Dashboard card dimensions
+    const FF = 'Helvetica Neue, Arial, sans-serif';
+    // Canvas gets no automatic emoji fallback the way the DOM does — name the
+    // platform emoji fonts explicitly or the gift and goose icons draw as tofu.
+    const EF = '"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", ' + FF;
+    const DIM = 'rgba(255,255,255,0.5)';
+    const BRIGHT = 'rgba(255,255,255,0.85)';
+
+    // One horizontal strip, mirroring #hud-stats: each stat is a short list of
+    // text runs drawn left to right, and consecutive stats are parted by a
+    // hairline. Same order, same colors, same hidden-when-absent rules as the
+    // live HUD, so a saved clip looks like what the rider was looking at.
+    const stats = [];
+    stats.push([
+      { text: '' + kmh, font: 'bold ' + Math.round(20 * s) + 'px ' + FF, color: speedColor },
+      { text: 'km/h', font: '600 ' + Math.round(10 * s) + 'px ' + FF, color: DIM, gap: 3 * s },
+    ]);
+    stats.push([{ text: distText, font: '600 ' + Math.round(12 * s) + 'px ' + FF, color: DIM }]);
+    if (state.elapsedText) {
+      stats.push([{ text: state.elapsedText, font: '600 ' + Math.round(12 * s) + 'px ' + FF, color: DIM }]);
+    }
+    if (hasTimer) {
+      stats.push([{ text: timerText, font: 'bold ' + Math.round(16 * s) + 'px ' + FF, color: timerColor }]);
+    }
+    if (state.collectibleIcon) {
+      stats.push([
+        { text: state.collectibleIcon, font: Math.round(13 * s) + 'px ' + EF, color: BRIGHT },
+        { text: state.collectibleText, font: 'bold ' + Math.round(12 * s) + 'px ' + FF, color: BRIGHT, gap: 3 * s },
+      ]);
+    }
+    if (state.geese != null) {
+      // Worded, not the HUD's goose emoji: U+1FABF only landed in system fonts
+      // in 2022, and canvas has no DOM-style fallback to save a device that
+      // lacks it — a shared clip would carry a tofu box. The gift emoji above
+      // is old enough to be everywhere, so it stays as drawn.
+      stats.push([
+        { text: 'GEESE', font: '700 ' + Math.round(9 * s) + 'px ' + FF, color: DIM },
+        { text: '' + state.geese, font: 'bold ' + Math.round(12 * s) + 'px ' + FF, color: BRIGHT, gap: 3 * s },
+      ]);
+    }
+
+    // Measure — matches #hud-stats gap 7px + the 1px rule with its 4px margin.
+    const sepPre = 7 * s;
+    const sepW = 1 * s;
+    const sepPost = 4 * s;
+    let rowW = 0;
+    for (let i = 0; i < stats.length; i++) {
+      if (i > 0) rowW += sepPre + sepW + sepPost;
+      for (const run of stats[i]) {
+        ctx.font = run.font;
+        rowW += (run.gap || 0) + ctx.measureText(run.text).width;
+      }
+    }
+
+    // Card geometry
     const px = 14 * s;
     const py = 10 * s;
-    const padH = 8 * s;
-    const padV = 8 * s;
-    const speedFontSize = Math.round(28 * s);
-    const unitFontSize = Math.round(11 * s);
-    const distFontSize = Math.round(11 * s);
-    const timerFontSize = Math.round(21 * s);
-    const barH = 4 * s;
-    const lineGap = 3 * s;
+    const padH = 12 * s;
+    const padV = 7 * s;
+    const rowH = 20 * s;
+    const barH = 3 * s;
+    const lineGap = 4 * s;
+    const cardW = rowW + padH * 2;
+    const cardH = padV * 2 + rowH + lineGap + barH;
 
-    // Measure text to size the card
-    ctx.font = 'bold ' + speedFontSize + 'px Helvetica Neue, Arial, sans-serif';
-    const speedTextW = ctx.measureText('' + kmh).width;
-    ctx.font = '600 ' + unitFontSize + 'px Helvetica Neue, Arial, sans-serif';
-    const unitTextW = ctx.measureText('km/h').width;
-    const rowW = speedTextW + 4 * s + unitTextW;
-    ctx.font = '500 ' + distFontSize + 'px Helvetica Neue, Arial, sans-serif';
-    const distTextW = ctx.measureText(distText).width;
-    let timerTextW = 0;
-    if (hasTimer) {
-      ctx.font = 'bold ' + timerFontSize + 'px Helvetica Neue, Arial, sans-serif';
-      timerTextW = ctx.measureText(timerText).width;
-    }
-    const cardW = Math.max(rowW, distTextW, timerTextW) + padH * 2;
-    let cardH = speedFontSize + lineGap + barH + lineGap + distFontSize + padV * 2;
-    if (hasTimer) cardH += lineGap + timerFontSize;
-
-    // Card background (rgba(0,0,0,0.45) + border)
     ctx.save();
-    this._roundRect(ctx, px, py, cardW, cardH, 12 * s,
+    this._roundRect(ctx, px, py, cardW, cardH, 14 * s,
       'rgba(0,0,0,0.45)', 'rgba(255,255,255,0.12)', 1);
 
-    // Speed value
-    let cy = py + padV;
-    ctx.font = 'bold ' + speedFontSize + 'px Helvetica Neue, Arial, sans-serif';
-    ctx.fillStyle = speedColor;
-    ctx.textBaseline = 'top';
+    // Stats row — one shared centre line so the different sizes align.
+    const midY = py + padV + rowH / 2;
     ctx.textAlign = 'left';
-    ctx.fillText('' + kmh, px + padH, cy);
-
-    // "km/h" unit
-    ctx.font = '600 ' + unitFontSize + 'px Helvetica Neue, Arial, sans-serif';
-    ctx.fillStyle = 'rgba(255,255,255,0.5)';
-    ctx.textBaseline = 'bottom';
-    ctx.fillText('km/h', px + padH + speedTextW + 4 * s, cy + speedFontSize);
-
-    // Speed bar
-    cy += speedFontSize + lineGap;
-    const barW = cardW - padH * 2;
-    // Bar track
-    this._roundRect(ctx, px + padH, cy, barW, barH, 2 * s,
-      'rgba(255,255,255,0.1)', 'transparent', 0);
-    // Bar fill
-    const fillW = Math.min(1, kmh / maxKmh) * barW;
-    if (fillW > 0) {
-      this._roundRect(ctx, px + padH, cy, fillW, barH, 2 * s,
-        barColor, 'transparent', 0);
+    ctx.textBaseline = 'middle';
+    let cx = px + padH;
+    for (let i = 0; i < stats.length; i++) {
+      if (i > 0) {
+        cx += sepPre;
+        ctx.fillStyle = 'rgba(255,255,255,0.16)';
+        ctx.fillRect(cx, midY - 6.5 * s, sepW, 13 * s);
+        cx += sepW + sepPost;
+      }
+      for (const run of stats[i]) {
+        cx += run.gap || 0;
+        ctx.font = run.font;
+        ctx.fillStyle = run.color;
+        ctx.fillText(run.text, cx, midY);
+        cx += ctx.measureText(run.text).width;
+      }
     }
 
-    // Distance
-    cy += barH + lineGap;
-    ctx.font = '500 ' + distFontSize + 'px Helvetica Neue, Arial, sans-serif';
-    ctx.fillStyle = 'rgba(255,255,255,0.45)';
-    ctx.textBaseline = 'top';
-    ctx.fillText(distText, px + padH, cy);
-
-    // Timer
-    if (hasTimer) {
-      cy += distFontSize + lineGap;
-      ctx.font = 'bold ' + timerFontSize + 'px Helvetica Neue, Arial, sans-serif';
-      ctx.fillStyle = timerColor;
-      ctx.textBaseline = 'top';
-      ctx.fillText(timerText, px + padH, cy);
+    // Speed bar under the strip, spanning the card
+    const barY = py + padV + rowH + lineGap;
+    const barW = cardW - padH * 2;
+    this._roundRect(ctx, px + padH, barY, barW, barH, 2 * s,
+      'rgba(255,255,255,0.1)', 'transparent', 0);
+    const fillW = Math.min(1, kmh / maxKmh) * barW;
+    if (fillW > 0) {
+      this._roundRect(ctx, px + padH, barY, fillW, barH, 2 * s,
+        barColor, 'transparent', 0);
     }
 
     ctx.restore();
@@ -1138,208 +1158,22 @@ export class GameRecorder {
     drawBtn(rx, state.rightPressed, false);
   }
 
-  // ── Gauges — replicates .gauge-wrap (YOU + BIKE, optionally PARTNER) ──
-
-  _drawGauges(ctx, w, h, s, state) {
-    const btnH = Math.min(Math.max(80 * s, h * 0.12), 140 * s);
-    const bottomPad = 8 * s;
-    const pedalTop = h - bottomPad - btnH;
-    const gaugeSize = 54 * s;
-    const gaugeGap = 6 * s;
-
-    // Position gauges above pedal buttons, centered
-    const gaugeY = pedalTop - gaugeGap - gaugeSize;
-
-    if (state.hasPartner) {
-      // 3 gauges: YOU | BIKE | PARTNER
-      const totalW = gaugeSize * 3 + gaugeGap * 2;
-      const startX = (w - totalW) / 2;
-      this._drawSingleGauge(ctx, startX, gaugeY, gaugeSize, s, 'YOU', state.youDeg, '#fa3', 'green', 0);
-      this._drawSingleGauge(ctx, startX + gaugeSize + gaugeGap, gaugeY, gaugeSize, s, 'BIKE', state.bikeDeg, '#4af', 'red', state.bikeDanger);
-      this._drawSingleGauge(ctx, startX + (gaugeSize + gaugeGap) * 2, gaugeY, gaugeSize, s,
-        state.mode === 'captain' ? 'STOKER' : 'CAPTAIN', state.partnerDeg, '#a6f', 'purple', 0);
-    } else {
-      // 2 gauges: YOU | BIKE
-      const totalW = gaugeSize * 2 + gaugeGap;
-      const startX = (w - totalW) / 2;
-      this._drawSingleGauge(ctx, startX, gaugeY, gaugeSize, s, 'YOU', state.youDeg, '#fa3', 'green', 0);
-      this._drawSingleGauge(ctx, startX + gaugeSize + gaugeGap, gaugeY, gaugeSize, s, 'BIKE', state.bikeDeg, '#4af', 'red', state.bikeDanger);
-    }
-  }
-
-  _drawSingleGauge(ctx, gx, gy, size, s, title, needleDeg, needleColor, sectorType, danger) {
-    const cx = gx + size / 2;
-    const cy = gy + size / 2;
-    const r = size * 52 / 120; // matches SVG r=52 in viewBox 120
-
-    ctx.save();
-
-    // Background circle
-    ctx.beginPath();
-    ctx.arc(cx, cy, r, 0, Math.PI * 2);
-    ctx.fillStyle = 'rgba(0,0,0,0.5)';
-    ctx.fill();
-    ctx.strokeStyle = 'rgba(255,255,255,0.3)';
-    ctx.lineWidth = 1.5 * s;
-    ctx.stroke();
-
-    // Sector zones
-    if (sectorType === 'green') {
-      // Right safe zone (45° to 135° from top = π/4 to 3π/4 from right)
-      ctx.fillStyle = 'rgba(0,180,0,0.2)';
-      ctx.beginPath();
-      ctx.moveTo(cx, cy);
-      ctx.arc(cx, cy, r, -Math.PI * 3 / 4, -Math.PI / 4);
-      ctx.closePath();
-      ctx.fill();
-      // Left safe zone
-      ctx.beginPath();
-      ctx.moveTo(cx, cy);
-      ctx.arc(cx, cy, r, Math.PI / 4, Math.PI * 3 / 4);
-      ctx.closePath();
-      ctx.fill();
-    } else if (sectorType === 'red') {
-      // Danger zones at sides (horizontal = tipped over)
-      ctx.fillStyle = 'rgba(255,50,50,0.25)';
-      // Left danger
-      ctx.beginPath();
-      ctx.moveTo(cx, cy);
-      ctx.arc(cx, cy, r, Math.PI * 0.55, Math.PI * 0.8);
-      ctx.closePath();
-      ctx.fill();
-      // Right danger
-      ctx.beginPath();
-      ctx.moveTo(cx, cy);
-      ctx.arc(cx, cy, r, -Math.PI * 0.8, -Math.PI * 0.55);
-      ctx.closePath();
-      ctx.fill();
-    } else if (sectorType === 'purple') {
-      ctx.fillStyle = 'rgba(170,102,255,0.15)';
-      ctx.beginPath();
-      ctx.moveTo(cx, cy);
-      ctx.arc(cx, cy, r, -Math.PI * 3 / 4, -Math.PI / 4);
-      ctx.closePath();
-      ctx.fill();
-      ctx.beginPath();
-      ctx.moveTo(cx, cy);
-      ctx.arc(cx, cy, r, Math.PI / 4, Math.PI * 3 / 4);
-      ctx.closePath();
-      ctx.fill();
-    }
-
-    // Top tick mark
-    const tickLen = size * 9 / 120;
-    ctx.beginPath();
-    ctx.moveTo(cx, gy + size * 9 / 120);
-    ctx.lineTo(cx, gy + size * 18 / 120);
-    ctx.strokeStyle = 'rgba(255,255,255,0.5)';
-    ctx.lineWidth = 1.2 * s;
-    ctx.stroke();
-
-    // Red danger ticks for BIKE gauge
-    if (sectorType === 'red') {
-      ctx.strokeStyle = 'rgba(255,50,50,0.5)';
-      ctx.lineWidth = 0.8 * s;
-      const drawTick = (ang, inner, outer) => {
-        const a = (ang - 90) * Math.PI / 180;
-        ctx.beginPath();
-        ctx.moveTo(cx + Math.cos(a) * r * outer, cy + Math.sin(a) * r * outer);
-        ctx.lineTo(cx + Math.cos(a) * r * inner, cy + Math.sin(a) * r * inner);
-        ctx.stroke();
-      };
-      drawTick(-60, 0.75, 0.95);
-      drawTick(60, 0.75, 0.95);
-      drawTick(-75, 0.8, 0.95);
-      drawTick(75, 0.8, 0.95);
-    }
-
-    // Needle (rotated)
-    ctx.save();
-    ctx.translate(cx, cy);
-    ctx.rotate(needleDeg * Math.PI / 180);
-    const needleW = 2.2 * s;
-    // Left arm
-    ctx.beginPath();
-    ctx.moveTo(-r * 0.7, 0);
-    ctx.lineTo(-r * 0.2, 0);
-    ctx.strokeStyle = needleColor;
-    ctx.lineWidth = needleW;
-    ctx.lineCap = 'round';
-    ctx.stroke();
-    // Right arm
-    ctx.beginPath();
-    ctx.moveTo(r * 0.2, 0);
-    ctx.lineTo(r * 0.7, 0);
-    ctx.stroke();
-    // Center ring
-    ctx.beginPath();
-    ctx.arc(0, 0, 3 * s, 0, Math.PI * 2);
-    ctx.strokeStyle = needleColor;
-    ctx.lineWidth = 1.5 * s;
-    ctx.stroke();
-    // Center crosshair lines
-    ctx.lineWidth = 1.2 * s;
-    ctx.beginPath(); ctx.moveTo(-3 * s, 0); ctx.lineTo(-r * 0.2, 0); ctx.stroke();
-    ctx.beginPath(); ctx.moveTo(3 * s, 0); ctx.lineTo(r * 0.2, 0); ctx.stroke();
-    ctx.beginPath(); ctx.moveTo(0, -3 * s); ctx.lineTo(0, -r * 0.18); ctx.stroke();
-    ctx.restore();
-
-    // Top pointer triangle
-    ctx.fillStyle = 'rgba(255,255,255,0.8)';
-    ctx.beginPath();
-    ctx.moveTo(cx, gy + size * 10 / 120);
-    ctx.lineTo(cx - 2.5 * s, gy + size * 16 / 120);
-    ctx.lineTo(cx + 2.5 * s, gy + size * 16 / 120);
-    ctx.closePath();
-    ctx.fill();
-
-    // Title text above gauge
-    ctx.font = '600 ' + Math.round(7 * s) + 'px Helvetica Neue, Arial, sans-serif';
-    ctx.fillStyle = 'rgba(255,255,255,0.7)';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'bottom';
-    ctx.fillText(title, cx, gy - 1 * s);
-
-    // Degree label below gauge
-    const degText = Math.abs(needleDeg).toFixed(1) + '\u00B0';
-    let labelColor = '#fff';
-    if (sectorType === 'red') {
-      if (danger > 0.75) labelColor = '#ff4444';
-      else if (danger > 0.5) labelColor = '#ffaa22';
-    }
-    ctx.font = 'bold ' + Math.round(9 * s) + 'px Helvetica Neue, Arial, sans-serif';
-    ctx.fillStyle = labelColor;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'top';
-    ctx.shadowColor = 'rgba(0,0,0,0.7)';
-    ctx.shadowBlur = 2 * s;
-    ctx.fillText(degText, cx, gy + size + 1 * s);
-    ctx.shadowBlur = 0;
-
-    ctx.restore();
-  }
-
-  // ── Partner pedal indicators — wider apart with partner role label ──
+  // ── Partner pedal indicators — a pair centred above the pedal buttons ──
 
   _drawPartnerIndicators(ctx, w, h, s, state) {
     const btnH = Math.min(Math.max(80 * s, h * 0.12), 140 * s);
     const bottomPad = 8 * s;
     const pedalTop = h - bottomPad - btnH;
-    const gaugeSize = 54 * s;
-    const gaugeGap = 6 * s;
-    // Indicators sit at same Y as gauges, flanking the gauge row
-    const gaugeY = pedalTop - gaugeGap - gaugeSize;
 
     const indW = 28 * s;
     const indH = 54 * s;
     const indR = 8 * s;
+    const indGap = 18 * s;
 
-    // Position: wider apart — outside the 3-gauge row
-    const totalGaugeW = gaugeSize * 3 + gaugeGap * 2;
-    const gaugeStartX = (w - totalGaugeW) / 2;
-    const upX = gaugeStartX - indW - 6 * s;
-    const downX = gaugeStartX + totalGaugeW + 6 * s;
-    const indY = gaugeY;
+    // Matches #gauge-bar: the two indicators, centred, sitting on the pedals.
+    const indY = pedalTop - 6 * s - indH;
+    const upX = w / 2 - indGap / 2 - indW;
+    const downX = w / 2 + indGap / 2;
 
     const drawInd = (ix, iy, isUp, isFlash, isWrong) => {
       let bg, border;

--- a/js/game-recorder.js
+++ b/js/game-recorder.js
@@ -795,7 +795,7 @@ export class GameRecorder {
     }
 
     // ── Speed dashboard (top-left, matches #hud-dashboard) ──
-    this._drawSpeedDashboard(ctx, s, state);
+    this._drawSpeedDashboard(ctx, w, s, state);
 
     // ── Pedal buttons (bottom, matches .pedal-touch) ──
     this._drawPedalButtons(ctx, w, h, s, state);
@@ -851,7 +851,7 @@ export class GameRecorder {
 
   // ── Speed dashboard — replicates #hud-dashboard ──
 
-  _drawSpeedDashboard(ctx, s, state) {
+  _drawSpeedDashboard(ctx, w, s, state) {
     const kmh = Math.round((state.speed || 0) * 3.6);
     const maxKmh = 58;
     const dist = state.distance || 0;
@@ -915,10 +915,10 @@ export class GameRecorder {
       ]);
     }
 
-    // Measure — matches #hud-stats gap 7px + the 1px rule with its 4px margin.
-    const sepPre = 7 * s;
+    // Measure — matches #hud-stats gap 6px + the 1px rule with its 3px margin.
+    const sepPre = 6 * s;
     const sepW = 1 * s;
-    const sepPost = 4 * s;
+    const sepPost = 3 * s;
     let rowW = 0;
     for (let i = 0; i < stats.length; i++) {
       if (i > 0) rowW += sepPre + sepW + sepPost;
@@ -936,7 +936,9 @@ export class GameRecorder {
     const rowH = 20 * s;
     const barH = 3 * s;
     const lineGap = 4 * s;
-    const cardW = rowW + padH * 2;
+    // Spans the frame like the phone's strip does, but grows past that rather
+    // than clipping if a long readout needs more than the width allows.
+    const cardW = Math.max(rowW + padH * 2, w - px * 2);
     const cardH = padV * 2 + rowH + lineGap + barH;
 
     ctx.save();

--- a/js/game.js
+++ b/js/game.js
@@ -29,6 +29,7 @@ import { HUD } from './hud.js';
 import { GrassParticles } from './grass-particles.js';
 import { Lobby } from './lobby.js';
 import { GameRecorder } from './game-recorder.js';
+import { QuickMenu } from './quick-menu.js';
 import { ArchIndicator } from './arch-indicator.js';
 import { AudioEngine, MOTIF } from './audio-engine.js';
 import { hapticCrash, hapticTreeHit, hapticCheckpoint, hapticFinish, hapticOffRoad, hapticBump, setHapticSources } from './haptics.js';
@@ -611,6 +612,14 @@ class Game {
       this._updateMusicBtnIcon();
     });
 
+    // Quick menu — the only ride control left on screen. It proxies the hidden
+    // safety/speed/assist/reset/lobby buttons plus the clip and music toggles,
+    // so it has to be built after all of them are wired above.
+    this.quickMenu = new QuickMenu({
+      available: () => this.input.motionEnabled || this.input.gyroConnected,
+      run: () => this._recalibrateTilt(),
+    });
+
     // Volume changes from lobby slider
     this.lobby.onVolumeChanged = (vol) => {
       this._musicEl.volume = vol;
@@ -925,7 +934,6 @@ class Game {
         this._partnerHasTilt = profile.hasTilt;
         this._partnerCanSteer = (profile.canSteer !== false);
         this._partnerMethod = profile.method || null;
-        if (this.hud) this.hud.partnerCanSteer = this._partnerCanSteer;
         if (this._onStokerReady) this._onStokerReady();
         return;
       }
@@ -981,12 +989,7 @@ class Game {
     // Store room role for return-to-room
     this._roomRole = mode;
 
-    // Update partner gauge label to show partner's role
-    const partnerTitle = document.querySelector('#partner-gauge .gauge-title');
-    if (partnerTitle) partnerTitle.textContent = mode === 'captain' ? 'STOKER' : 'CAPTAIN';
-
-    // Show partner gauge + pedal indicators immediately
-    document.getElementById('partner-gauge').style.display = '';
+    // Show the partner's pedal indicators immediately
     document.getElementById('partner-pedal-up').style.display = 'flex';
     document.getElementById('partner-pedal-down').style.display = 'flex';
 
@@ -1053,12 +1056,9 @@ class Game {
     this._remoteLastTapTime = 0;
     this.remoteLean = 0;
 
-    // Partner gauge: show P2 lean + pedal indicators (reuses the online MP HUD)
-    document.getElementById('partner-gauge').style.display = '';
+    // Show P2's pedal indicators (reuses the online MP HUD)
     document.getElementById('partner-pedal-up').style.display = 'flex';
     document.getElementById('partner-pedal-down').style.display = 'flex';
-    const partnerTitle = document.querySelector('#partner-gauge .gauge-title');
-    if (partnerTitle) partnerTitle.textContent = 'PLAYER 2';
 
     // Tag the body so local-mode-specific CSS (contribution bar recolor, etc.)
     // can take effect. Cleared in _returnToLobby.
@@ -1563,9 +1563,10 @@ class Game {
     this._hideVictory();
     this.instructionsEl.classList.add('hidden');
 
-    // Show in-game music button
+    // Show in-game music button (off-screen; the quick menu proxies it)
     this._musicBtn.style.display = 'block';
     this._updateMusicBtnIcon();
+    this.quickMenu.setVisible(true);
 
     // Apply difficulty preset and create DDA manager
     const difficultyName = this.lobby.selectedDifficulty || 'adventurous';
@@ -1680,7 +1681,8 @@ class Game {
     const firstTarget = this.raceManager.checkpoints.length > 0 ? this.raceManager.checkpoints[0] : this.raceManager.raceDistance;
     const initialBudget = this.raceManager._segmentBudget(firstTarget);
     this.hud.updateTimer(initialBudget, initialBudget);
-    this.hud.showCollectibles(level);
+    this.hud.showCollectibles(level, this.collectibleManager.getTotalItems());
+    this.hud.showGeese();
     this.world.setRaceMarkers(level, this.camera);
 
     // Tutorial: place all items from all phases so they're visible ahead
@@ -1775,6 +1777,7 @@ class Game {
     document.body.classList.remove('versus-fullframe');
     this._musicBtn.style.display = 'block';
     this._updateMusicBtnIcon();
+    this.quickMenu.setVisible(true);
 
     const difficultyName = this.lobby.selectedDifficulty || 'adventurous';
     applyDifficulty(difficultyName);
@@ -2095,6 +2098,8 @@ class Game {
 
     // Refresh HUD so speed/distance reflect the reset state during countdown
     this.hud.update(this.bike, this.input, this.pedalCtrl || this.sharedPedal, 0);
+    // Back into a ride — restore the quick menu the result overlays retired.
+    this.quickMenu.setVisible(true);
 
     // Captain always broadcasts reset so stoker also resets.
     // Stoker receiving EVT_RESET calls _resetGame(fromRemote=true) which won't re-send.
@@ -2237,6 +2242,8 @@ class Game {
   _showGameOver(fromRemote = false) {
     this.state = 'gameover';
     this.hud.hideTimer();
+    // The quick menu sits above the result overlays, so retire it with the ride.
+    this.quickMenu.setVisible(false);
     if (this.raceManager) this.raceManager.crashCount++;
     hapticCrash();
 
@@ -2595,6 +2602,8 @@ class Game {
   _showVictory(fromRemote = false) {
     this.state = 'victory';
     this.hud.hideTimer();
+    // The quick menu sits above the result overlays, so retire it with the ride.
+    this.quickMenu.setVisible(false);
     const overlay = document.getElementById('victory-overlay');
     overlay.classList.add('visible');
 
@@ -3078,6 +3087,7 @@ class Game {
       this.input.suppressGamepadLean = !this.lobby.joystickActive;
     }
     this._musicBtn.style.display = 'none';
+    this.quickMenu.setVisible(false);
     if (!this.lobby.musicActive) {
       this._musicEl.pause();
       this._musicEl.currentTime = 0;
@@ -3096,6 +3106,7 @@ class Game {
     if (this.obstacleManager) { this.obstacleManager.destroy(); this.obstacleManager = null; }
     this._contribBar.style.display = 'none';
     this.hud.hideCollectibles();
+    this.hud.hideGeese();
     this.hud.hideTimer();
     this.world.clearRaceMarkers();
     this.recorder.stopBuffer();
@@ -3137,8 +3148,6 @@ class Game {
     const gpBadge = document.getElementById('gamepad-badge');
     if (gpBadge && this.input.gamepadConnected) gpBadge.style.display = 'block';
     document.getElementById('side-buttons').style.display = '';
-    const partnerTitle = document.querySelector('#partner-gauge .gauge-title');
-    if (partnerTitle) partnerTitle.textContent = 'PARTNER';
 
     this.archIndicator.hide();
     this._partnerBikeColor = null;
@@ -3206,6 +3215,7 @@ class Game {
 
   _returnToRoom() {
     this._musicBtn.style.display = 'none';
+    this.quickMenu.setVisible(false);
     if (!this.net) {
       // Fallback to full lobby return if no connection
       this._returnToLobby();
@@ -3239,6 +3249,7 @@ class Game {
     if (this.obstacleManager) { this.obstacleManager.destroy(); this.obstacleManager = null; }
     this._contribBar.style.display = 'none';
     this.hud.hideCollectibles();
+    this.hud.hideGeese();
     this.hud.hideTimer();
     this.world.clearRaceMarkers();
     this.recorder.stopBuffer();
@@ -3323,25 +3334,15 @@ class Game {
     }
     const flashing = this._recFlashTimer > 0;
 
-    // YOU gauge angle (phone tilt / gamepad / keyboard)
-    let youDeg = 0;
-    if (isMobile) {
-      youDeg = Math.max(-90, Math.min(90, this.input.motionRawRelative || 0));
-    } else if (this.input.gamepadConnected) {
-      youDeg = this.input.suppressGamepadLean ? 0 : this.input.gamepadLean * 90;
-    } else {
-      const aHeld = this.input.isPressed('KeyA');
-      const dHeld = this.input.isPressed('KeyD');
-      youDeg = aHeld ? -45 : (dHeld ? 45 : 0);
-    }
-
-    // BIKE gauge angle + danger level
-    const bikeLeanRad = this.bike.lean;
-    const bikeDeg = Math.max(-90, Math.min(90, bikeLeanRad * 180 / Math.PI));
-    const bikeDanger = Math.abs(bikeLeanRad) / 1.35;
-
-    // PARTNER gauge angle
-    const partnerDeg = remoteData ? Math.max(-90, Math.min(90, remoteData.remoteLean * 90)) : 0;
+    // Top strip stats, mirroring the HUD's #hud-stats row
+    const elapsedText = this.raceManager && this.raceManager.startTime > 0
+      ? '\u23F1 ' + this.raceManager.getElapsedFormatted()
+      : '';
+    const collectibleIcon = this.collectibleManager ? this.hud.collectibleIconChar : '';
+    const collectibleText = this.collectibleManager
+      ? this.collectibleManager.collected + '/' + this.collectibleManager.getTotalItems()
+      : '';
+    const geese = this.geeseManager ? this.geeseManager.getDisruptedCount() : null;
 
     // Checkpoint flash progress (0..1 = animating, -1 = inactive)
     const cpElapsed = (performance.now() - this._checkpointFlashTime) / 1000;
@@ -3371,10 +3372,10 @@ class Game {
       partnerDownFlash: flashing && this._recFlashFoot === 'down',
       partnerFlashWrong: flashing && this._recFlashWrong,
       mode: this.mode,
-      youDeg,
-      bikeDeg,
-      bikeDanger,
-      partnerDeg,
+      elapsedText,
+      collectibleIcon,
+      collectibleText,
+      geese,
       hasPartner: !!remoteData,
       checkpointFlash: cpFlash
     };
@@ -4383,6 +4384,7 @@ class Game {
     }
     if (this.geeseManager) {
       this.geeseManager.update(dt, this.bike.distanceTraveled, [this.bike.position]);
+      this.hud.updateGeese(this.geeseManager.getDisruptedCount());
     }
   }
 
@@ -4996,6 +4998,7 @@ class Game {
     }
     if (this.geeseManager) {
       this.geeseManager.update(dt, this.bike.distanceTraveled, [this.bike.position]);
+      this.hud.updateGeese(this.geeseManager.getDisruptedCount());
     }
 
     if (this.bike.speed > 8) {
@@ -6255,6 +6258,7 @@ class Game {
 
     // Solo: full cleanup and return to lobby
     this._musicBtn.style.display = 'none';
+    this.quickMenu.setVisible(false);
     this._hideGameOver();
     this._hideVictory();
     this._hideAllOverlays();
@@ -6263,6 +6267,7 @@ class Game {
     this.raceManager = null;
     this.hud.raceManager = null;
     this.hud.hideCollectibles();
+    this.hud.hideGeese();
     this.hud.hideTimer();
     this.world.clearRaceMarkers();
     this.archIndicator.hide();

--- a/js/hud.js
+++ b/js/hud.js
@@ -16,25 +16,10 @@ export class HUD {
     this.crashOverlay = document.getElementById('crash-overlay');
     this.crashFlash = 0;
 
-    // Gauges
-    this.bikeNeedle = document.getElementById('bike-needle');
-    this.bikeLabel = document.getElementById('bike-label');
-    this.phoneNeedle = document.getElementById('phone-needle');
-    this.phoneLabel = document.getElementById('phone-label');
-    this.phoneGauge = document.getElementById('phone-gauge');
-
-    // Partner gauge
-    this.partnerGauge = document.getElementById('partner-gauge');
-    this.partnerNeedle = document.getElementById('partner-needle');
-    this.partnerLabel = document.getElementById('partner-label');
+    // Partner pedal indicators. The YOU / BIKE / PARTNER lean gauges that used
+    // to sit beside them were removed from the HUD entirely — see index.html.
     this.partnerPedalUp = document.getElementById('partner-pedal-up');
     this.partnerPedalDown = document.getElementById('partner-pedal-down');
-    // Whether the partner has ANY steering input (tilt, gamepad, gyro, or
-    // keyboard). When false (e.g. a mobile player who declined motion with no
-    // gamepad), their lean stays 0 and the needle sits frozen, so we hide the
-    // gauge. A desktop joystick/keyboard partner CAN steer, so we keep it shown.
-    // Set by the game from the partner's reported readiness; defaults true.
-    this.partnerCanSteer = true;
     this._lastRemoteTapTime = 0;
     this._lastRemoteFootValue = null;
     this._pedalFlashTimer = 0;
@@ -57,14 +42,19 @@ export class HUD {
     this.progressDest = document.getElementById('progress-destination');
     this._checkpointEls = [];
 
-    // Collectible counter
+    // Collectible + geese counters (both stats in the top strip)
     this.collectibleWrap = document.getElementById('collectible-counter');
     this.collectibleIcon = document.getElementById('collectible-icon');
     this.collectibleCount = document.getElementById('collectible-count');
+    this.geeseWrap = document.getElementById('geese-counter');
+    this.geeseCount = document.getElementById('geese-count');
+    this.collectibleIconChar = '';
+    this._prevGeese = -1;
 
     // Segment timer
     this.timerRow = document.getElementById('timer-row');
     this.timerEl = document.getElementById('segment-timer');
+    this.elapsedRow = document.getElementById('elapsed-row');
 
     // Center countdown overlay
     this.countdownOverlay = document.getElementById('countdown-overlay');
@@ -75,9 +65,6 @@ export class HUD {
     this._prevKmh = -1;
     this._prevSpeedColor = '';
     this._prevDistText = '';
-    this._prevBikeDeg = NaN;
-    this._prevBikeDangerZone = -1;
-    this._prevPhoneDeg = NaN;
     this._prevStatusText = '';
     this._prevStatusColor = '';
   }
@@ -121,6 +108,7 @@ export class HUD {
 
   initTimer() {
     this.timerRow.classList.add('visible');
+    this.elapsedRow.classList.add('visible');
     this.timerEl.className = '';
     this.timerEl.textContent = '';
     this.elapsedEl.textContent = '\u23F1 0s';
@@ -159,25 +147,49 @@ export class HUD {
 
   hideTimer() {
     this.timerRow.classList.remove('visible');
+    this.elapsedRow.classList.remove('visible');
     this.countdownOverlay.classList.remove('visible');
     this.countdownNumber.textContent = '';
     this._lastCountdownSec = -1;
     this.elapsedEl.textContent = '';
   }
 
-  showCollectibles(level) {
+  showCollectibles(level, total) {
     const icons = { presents: '\uD83C\uDF81', gems: '\uD83D\uDC8E' }; // 🎁 💎
-    this.collectibleIcon.textContent = icons[level.collectibles] || '\u2B50';
-    this.collectibleCount.textContent = '0';
-    this.collectibleWrap.style.display = 'flex';
+    // Kept as a field too: GameRecorder redraws this strip into saved clips.
+    this.collectibleIconChar = icons[level.collectibles] || '\u2B50';
+    this.collectibleIcon.textContent = this.collectibleIconChar;
+    // Show the target from the start — "0" alone reads as a stat with no scale.
+    this.collectibleCount.textContent = total > 0 ? '0/' + total : '0';
+    this.collectibleWrap.classList.add('visible');
   }
 
   updateCollectibles(collected, total) {
-    this.collectibleCount.textContent = collected + ' / ' + total;
+    this.collectibleCount.textContent = collected + '/' + total;
   }
 
   hideCollectibles() {
-    this.collectibleWrap.style.display = 'none';
+    this.collectibleWrap.classList.remove('visible');
+  }
+
+  /** Start the geese tally at zero and reveal it in the top strip. */
+  showGeese() {
+    if (!this.geeseWrap) return;
+    this._prevGeese = 0;
+    this.geeseCount.textContent = '0';
+    this.geeseWrap.classList.add('visible');
+  }
+
+  updateGeese(count) {
+    if (!this.geeseWrap || count === this._prevGeese) return;
+    this._prevGeese = count;
+    this.geeseCount.textContent = count;
+  }
+
+  hideGeese() {
+    if (!this.geeseWrap) return;
+    this.geeseWrap.classList.remove('visible');
+    this._prevGeese = -1;
   }
 
   update(bike, input, pedalCtrl, dt, remoteData) {
@@ -268,39 +280,6 @@ export class HUD {
       }
     }
 
-    // Phone gauge (show on both mobile and desktop)
-    let phoneDeg;
-    if (isMobile) {
-      const rawRel = input.motionRawRelative || 0;
-      phoneDeg = Math.round(Math.max(-90, Math.min(90, rawRel)));
-    } else if (input.gamepadConnected) {
-      phoneDeg = input.suppressGamepadLean ? 0 : Math.round(input.gamepadLean * 90);
-    } else {
-      const aHeld = input.isPressed('KeyA');
-      const dHeld = input.isPressed('KeyD');
-      phoneDeg = aHeld ? -45 : (dHeld ? 45 : 0);
-    }
-    if (phoneDeg !== this._prevPhoneDeg) {
-      this._prevPhoneDeg = phoneDeg;
-      this.phoneNeedle.setAttribute('transform', 'rotate(' + phoneDeg + ', 60, 60)');
-      this.phoneLabel.textContent = Math.abs(phoneDeg) + '\u00B0';
-    }
-
-    // Bike gauge (round to integer degrees to reduce DOM writes)
-    const tiltDeg = (bike.lean * 180 / Math.PI);
-    const bikeDeg = Math.round(Math.max(-90, Math.min(90, tiltDeg)));
-    if (bikeDeg !== this._prevBikeDeg) {
-      this._prevBikeDeg = bikeDeg;
-      this.bikeNeedle.setAttribute('transform', 'rotate(' + bikeDeg + ', 60, 60)');
-      this.bikeLabel.textContent = Math.abs(tiltDeg).toFixed(1) + '\u00B0';
-    }
-    const danger = Math.abs(bike.lean) / 1.35;
-    const dangerZone = danger > 0.75 ? 2 : (danger > 0.5 ? 1 : 0);
-    if (dangerZone !== this._prevBikeDangerZone) {
-      this._prevBikeDangerZone = dangerZone;
-      this.bikeLabel.style.color = dangerZone === 2 ? '#ff4444' : (dangerZone === 1 ? '#ffaa22' : '#ffffff');
-    }
-
     // Status text (only when not controlled by countdown)
     let statusText = '';
     let statusColor = '';
@@ -321,17 +300,10 @@ export class HUD {
       if (statusColor) this.statusEl.style.color = statusColor;
     }
 
-    // Partner gauge + pedal indicators
-    if (remoteData && this.partnerGauge) {
-      // Hide the lean needle when the partner has no steering input — otherwise
-      // it sits frozen at 0°. Pedal indicators below stay (they can still pedal).
-      this.partnerGauge.style.display = (this.partnerCanSteer !== false) ? '' : 'none';
+    // Partner pedal indicators
+    if (remoteData) {
       if (this.partnerPedalUp) this.partnerPedalUp.style.display = 'flex';
       if (this.partnerPedalDown) this.partnerPedalDown.style.display = 'flex';
-      // Needle: remoteLean (-1..1) → degrees (-90..90)
-      const partnerDeg = Math.max(-90, Math.min(90, remoteData.remoteLean * 90));
-      this.partnerNeedle.setAttribute('transform', 'rotate(' + partnerDeg.toFixed(1) + ', 60, 60)');
-      this.partnerLabel.textContent = Math.abs(partnerDeg).toFixed(1) + '\u00B0';
 
       // Pedal flash: detect new taps, red for wrong (same foot repeated)
       if (remoteData.remoteLastTapTime && remoteData.remoteLastTapTime !== this._lastRemoteTapTime) {
@@ -352,8 +324,7 @@ export class HUD {
           if (this.partnerPedalDown) this.partnerPedalDown.classList.remove('flash', 'flash-wrong');
         }
       }
-    } else if (this.partnerGauge) {
-      this.partnerGauge.style.display = 'none';
+    } else {
       if (this.partnerPedalUp) this.partnerPedalUp.style.display = 'none';
       if (this.partnerPedalDown) this.partnerPedalDown.style.display = 'none';
     }

--- a/js/input-manager.js
+++ b/js/input-manager.js
@@ -293,7 +293,6 @@ export class InputManager {
     if (isMobile) {
       if (enableTouch) this._setupTouch();
       if (enableMotion) this._setupMotion();
-      if (enableTouch || enableMotion) this._setupCalibration();
     }
 
     if (this._slot) this.attachSlot(this._slot);
@@ -759,19 +758,6 @@ export class InputManager {
 
     this._smoothedLean += (lean - this._smoothedLean) * smoothK;
     this.motionLean = this._smoothedLean;
-  }
-
-  _setupCalibration() {
-    const gauge = document.getElementById('phone-gauge');
-    const flash = document.getElementById('calibrate-flash');
-    const doCalibrate = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this.startTiltCalibration();
-      if (flash) { flash.style.display = 'block'; setTimeout(() => { flash.style.display = 'none'; }, 800); }
-    };
-    gauge.addEventListener('touchstart', doCalibrate, { passive: false });
-    gauge.addEventListener('click', doCalibrate);
   }
 
   /**

--- a/js/quick-menu.js
+++ b/js/quick-menu.js
@@ -1,0 +1,169 @@
+// ============================================================
+// QUICK MENU — the single in-ride control button + its sheet
+// ============================================================
+//
+// Replaces the top-right D-pad disc and the two floating buttons that used to
+// stack down the left edge (clip + music). Those elements still exist and still
+// own all the behaviour; this is purely a front end for them:
+//
+//   * clicking a sheet entry forwards a click() to the real button, so every
+//     handler, analytics call and network side effect runs exactly as before;
+//   * the sheet reads its labels back off those same buttons when it opens, so
+//     there is no second copy of "is safety on" to drift out of sync;
+//   * availability follows their inline `style.display`, which Game and
+//     GameRecorder already maintain (stoker loses the ride controls, the clip
+//     entry only lights up once a recording is buffering).
+//
+// Two taps to reach anything: one to open, one to act. Nothing is on screen
+// while riding except the button itself.
+
+export class QuickMenu {
+  /**
+   * @param {object} [recenter]  the one entry with no button behind it:
+   *   { available(): boolean, run(): void } — tilt recentring, which lost its
+   *   on-screen affordance along with the YOU lean gauge.
+   */
+  constructor(recenter) {
+    this.btn = document.getElementById('quick-menu-btn');
+    this.overlay = document.getElementById('quick-menu-overlay');
+    this.sheet = document.getElementById('quick-menu-sheet');
+    if (!this.btn || !this.overlay) return;
+
+    // The real controls. Everything here is a proxy for one of them.
+    this.sideButtons = document.getElementById('side-buttons');
+    this.safetyBtn = document.getElementById('safety-btn');
+    this.speedBtn = document.getElementById('speed-btn');
+    this.assistBtn = document.getElementById('assist-btn');
+    this.resetBtn = document.getElementById('reset-btn');
+    this.lobbyBtn = document.getElementById('lobby-btn');
+    this.shareBtn = document.getElementById('share-btn');
+    this.musicBtn = document.getElementById('music-btn');
+
+    this.recenter = recenter || null;
+    this.open = false;
+
+    this.btn.addEventListener('click', () => this.toggle());
+    document.getElementById('quick-menu-close').addEventListener('click', () => this.close());
+    // Tapping the dimmed backdrop (anywhere outside the sheet) closes too.
+    this.overlay.addEventListener('click', (e) => {
+      if (e.target === this.overlay) this.close();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && this.open) {
+        e.stopPropagation();
+        this.close();
+      }
+    });
+
+    // Toggles keep the sheet open so the new state is visible; actions close it.
+    this._bind('qm-safety', this.safetyBtn, false);
+    this._bind('qm-speed', this.speedBtn, false);
+    this._bind('qm-assist', this.assistBtn, false);
+    this._bind('qm-music', this.musicBtn, false);
+    this._bind('qm-clip', this.shareBtn, true);
+    this._bind('qm-reset', this.resetBtn, true);
+    this._bind('qm-lobby', this.lobbyBtn, true);
+
+    const recenterEl = document.getElementById('qm-recenter');
+    if (recenterEl) {
+      recenterEl.addEventListener('click', () => {
+        if (this.recenter) this.recenter.run();
+        this.close();
+      });
+    }
+  }
+
+  /** Show or hide the corner button — called when a ride starts and ends. */
+  setVisible(visible) {
+    if (!this.btn) return;
+    this.btn.classList.toggle('visible', visible);
+    if (!visible) this.close();
+  }
+
+  toggle() {
+    if (this.open) this.close();
+    else this.show();
+  }
+
+  show() {
+    if (!this.overlay) return;
+    this.sync();
+    this.open = true;
+    this.overlay.classList.add('visible');
+    this.btn.setAttribute('aria-expanded', 'true');
+  }
+
+  close() {
+    if (!this.overlay) return;
+    this.open = false;
+    this.overlay.classList.remove('visible');
+    this.btn.setAttribute('aria-expanded', 'false');
+  }
+
+  /**
+   * Pull every entry's label, on/off styling and enabled state from the button
+   * it proxies. Runs on open and after each toggle, which is often enough —
+   * nothing in the sheet can change while it is closed and unseen.
+   */
+  sync() {
+    // Game hides #side-buttons for the stoker: only the captain owns safety,
+    // speed and reset. Mirror that rather than handing the stoker controls the
+    // D-pad never gave them.
+    const rideControls = this.sideButtons && this.sideButtons.style.display !== 'none';
+    this._show('qm-safety', rideControls);
+    this._show('qm-speed', rideControls);
+    this._show('qm-reset', rideControls);
+    this._show('qm-lobby', rideControls);
+
+    this._setState('qm-safety', this._isOn(this.safetyBtn, 'safety-on'));
+    this._setState('qm-speed', this._isOn(this.speedBtn, 'speed-on'));
+
+    // Assist only exists once the difficulty manager offers it.
+    const assistOffered = this.assistBtn && this.assistBtn.style.display !== 'none';
+    this._show('qm-assist', !!assistOffered);
+    this._setState('qm-assist', this._isOn(this.assistBtn, 'assist-on'));
+
+    // #music-btn carries `.muted` when the track is off.
+    const musicOn = this.musicBtn && !this.musicBtn.classList.contains('muted');
+    this._setState('qm-music', !!musicOn);
+
+    // Recentring only means anything to a rider steering by tilt or gyro.
+    this._show('qm-recenter', !!(this.recenter && this.recenter.available()));
+
+    // The recorder shows #share-btn only while a clip is actually buffering.
+    const clipReady = this.shareBtn && this.shareBtn.style.display !== 'none';
+    const clip = document.getElementById('qm-clip');
+    if (clip) {
+      clip.disabled = !clipReady;
+      clip.querySelector('.qm-state').textContent = clipReady ? '' : 'N/A';
+    }
+  }
+
+  _bind(id, target, closeAfter) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener('click', () => {
+      if (el.disabled || !target) return;
+      target.click();
+      if (closeAfter) this.close();
+      else this.sync();
+    });
+  }
+
+  _show(id, visible) {
+    const el = document.getElementById(id);
+    if (el) el.hidden = !visible;
+  }
+
+  _isOn(btn, onClass) {
+    return !!(btn && btn.classList.contains(onClass));
+  }
+
+  _setState(id, on) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.classList.toggle('qm-on', on);
+    const state = el.querySelector('.qm-state');
+    if (state) state.textContent = on ? 'ON' : 'OFF';
+  }
+}


### PR DESCRIPTION
Closes #367.

The phone ride screen carried six pieces of chrome at once. This reduces it to a strip at the top, a button in the corner, and the pedals.

## Removed

The YOU / BIKE / PARTNER lean gauges above the pedal buttons, on mobile **and** desktop. The partner pedal indicators stay — they carry live multiplayer feedback nothing else shows, and they now sit centred over the pedals on their own.

## Hidden, still wired

`#side-buttons` (the D-pad disc), `#share-btn` and `#music-btn` stay in the DOM. They remain the single home for both state and behaviour:

- the gamepad D-pad still drives the game by clicking them;
- `Game` and `GameRecorder` still write their inline `display` to signal availability (the stoker doesn't get the captain's ride controls; the clip entry only lights up once a recording is buffering);
- the quick menu reads that state and proxies clicks to them, so there is no second copy of "is safety on" to drift out of sync, and every existing handler, analytics call and network side effect fires exactly as before.

`#side-buttons` is hidden with a plain `display: none` rule, so the `style.display = ''` restores already in `game.js` resolve back to hidden. The two floating buttons need `!important` because their inline display is still written and still meaningful.

## Top strip

`#hud-dashboard` goes from a vertical card to one horizontal row — speed · distance · elapsed · segment timer — with the gift counter folded in from the far corner and a new geese-scattered tally beside it, read from the `getDisruptedCount()` that `GeeseManager` already keeps for the victory screen (#363).

Stats hide individually and the hairline separators go with them. The strip is capped so it never reaches the quick-menu button, tightens below 400px, and wraps to a second row rather than spilling if every value runs long at once (128 km/h · 12.34 km · 12:34 · 120s · 24/24 · 128 fits inside the pill at 320px).

The gift count now shows its target from the start (`0/7`) instead of a bare `0`.

## Quick menu

One button in the corner the D-pad vacated. Tap to open the sheet, tap an entry to act — safety, auto speed, assist, music, save clip, reset, return to lobby, plus tilt recentring, which otherwise loses its only labelled affordance along with the YOU gauge (`_setupCalibration` bound it to `#phone-gauge`; the canvas tap in `game.js` still works). Toggles keep the sheet open so the new state is visible; actions close it. Closes on the ✕ or a tap anywhere outside the sheet.

It appears when a ride starts, and is retired on the victory and game-over overlays (which it would otherwise sit above), on return to lobby/room, and restored on reset. It is hidden in versus, which draws its own per-team panels.

## Clip overlay

`GameRecorder` redraws the HUD into saved clips, so its overlay follows the same change: `_drawGauges`/`_drawSingleGauge` are gone, `_drawSpeedDashboard` is redrawn as the same horizontal strip with gifts and geese, and `_drawPartnerIndicators` is recentred now that there is no gauge row to flank.

The goose tally is worded `GEESE 12` in the clip rather than drawn with 🪿. U+1FABF only reached system fonts in 2022 and canvas has no DOM-style fallback chain, so a device that lacks it would put a tofu box into a clip people go on to share. The gift emoji is old enough to be safe and stays as drawn.

## Verified

Driven in headless Chromium against a local server, at phone (390×844, plus 320/360/375/430 for the strip) and desktop (1280×800) sizes:

- lobby → ride → reset → victory → lobby, with the quick-menu button appearing and retiring at each step, and no page errors;
- tapping SAFETY in the sheet flips `game.safetyMode`, the real `#safety-btn` class, and the sheet's own label together;
- the sheet's ON/OFF states match `game.safetyMode` / `game.autoSpeed`; assist and recenter stay hidden when not offered;
- backdrop tap closes the sheet;
- a composited clip frame renders the new strip and the recentred partner indicators.

Screenshots of the mobile ride screen, the sheet, and a clip frame are in the linked session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQmPBWFp3EBxdfHFCSoMk

---
_Generated by [Claude Code](https://claude.ai/code/session_012gQmPBWFp3EBxdfHFCSoMk)_